### PR TITLE
fix(measurementkit/task_cgo.go): build again on Alpine

### DIFF
--- a/measurementkit/task_cgo.go
+++ b/measurementkit/task_cgo.go
@@ -29,8 +29,9 @@ import (
 	//
 	// #cgo linux,amd64 LDFLAGS: -static
 	// #cgo linux,amd64 LDFLAGS: /usr/local/lib/libmeasurement_kit.a
-	// #cgo linux,amd64 LDFLAGS: /usr/local/lib/libmaxminddb.a
-	// #cgo linux,amd64 LDFLAGS: /usr/local/lib/libcurl.a
+	// #cgo linux,amd64 LDFLAGS: /usr/lib/libmaxminddb.a
+	// #cgo linux,amd64 LDFLAGS: /usr/lib/libcurl.a
+	// #cgo linux,amd64 LDFLAGS: /usr/lib/libnghttp2.a
 	// #cgo linux,amd64 LDFLAGS: /usr/lib/libevent_openssl.a
 	// #cgo linux,amd64 LDFLAGS: /usr/lib/libssl.a
 	// #cgo linux,amd64 LDFLAGS: /usr/lib/libcrypto.a


### PR DESCRIPTION
Since openobservatory/mk-alpine:20190616, we use all the static
libraries that Alpine can provide us and only recompile MK.

Companion of https://github.com/measurement-kit/script-build-linux/pull/7

Xref: https://github.com/ooni/probe-cli/pull/46#issuecomment-502439944