### PR TITLE
Add support for passing the limit and category code to the testlists pkg

### DIFF
--- a/cmd/miniooni/main.go
+++ b/cmd/miniooni/main.go
@@ -228,7 +228,7 @@ func main() {
 
 	if name == "web_connectivity" {
 		if len(globalOptions.inputs) <= 0 {
-			list, err := testlists.NewClient(sess).Do(ctx, sess.ProbeCC())
+			list, err := testlists.NewClient(sess).Do(ctx, sess.ProbeCC(), 100)
 			if err != nil {
 				log.WithError(err).Fatal("cannot fetch test lists")
 			}

--- a/orchestra/testlists/testlists.go
+++ b/orchestra/testlists/testlists.go
@@ -3,6 +3,7 @@ package testlists
 
 import (
 	"context"
+	"strings"
 	"net/http"
 	"net/url"
 
@@ -45,6 +46,9 @@ type Client struct {
 
 	// UserAgent is the user agent to use.
 	UserAgent string
+
+	// EnabledCategories is a list of category codes that are enabled
+	EnabledCategories []string
 }
 
 // NewClient creates a new client in the context of the given session.
@@ -57,14 +61,25 @@ func NewClient(sess *session.Session) *Client {
 	}
 }
 
+// SetEnabledCategories configures the client category codes
+func (c *Client) SetEnabledCategories(categories []string) error {
+	c.EnabledCategories = categories
+}
+
 // Do retrieves the test list for the specified country.
 func (c *Client) Do(
-	ctx context.Context, countryCode string,
+	ctx context.Context, countryCode string, limit int,
 ) ([]URLInfo, error) {
 	var resp response
 	query := url.Values{}
 	if countryCode != "" {
 		query.Set("probe_cc", countryCode)
+	}
+	if (limit > 0) {
+		query.Set("limit", limit)
+	}
+	if (len(c.EnabledCategories) > 0) {
+		query.Set("category_codes", strings.Join(c.EnabledCategories, ","))
 	}
 	err := (&jsonapi.Client{
 		BaseURL:    c.BaseURL,

--- a/orchestra/testlists/testlists.go
+++ b/orchestra/testlists/testlists.go
@@ -3,6 +3,7 @@ package testlists
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"net/http"
 	"net/url"
@@ -64,6 +65,7 @@ func NewClient(sess *session.Session) *Client {
 // SetEnabledCategories configures the client category codes
 func (c *Client) SetEnabledCategories(categories []string) error {
 	c.EnabledCategories = categories
+	return nil
 }
 
 // Do retrieves the test list for the specified country.
@@ -76,7 +78,7 @@ func (c *Client) Do(
 		query.Set("probe_cc", countryCode)
 	}
 	if (limit > 0) {
-		query.Set("limit", limit)
+		query.Set("limit", fmt.Sprintf("%d", limit))
 	}
 	if (len(c.EnabledCategories) > 0) {
 		query.Set("category_codes", strings.Join(c.EnabledCategories, ","))

--- a/orchestra/testlists/testlists_test.go
+++ b/orchestra/testlists/testlists_test.go
@@ -20,7 +20,7 @@ func makeClient() *testlists.Client {
 
 func TestIntegration(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
-	urls, err := makeClient().Do(context.Background(), "IT")
+	urls, err := makeClient().Do(context.Background(), "IT", 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is useful so that we can better configure the testing targets.

It's especially important since now the backend will return the full test list by default.