### PR TITLE
Pure Go implementation of Telegram experiment

### DIFF
--- a/experiment/ootemplate/doc.go
+++ b/experiment/ootemplate/doc.go
@@ -1,0 +1,65 @@
+// Package ootemplate contains base code for OONI measurements.
+//
+// Traditionally OONI has always had a layer of abstraction between the
+// code implementing the measurements and the measurement engine. The name
+// originally provided to this layer was "test templates". This package
+// is following the original convention, hence its name.
+//
+// Compared to the original code and specification, this code is more
+// strict with respect to typing. There is currently a bunch of places
+// in which nullable strings that oughta be `null` according to the
+// spec are instead serialized as empty strings.
+//
+// # TCP connect template
+//
+// Strictly speaking this is not listed as a template in the OONI spec, yet
+// it is widely used, e.g., by IM tests.
+//
+// This template attempts to connect directly to a specific TCP endpoint
+// and produces the following JSON measurement:
+//
+//         {
+//           "ip": "149.154.167.50",
+//           "port": 443,
+//           "status": {
+//             "failure": "generic_timeout_error",
+//             "success": false
+//           }
+//         }
+//
+// # HTTP template
+//
+// The HTTP template is the basic building block of Web Connectivity as
+// well as of the IM tests. The implementation we have here is following
+// the informal specification given in the Web Connectivity test.
+//
+// The emitted JSON measurement is:
+//
+//         {
+//           "failure": "",
+//           "request": {
+//             "body": "",
+//             "headers": {
+//               "Accept": "text/html",
+//             },
+//             "method": "GET",
+//             "tor": {
+//               "exit_ip": null,
+//               "exit_name": null,
+//               "is_tor": false
+//             },
+//             "url": "http://torproject.org/"
+//           },
+//           "response": {
+//             "body": "....",
+//             "code": 200,
+//             "headers": {
+//               "Accept-Ranges": "bytes",
+//             }
+//            }
+//         }
+//
+// This should be close enough to the expected format not to create issues
+// to the pipeline parser. As mentioned, most string fields that may be
+// nullable are actually emitted as empty rather then null, when not set.
+package ootemplate

--- a/experiment/ootemplate/http.go
+++ b/experiment/ootemplate/http.go
@@ -220,6 +220,8 @@ func HTTPPerformMany(
 	client, measurer := NewHTTPClientWithMeasurer(logger, nil, nil)
 	for _, req := range requests {
 		resp, err := client.Do(req)
+		// Note that here we just drain the body if needed, for correctness, but
+		// otherwise we ignore the result because we have it in measurer.
 		if err == nil {
 			ioutil.ReadAll(resp.Body)
 			resp.Body.Close()

--- a/experiment/ootemplate/http.go
+++ b/experiment/ootemplate/http.go
@@ -110,7 +110,6 @@ func getbody(s *io.ReadCloser, dest *HTTPBody) (err error) {
 	}
 	(*s).Close()
 	*s = ioutil.NopCloser(bytes.NewReader(data))
-	// TODO(bassosimone): we don't know whether the body is UTF-8
 	(*dest).Value = string(data)
 	return
 }

--- a/experiment/ootemplate/http.go
+++ b/experiment/ootemplate/http.go
@@ -183,8 +183,8 @@ func NewHTTPClientWithMeasurer(
 // HTTPRequesTemplate is a quick template for setting up an HTTP request
 // for performing OONI measurements.
 type HTTPRequestTemplate struct {
-	Method string
-	URL string
+	Method    string
+	URL       string
 	UserAgent string
 }
 
@@ -214,7 +214,7 @@ func HTTPPerformMany(
 	client, measurer := NewHTTPClientWithMeasurer(logger, nil, nil)
 	var waitgroup sync.WaitGroup
 	waitgroup.Add(len(requests))
-	for _, req := range(requests) {
+	for _, req := range requests {
 		go func(req *http.Request) {
 			resp, err := client.Do(req)
 			if err == nil {

--- a/experiment/ootemplate/http.go
+++ b/experiment/ootemplate/http.go
@@ -1,0 +1,230 @@
+package ootemplate
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/ooni/probe-engine/httpx/httplog"
+	"github.com/ooni/probe-engine/httpx/httptracex"
+	"github.com/ooni/probe-engine/httpx/httpx"
+	"github.com/ooni/probe-engine/log"
+)
+
+// HTTPTor contains Tor information
+type HTTPTor struct {
+	ExitIP   *string `json:"exit_ip"`
+	ExitName *string `json:"exit_name"`
+	IsTor    bool    `json:"is_tor"`
+}
+
+// HTTPBody is an HTTP body. We use this helper class to define a custom
+// JSON encoder that allows us to choose the proper representation depending
+// on whether the Value field is UTF-8 or not.
+type HTTPBody struct {
+	Value string
+}
+
+// MarshalJSON marshal the body to JSON following the OONI spec that says
+// that UTF-8 bodies are represened as string and non-UTF-8 bodies are
+// instead represented as `{"format":"base64","data":"..."}`.
+func (hb HTTPBody) MarshalJSON() ([]byte, error) {
+	if utf8.ValidString(hb.Value) {
+		return json.Marshal(hb.Value)
+	}
+	er := make(map[string]string)
+	er["format"] = "base64"
+	er["data"] = base64.StdEncoding.EncodeToString([]byte(hb.Value))
+	return json.Marshal(er)
+}
+
+// HTTPRequest contains an HTTP request
+type HTTPRequest struct {
+	Headers map[string]string `json:"headers"`
+	Method  string            `json:"method"`
+	Tor     HTTPTor           `json:"tor"`
+	URL     string            `json:"url"`
+	Body    HTTPBody          `json:"body"`
+}
+
+// HTTPResponse contains an HTTP response
+type HTTPResponse struct {
+	Body    HTTPBody          `json:"body"`
+	Code    int               `json:"code"`
+	Headers map[string]string `json:"headers"`
+}
+
+// HTTPRoundTrip contains the measurement of an HTTP round trip.
+type HTTPRoundTrip struct {
+	Failure  string       `json:"failure"`
+	Request  HTTPRequest  `json:"request"`
+	Response HTTPResponse `json:"response"`
+}
+
+// HTTPMeasurer measures several round trips.
+type HTTPMeasurer struct {
+	RoundTrips   []HTTPRoundTrip
+	Mutex        sync.Mutex
+	RoundTripper http.RoundTripper
+}
+
+func makeroundtrip() HTTPRoundTrip {
+	return HTTPRoundTrip{
+		Request: HTTPRequest{
+			Headers: make(map[string]string),
+		},
+		Response: HTTPResponse{
+			Headers: make(map[string]string),
+		},
+	}
+}
+
+func getheaders(s http.Header) (d map[string]string) {
+	d = make(map[string]string)
+	for k, v := range s {
+		// TODO(bassosimone): this representation of headers loses information
+		// and we should instead use a list based representation
+		if len(v) > 0 {
+			d[k] = v[0]
+		}
+	}
+	return
+}
+
+func getbody(s *io.ReadCloser, dest *HTTPBody) (err error) {
+	if *s == nil {
+		(*dest).Value = ""
+		return
+	}
+	data, err := ioutil.ReadAll(*s)
+	if err != nil {
+		return
+	}
+	(*s).Close()
+	*s = ioutil.NopCloser(bytes.NewReader(data))
+	// TODO(bassosimone): we don't know whether the body is UTF-8
+	(*dest).Value = string(data)
+	return
+}
+
+// RoundTrip performs an HTTP round trip and saves the results.
+func (hm *HTTPMeasurer) RoundTrip(req *http.Request) (*http.Response, error) {
+	ootrip := makeroundtrip()
+	defer func() {
+		hm.Mutex.Lock()
+		defer hm.Mutex.Unlock()
+		hm.RoundTrips = append(hm.RoundTrips, ootrip)
+	}()
+	ootrip.Request.Headers = getheaders(req.Header)
+	ootrip.Request.Method = req.Method
+	ootrip.Request.URL = req.URL.String()
+	err := getbody(&req.Body, &ootrip.Request.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := hm.RoundTripper.RoundTrip(req)
+	if err != nil {
+		ootrip.Failure = err.Error()
+		return resp, err
+	}
+	ootrip.Response.Code = resp.StatusCode
+	ootrip.Response.Headers = getheaders(resp.Header)
+	err = getbody(&resp.Body, &ootrip.Response.Body)
+	if err != nil {
+		ootrip.Failure = err.Error()
+		return resp, err
+	}
+	return resp, nil
+}
+
+// NewHTTPClientWithMeasurer is like httpx.NewTracingProxying client except
+// that it also returns a measurer where you can see round trips.
+//
+// The |log| argument is an apex/log.Log compatible logger. The |proxy|
+// argument is the function that should be used to setup a proxy (we don't
+// need a proxy when measuring, except for circumvention tools). The
+// |tlsConfig| argument is an optional TLS configuration with which you
+// can, e.g., supply the path to an extrnal CA bundle.
+func NewHTTPClientWithMeasurer(
+	logger log.Logger, proxy func(req *http.Request) (*url.URL, error),
+	tlsConfig *tls.Config,
+) (client *http.Client, measurer *HTTPMeasurer) {
+	// This creates a transport that contains as transport the measurer in
+	// httptracex, which routes events to the |Handler| and uses as a
+	// real transport |RoundTripper|. Here |RoundTripper| is a real HTTP
+	// transport. The httptracex.Measurer is currently only used for
+	// logging via httplog.RoundTripLogger. We have improvements in
+	// ooni/probe-engine#26 that will allow us to collect much more low level
+	// data than now (e.g. TLS). For now the plan is to just tap into the
+	// round-trip to collect the bare minimum required to implement Telegram.
+	//
+	// TODO(bassosimone): modify the code such that we can take advantage
+	// of the httptracex framework to log everything HTTP.
+	measurer = &HTTPMeasurer{
+		RoundTripper: &httptracex.Measurer{
+			RoundTripper: httpx.NewTransport(proxy, tlsConfig),
+			Handler: &httplog.RoundTripLogger{
+				Logger: logger,
+			},
+		},
+	}
+	// This creates an HTTP client where the transport is our measurer
+	client = &http.Client{Transport: measurer}
+	return
+}
+
+// HTTPRequesTemplate is a quick template for setting up an HTTP request
+// for performing OONI measurements.
+type HTTPRequestTemplate struct {
+	Method string
+	URL string
+	UserAgent string
+}
+
+// HTTPPerformMany performs the many HTTP requests described by the
+// provided template using a custom client and then returns the measurements
+// as a list of HTTP round trips. This function returns an error when we
+// cannot even prepare a request because you provided us with invalid data,
+// otherwise in any other case it will succeed.
+func HTTPPerformMany(
+	ctx context.Context, logger log.Logger, templates ...HTTPRequestTemplate,
+) ([]HTTPRoundTrip, error) {
+	var requests []*http.Request
+	for _, t := range templates {
+		req, err := http.NewRequest(t.Method, t.URL, nil)
+		if err != nil {
+			return nil, err
+		}
+		if t.UserAgent == "" {
+			// 11.8% as of August 24, 2019 according to
+			// https://techblog.willshouse.com/2012/01/03/most-common-user-agents/
+			t.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+		}
+		req.Header.Add("User-Agent", t.UserAgent)
+		req = req.WithContext(ctx)
+		requests = append(requests, req)
+	}
+	client, measurer := NewHTTPClientWithMeasurer(logger, nil, nil)
+	var waitgroup sync.WaitGroup
+	waitgroup.Add(len(requests))
+	for _, req := range(requests) {
+		go func(req *http.Request) {
+			resp, err := client.Do(req)
+			if err == nil {
+				ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
+			}
+			waitgroup.Done()
+		}(req)
+	}
+	waitgroup.Wait()
+	return measurer.RoundTrips, nil
+}

--- a/experiment/ootemplate/http_test.go
+++ b/experiment/ootemplate/http_test.go
@@ -1,0 +1,36 @@
+package ootemplate_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/experiment/ootemplate"
+)
+
+func TestHTTPPerformMany(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	ctx := context.Background()
+	templates := []ootemplate.HTTPRequestTemplate{
+		ootemplate.HTTPRequestTemplate{
+			Method: "GET",
+			URL: "http://google.com",
+		},
+		ootemplate.HTTPRequestTemplate{
+			Method: "GET",
+			URL: "http://kernel.org",
+		},
+	}
+	roundtrips, err := ootemplate.HTTPPerformMany(ctx, log.Log, templates...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, roundtrip := range roundtrips {
+		data, err := json.MarshalIndent(roundtrip, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%s", string(data))
+	}
+}

--- a/experiment/ootemplate/http_test.go
+++ b/experiment/ootemplate/http_test.go
@@ -15,11 +15,11 @@ func TestHTTPPerformMany(t *testing.T) {
 	templates := []ootemplate.HTTPRequestTemplate{
 		ootemplate.HTTPRequestTemplate{
 			Method: "GET",
-			URL: "http://google.com",
+			URL:    "http://google.com",
 		},
 		ootemplate.HTTPRequestTemplate{
 			Method: "GET",
-			URL: "http://kernel.org",
+			URL:    "http://kernel.org",
 		},
 	}
 	roundtrips, err := ootemplate.HTTPPerformMany(ctx, log.Log, templates...)

--- a/experiment/ootemplate/tcpconnect.go
+++ b/experiment/ootemplate/tcpconnect.go
@@ -1,0 +1,105 @@
+package ootemplate
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+
+	"github.com/ooni/probe-engine/httpx/retryx"
+	"github.com/ooni/probe-engine/log"
+)
+
+// TCPConnectStatus contains the TCP connect status.
+type TCPConnectStatus struct {
+	Failure string `json:"failure"`
+	Success bool   `json:"success"`
+}
+
+// TCPConnectResults contains the results of a TCP connect.
+type TCPConnectResults struct {
+	IP     string           `json:"ip"`
+	Port   uint16           `json:"port"`
+	Status TCPConnectStatus `json:"status"`
+}
+
+// TCPConnectOnce performs a single TCP connect attempt. There is no real
+// timeout except the one you can configure using the context.
+func TCPConnectOnce(
+	ctx context.Context, logger log.Logger, epnt string,
+) (results TCPConnectResults, err error) {
+	logger.Debugf("tcpconnect.go: connecting to %s", epnt)
+	defer func() {
+		if err != nil {
+			logger.Debugf("tcpconnect.go: connecting to %s: %s", epnt, err.Error())
+			results.Status.Failure = err.Error()
+		} else {
+			logger.Debugf("tcpconnect.go: connecting to %s: OK", epnt)
+			results.Status.Success = true
+		}
+	}()
+	var address, port string
+	address, port, err = net.SplitHostPort(epnt)
+	if err != nil {
+		return
+	}
+	var portnum int
+	portnum, err = strconv.Atoi(port)
+	if err != nil {
+		return
+	}
+	if portnum < 0 || portnum > 65535 {
+		err = errors.New("invalid port number")
+		return
+	}
+	results.IP = address
+	results.Port = uint16(portnum)
+	var conn net.Conn
+	conn, err = (&net.Dialer{}).DialContext(ctx, "tcp", epnt)
+	if err == nil {
+		conn.Close()
+	}
+	return
+}
+
+// TCPConnectWithRetry performs a TCP connect and retries a few times before
+// giving up. The return value indicates whether we succeded (error equal
+// to nil) or failed (non nil error). We also return the result of each of
+// the TCP connect attempts.
+func TCPConnectWithRetry(
+	ctx context.Context, logger log.Logger, epnt string,
+) ([]TCPConnectResults, error) {
+	var all []TCPConnectResults
+	err := retryx.Do(ctx, func() error {
+		results, err := TCPConnectOnce(ctx, logger, epnt)
+		all = append(all, results)
+		return err
+	})
+	return all, err
+}
+
+func tcpConnectAsyncLoop(
+	ctx context.Context, out chan<- TCPConnectResults,
+	logger log.Logger, epnts ...string,
+) {
+	defer close(out)
+	for _, epnt := range epnts {
+		results, _ := TCPConnectWithRetry(ctx, logger, epnt)
+		for _, entry := range results {
+			out <- entry
+			if ctx.Err() != nil {
+				return // bail out if the context has expired
+			}
+		}
+	}
+}
+
+// TCPConnectAsync connects to an array of endpoints and returns the results
+// on the returned channel, which will be closed when done.
+func TCPConnectAsync(
+	ctx context.Context, logger log.Logger, epnts ...string,
+) <-chan TCPConnectResults {
+	out := make(chan TCPConnectResults)
+	go tcpConnectAsyncLoop(ctx, out, logger, epnts...)
+	return out
+}

--- a/experiment/ootemplate/tcpconnect_test.go
+++ b/experiment/ootemplate/tcpconnect_test.go
@@ -1,0 +1,21 @@
+package ootemplate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/experiment/ootemplate"
+)
+
+func TestTCPConnectAsync(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	ctx := context.Background()
+	inputs := []string{
+		"149.154.175.50:443", "149.154.167.51:443", "149.154.175.100:443",
+		"149.154.167.91:443", "149.154.171.5:443",
+	}
+	for results := range ootemplate.TCPConnectAsync(ctx, log.Log, inputs...) {
+		t.Logf("%+v", results)
+	}
+}

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -93,7 +93,6 @@ func measure(
 	}
 	for res := range ootemplate.TCPConnectAsync(ctx, sess.Logger, epnts...) {
 		if res.Status.Success {
-			testkeys.TelegramTCPBlocking = false
 			testkeys.TCPConnect = append(testkeys.TCPConnect, res)
 		}
 	}

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -1,13 +1,17 @@
 // Package telegram contains the Telegram network experiment.
+//
+// See https://github.com/ooni/spec/blob/master/nettests/ts-020-telegram.md.
 package telegram
 
 import (
 	"context"
+	"net"
+	"strings"
+	"time"
 
 	"github.com/ooni/probe-engine/experiment"
 	"github.com/ooni/probe-engine/experiment/handler"
-	"github.com/ooni/probe-engine/experiment/mkevent"
-	"github.com/ooni/probe-engine/measurementkit"
+	"github.com/ooni/probe-engine/experiment/ootemplate"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/session"
 )
@@ -18,27 +22,101 @@ const (
 )
 
 // Config contains the experiment config.
-type Config struct {
-	// LogLevel is the MK log level. Empty implies "WARNING".
-	LogLevel string
+type Config struct {}
+
+// TestKeys contains telegram test keys.
+type TestKeys struct {
+	TelegramHTTPBlocking bool                           `json:"telegram_http_blocking"`
+	TelegramTCPBlocking  bool                           `json:"telegram_tcp_blocking"`
+	TelegramWebFailure   *string                        `json:"telegram_web_failure"`
+	TelegramWebStatus    *string                        `json:"telegram_web_status"`
+	TCPConnect           []ootemplate.TCPConnectResults `json:"tcp_connect"`
+	Requests             []ootemplate.HTTPRoundTrip     `json:"requests"`
 }
 
 func measure(
 	ctx context.Context, sess *session.Session, measurement *model.Measurement,
 	callbacks handler.Callbacks, config Config,
 ) error {
-	settings := measurementkit.NewSettings(
-		"Telegram", sess.SoftwareName, sess.SoftwareVersion,
-		sess.CABundlePath(), sess.ProbeASNString(), sess.ProbeCC(),
-		sess.ProbeIP(), sess.ProbeNetworkName(), config.LogLevel,
-	)
-	out, err := measurementkit.StartEx(settings, sess.Logger)
+	ctx, cancel := context.WithTimeout(ctx, 30 * time.Second)
+	defer cancel()
+	testkeys := &TestKeys{
+		TelegramHTTPBlocking: true,
+		TelegramTCPBlocking:  true,
+	}
+	measurement.TestKeys = testkeys
+	defer func() {
+		for _, tcpconn := range testkeys.TCPConnect {
+			if tcpconn.Status.Success == true {
+				testkeys.TelegramTCPBlocking = false
+				break
+			}
+		}
+		for _, roundtrip := range testkeys.Requests {
+			if strings.Contains(roundtrip.Request.URL, "web.telegram.org") {
+				continue
+			}
+			if roundtrip.Failure == "" {
+				testkeys.TelegramHTTPBlocking = false
+				break
+			}
+		}
+		var failure *string
+		count := 0
+		for _, roundtrip := range testkeys.Requests {
+			if !strings.Contains(roundtrip.Request.URL, "web.telegram.org") {
+				continue
+			}
+			count += 1
+			if roundtrip.Failure != "" {
+				failure = &roundtrip.Failure
+				break
+			}
+		}
+		var status string
+		if failure != nil {
+			testkeys.TelegramWebFailure = failure
+			status = "blocked"
+		} else if count > 0 {
+			status = "ok"
+		}
+		testkeys.TelegramWebStatus = &status
+	}()
+	var addresses = []string{
+		"149.154.175.50", "149.154.167.51", "149.154.175.100",
+		"149.154.167.91", "149.154.171.5",
+	}
+	var epnts []string
+	for _, addr := range addresses {
+		epnts = append(epnts, net.JoinHostPort(addr, "80"))
+		epnts = append(epnts, net.JoinHostPort(addr, "443"))
+	}
+	for res := range ootemplate.TCPConnectAsync(ctx, sess.Logger, epnts...) {
+		if res.Status.Success {
+			testkeys.TelegramTCPBlocking = false
+			testkeys.TCPConnect = append(testkeys.TCPConnect, res)
+		}
+	}
+	var templates []ootemplate.HTTPRequestTemplate
+	for _, addr := range addresses {
+		templates = append(templates, ootemplate.HTTPRequestTemplate{
+			Method: "POST", URL: "http://" + net.JoinHostPort(addr, "80"),
+		})
+		templates = append(templates, ootemplate.HTTPRequestTemplate{
+			Method: "POST", URL: "http://" + net.JoinHostPort(addr, "443"),
+		})
+	}
+	templates = append(templates, ootemplate.HTTPRequestTemplate{
+		Method: "GET", URL: "http://web.telegram.org",
+	})
+	templates = append(templates, ootemplate.HTTPRequestTemplate{
+		Method: "GET", URL: "https://web.telegram.org",
+	})
+	roundtrips, err := ootemplate.HTTPPerformMany(ctx, sess.Logger, templates...)
 	if err != nil {
 		return err
 	}
-	for ev := range out {
-		mkevent.Handle(sess, measurement, ev, callbacks)
-	}
+	testkeys.Requests = roundtrips
 	return nil
 }
 

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -92,9 +92,7 @@ func measure(
 		epnts = append(epnts, net.JoinHostPort(addr, "443"))
 	}
 	for res := range ootemplate.TCPConnectAsync(ctx, sess.Logger, epnts...) {
-		if res.Status.Success {
-			testkeys.TCPConnect = append(testkeys.TCPConnect, res)
-		}
+		testkeys.TCPConnect = append(testkeys.TCPConnect, res)
 	}
 	var templates []ootemplate.HTTPRequestTemplate
 	for _, addr := range addresses {

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -99,6 +99,9 @@ func measure(
 		templates = append(templates, ootemplate.HTTPRequestTemplate{
 			Method: "POST", URL: "http://" + net.JoinHostPort(addr, "80"),
 		})
+		// Note: it's intended to connect using `http` on port `443`. I was
+		// surprised as well, but this is the spec and using `https` is actually
+		// going to lead to I/O timeouts and other failures.
 		templates = append(templates, ootemplate.HTTPRequestTemplate{
 			Method: "POST", URL: "http://" + net.JoinHostPort(addr, "443"),
 		})

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -22,7 +22,7 @@ const (
 )
 
 // Config contains the experiment config.
-type Config struct {}
+type Config struct{}
 
 // TestKeys contains telegram test keys.
 type TestKeys struct {
@@ -38,7 +38,7 @@ func measure(
 	ctx context.Context, sess *session.Session, measurement *model.Measurement,
 	callbacks handler.Callbacks, config Config,
 ) error {
-	ctx, cancel := context.WithTimeout(ctx, 30 * time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	testkeys := &TestKeys{
 		TelegramHTTPBlocking: true,

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -86,12 +86,12 @@ func measure(
 		"149.154.175.50", "149.154.167.51", "149.154.175.100",
 		"149.154.167.91", "149.154.171.5",
 	}
-	var epnts []string
+	var endpoints []string
 	for _, addr := range addresses {
-		epnts = append(epnts, net.JoinHostPort(addr, "80"))
-		epnts = append(epnts, net.JoinHostPort(addr, "443"))
+		endpoints = append(endpoints, net.JoinHostPort(addr, "80"))
+		endpoints = append(endpoints, net.JoinHostPort(addr, "443"))
 	}
-	for res := range ootemplate.TCPConnectAsync(ctx, sess.Logger, epnts...) {
+	for res := range ootemplate.TCPConnectAsync(ctx, sess.Logger, endpoints...) {
 		testkeys.TCPConnect = append(testkeys.TCPConnect, res)
 	}
 	var templates []ootemplate.HTTPRequestTemplate

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-engine/experiment/telegram"
-	"github.com/ooni/probe-engine/measurementkit"
 	"github.com/ooni/probe-engine/session"
 )
 
@@ -16,9 +15,6 @@ const (
 )
 
 func TestIntegration(t *testing.T) {
-	if !measurementkit.Available() {
-		t.Skip("Measurement Kit not available; skipping")
-	}
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
 

--- a/orchestra/testlists/testlists.go
+++ b/orchestra/testlists/testlists.go
@@ -4,9 +4,9 @@ package testlists
 import (
 	"context"
 	"fmt"
-	"strings"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/ooni/probe-engine/httpx/jsonapi"
 	"github.com/ooni/probe-engine/log"
@@ -77,10 +77,10 @@ func (c *Client) Do(
 	if countryCode != "" {
 		query.Set("probe_cc", countryCode)
 	}
-	if (limit > 0) {
+	if limit > 0 {
 		query.Set("limit", fmt.Sprintf("%d", limit))
 	}
-	if (len(c.EnabledCategories) > 0) {
+	if len(c.EnabledCategories) > 0 {
 		query.Set("category_codes", strings.Join(c.EnabledCategories, ","))
 	}
 	err := (&jsonapi.Client{


### PR DESCRIPTION
This PR implements (i) TCPConnect and HTTP OONI templates and (ii) the Telegram experiment implemented on top of such functionality. Among other things, this PR is meant to show how one could convert an existing OONI test from Measurement Kit to Go (see #40).

The two main limitations of this code are (1) that we're not taking full advantage of the httpx/httptracex tracer to collect low level information (see #26) and (2) that some keys that the spec says are nullable are emitted as empty strings instead.

The first limitation could be addressed by future commits without changing the Telegram test because what is needed are improvements in the OONI templates layer. The second limitation instead is probably an opportunity to relax the specs. (After all, the Python parser we use should probably use robust coding like `if not value:` rather than `if value is None:` and therefore I believe these changes should not have such a dramatic impact on anything.)

Closes #54 