### PR TITLE
session: expose the ProbeASN as an integer

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -143,7 +143,7 @@ func (s *Session) ProbeASNString() string {
 }
 
 // ProbeASN returns the probe ASN as an integer.
-func (s *Session) ProbeASN() int {
+func (s *Session) ProbeASN() uint {
 	asn := model.DefaultProbeASN
 	if s.location != nil {
 		asn = s.location.ASN

--- a/session/session.go
+++ b/session/session.go
@@ -139,11 +139,16 @@ func (s *Session) AddAvailableHTTPSCollector(baseURL string) {
 
 // ProbeASNString returns the probe ASN as a string.
 func (s *Session) ProbeASNString() string {
+	return fmt.Sprintf("AS%d", s.ProbeASN())
+}
+
+// ProbeASN returns the probe ASN as an integer.
+func (s *Session) ProbeASN() int {
 	asn := model.DefaultProbeASN
 	if s.location != nil {
 		asn = s.location.ASN
 	}
-	return fmt.Sprintf("AS%d", asn)
+	return asn
 }
 
 // ProbeCC returns the probe CC.


### PR DESCRIPTION
Needed by the probe-cli. I'm trying to reduce the coupling between internals of this repo and the probe-cli, so I am adding a session method to get the ASN as an integer, rather than continuing to assume that the probe-cli can access whatever package in here. I look forward for the cli to be able to use mainly the session and a few other packages possibly.