### PR TITLE
Write more abstract and powerful API

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -1,0 +1,386 @@
+// Package engine contains the engine API
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/ooni/probe-engine/experiment"
+	"github.com/ooni/probe-engine/experiment/dash"
+	"github.com/ooni/probe-engine/experiment/example"
+	"github.com/ooni/probe-engine/experiment/fbmessenger"
+	"github.com/ooni/probe-engine/experiment/hhfm"
+	"github.com/ooni/probe-engine/experiment/hirl"
+	"github.com/ooni/probe-engine/experiment/ndt"
+	"github.com/ooni/probe-engine/experiment/ndt7"
+	"github.com/ooni/probe-engine/experiment/psiphon"
+	"github.com/ooni/probe-engine/experiment/telegram"
+	"github.com/ooni/probe-engine/experiment/web_connectivity"
+	"github.com/ooni/probe-engine/experiment/whatsapp"
+	"github.com/ooni/probe-engine/log"
+	"github.com/ooni/probe-engine/model"
+)
+
+// Callbacks contains event handling callbacks
+//
+// This is a copy of experiment/handler.Callbacks. Go will make sure
+// the interface will match for us. This means we can have this set of
+// callbacks as part of the toplevel engine API.
+type Callbacks interface {
+	// OnDataUsage provides information about data usage.
+	OnDataUsage(dloadKiB, uploadKiB float64)
+
+	// OnProgress provides information about an experiment progress.
+	OnProgress(percentage float64, message string)
+}
+
+// ExperimentBuilder is an experiment builder.
+type ExperimentBuilder struct {
+	build      func(interface{}) *experiment.Experiment
+	callbacks  Callbacks
+	config     interface{}
+	needsInput bool
+}
+
+// NeedsInput returns whether the experiment needs input
+func (b *ExperimentBuilder) NeedsInput() bool {
+	return b.needsInput
+}
+
+// OptionInfo contains info about an option
+type OptionInfo struct {
+	Doc  string
+	Type string
+}
+
+// Options returns info about all options
+func (b *ExperimentBuilder) Options() (map[string]OptionInfo, error) {
+	result := make(map[string]OptionInfo)
+	structinfo := reflect.ValueOf(b.config).Type()
+	if structinfo.Kind() != reflect.Struct {
+		return nil, errors.New("config is not a struct")
+	}
+	for i := 0; i < structinfo.NumField(); i++ {
+		field := structinfo.Field(i)
+		result[field.Name] = OptionInfo{
+			Doc:  field.Tag.Get("ooni"),
+			Type: field.Type.String(),
+		}
+	}
+	return result, nil
+}
+
+// SetOptionBool sets a bool option
+func (b *ExperimentBuilder) SetOptionBool(key string, value bool) error {
+	field, err := fieldbyname(b.config, key)
+	if err != nil {
+		return err
+	}
+	if field.Kind() != reflect.Bool {
+		return errors.New("field is not a bool")
+	}
+	field.SetBool(value)
+	return nil
+}
+
+// SetOptionInt sets an int option
+func (b *ExperimentBuilder) SetOptionInt(key string, value int64) error {
+	field, err := fieldbyname(b.config, key)
+	if err != nil {
+		return err
+	}
+	if field.Kind() != reflect.Int64 {
+		return errors.New("field is not an int64")
+	}
+	field.SetInt(value)
+	return nil
+}
+
+// SetOptionString sets a string option
+func (b *ExperimentBuilder) SetOptionString(key, value string) error {
+	field, err := fieldbyname(b.config, key)
+	if err != nil {
+		return err
+	}
+	if field.Kind() != reflect.String {
+		return errors.New("field is not a string")
+	}
+	field.SetString(value)
+	return nil
+}
+
+// SetCallbacks sets the interactive callbacks
+func (b *ExperimentBuilder) SetCallbacks(callbacks Callbacks) {
+	b.callbacks = callbacks
+}
+
+func fieldbyname(v interface{}, key string) (reflect.Value, error) {
+	// See https://stackoverflow.com/a/6396678/4354461
+	structinfo := reflect.ValueOf(v)
+	if structinfo.Kind() != reflect.Struct {
+		return reflect.Value{}, errors.New("value is not a struct")
+	}
+	field := structinfo.FieldByName(key)
+	if !field.IsValid() || !field.CanSet() {
+		return reflect.Value{}, errors.New("no such field")
+	}
+	return field, nil
+}
+
+// Build builds the experiment
+func (b *ExperimentBuilder) Build() *Experiment {
+	experiment := b.build(b.config)
+	experiment.Callbacks = b.callbacks
+	return &Experiment{
+		experiment: experiment,
+		name:       experiment.TestName,
+	}
+}
+
+func newExperimentBuilder(session *Session, name string) (*ExperimentBuilder, error) {
+	factory, _ := experimentsByName[name]
+	if factory == nil {
+		return nil, errors.New("no such experiment")
+	}
+	builder := factory(session)
+	builder.callbacks = &defaultCallbacks{
+		logger: session.session.Logger,
+	}
+	return builder, nil
+}
+
+type defaultCallbacks struct {
+	logger log.Logger
+}
+
+func (cb *defaultCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
+	// NOTHING
+}
+
+func (cb *defaultCallbacks) OnProgress(percentage float64, message string) {
+	cb.logger.Infof("%s", message)
+}
+
+// Experiment is an experiment instance.
+type Experiment struct {
+	experiment *experiment.Experiment
+	name       string
+}
+
+// Name returns the experiment name.
+func (e *Experiment) Name() string {
+	return e.name
+}
+
+// OpenReport is an idempotent method to open a report. We assume that
+// you have configured the available collectors, either manually or
+// through using the session's MaybeLookupBackends method.
+func (e *Experiment) OpenReport() error {
+	ctx := context.Background()
+	return e.experiment.OpenReport(ctx)
+}
+
+// ReportID returns the open reportID, if we have opened a report
+// successfully before, or an empty string, otherwise.
+func (e *Experiment) ReportID() string {
+	return e.experiment.ReportID()
+}
+
+// Measure performs a measurement with input. We assume that you have
+// configured the available test helpers, either manually or by calling
+// the session's MaybeLookupBackends() method.
+func (e *Experiment) Measure(input string) (*Measurement, error) {
+	ctx := context.Background()
+	measurement, err := e.experiment.Measure(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return &Measurement{m: measurement}, nil
+}
+
+// SubmitAndUpdateMeasurement submits a measurement and updates the
+// fields whose value has changed as part of the submission.
+func (e *Experiment) SubmitAndUpdateMeasurement(measurement *Measurement) error {
+	return e.experiment.SubmitMeasurement(context.Background(), &measurement.m)
+}
+
+// SaveMeasurement saves the measurement at the specified path.
+func (e *Experiment) SaveMeasurement(measurement *Measurement, path string) error {
+	return e.experiment.SaveMeasurement(measurement.m, path)
+}
+
+// CloseReport is an idempotent method that closes and open report
+// if one has previously been opened, otherwise it does nothing.
+func (e *Experiment) CloseReport() error {
+	return e.experiment.CloseReport(context.Background())
+}
+
+// Measurement is a OONI measurement
+type Measurement struct {
+	m model.Measurement
+}
+
+// AddAnnotations adds annotation to the measurement
+func (m *Measurement) AddAnnotations(annotations map[string]string) {
+	m.m.AddAnnotations(annotations)
+}
+
+// MakeGenericTestKeys casts the m.TestKeys to a map[string]interface{}.
+//
+// Ideally, all tests should have a clear Go structure, well defined, that
+// will be stored in m.TestKeys as an interface. This is not already the
+// case and it's just valid for tests written in Go. Until all tests will
+// be written in Go, we'll keep this glue here to make sure we convert from
+// the engine format to the cli format.
+//
+// This function will first attempt to cast directly to map[string]interface{},
+// which is possible for MK tests, and then use JSON serialization and
+// de-serialization only if that's required.
+func (m *Measurement) MakeGenericTestKeys() (map[string]interface{}, error) {
+	if result, ok := m.m.TestKeys.(map[string]interface{}); ok {
+		return result, nil
+	}
+	data, err := json.Marshal(m.m.TestKeys)
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	return result, err
+}
+
+var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
+	"dash": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return dash.NewExperiment(session.session, config.(dash.Config))
+			},
+			config:     dash.Config{},
+			needsInput: false,
+		}
+	},
+
+	"example": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return example.NewExperiment(session.session, config.(example.Config))
+			},
+			config: example.Config{
+				SleepTime: 2 * time.Second,
+			},
+			needsInput: false,
+		}
+	},
+
+	"facebook_messenger": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return fbmessenger.NewExperiment(session.session, config.(fbmessenger.Config))
+			},
+			config:     fbmessenger.Config{},
+			needsInput: false,
+		}
+	},
+
+	"http_header_field_manipulation": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return hhfm.NewExperiment(session.session, config.(hhfm.Config))
+			},
+			config:     hhfm.Config{},
+			needsInput: false,
+		}
+	},
+
+	"http_invalid_request_line": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return hirl.NewExperiment(session.session, config.(hirl.Config))
+			},
+			config:     hirl.Config{},
+			needsInput: false,
+		}
+	},
+
+	"ndt": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return ndt.NewExperiment(session.session, config.(ndt.Config))
+			},
+			config:     ndt.Config{},
+			needsInput: false,
+		}
+	},
+
+	"ndt7": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return ndt7.NewExperiment(session.session, config.(ndt7.Config))
+			},
+			config:     ndt7.Config{},
+			needsInput: false,
+		}
+	},
+
+	"psiphon": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return psiphon.NewExperiment(session.session, config.(psiphon.Config))
+			},
+			config: psiphon.Config{
+				ConfigFilePath: filepath.Join(
+					session.session.AssetsDir, "psiphon_config.json",
+				),
+				WorkDir: session.session.TempDir,
+			},
+			needsInput: false,
+		}
+	},
+
+	"telegram": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return telegram.NewExperiment(session.session, config.(telegram.Config))
+			},
+			config:     telegram.Config{},
+			needsInput: false,
+		}
+	},
+
+	"web_connectivity": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return web_connectivity.NewExperiment(
+					session.session, config.(web_connectivity.Config),
+				)
+			},
+			config:     web_connectivity.Config{},
+			needsInput: true,
+		}
+	},
+
+	"whatsapp": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *experiment.Experiment {
+				return whatsapp.NewExperiment(
+					session.session, config.(whatsapp.Config),
+				)
+			},
+			config:     whatsapp.Config{},
+			needsInput: false,
+		}
+	},
+}
+
+// AllExperiments returns the name of all experiments
+func AllExperiments() []string {
+	var names []string
+	for key := range experimentsByName {
+		names = append(names, key)
+	}
+	return names
+}

--- a/experiment/dash/dash_cgo_test.go
+++ b/experiment/dash/dash_cgo_test.go
@@ -26,6 +26,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/dash/dash_otherwise_test.go
+++ b/experiment/dash/dash_otherwise_test.go
@@ -26,6 +26,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/example/example_test.go
+++ b/experiment/example/example_test.go
@@ -21,6 +21,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)
@@ -30,7 +31,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	experiment := example.NewExperiment(
-		sess, example.Config{SleepTime: 2 * time.Second},
+		sess, example.Config{SleepTime: int64(2 * time.Second)},
 	)
 	if err := experiment.OpenReport(ctx); err != nil {
 		t.Fatal(err)
@@ -43,5 +44,23 @@ func TestIntegration(t *testing.T) {
 	}
 	if err := experiment.SubmitMeasurement(ctx, &measurement); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestIntegrationFailure(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	ctx := context.Background()
+	sess := session.New(
+		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
+	)
+	experiment := example.NewExperiment(
+		sess, example.Config{
+			SleepTime:   int64(2 * time.Second),
+			ReturnError: true,
+		},
+	)
+	if _, err := experiment.Measure(ctx, ""); err == nil {
+		t.Fatal("expected an error here")
 	}
 }

--- a/experiment/experiment_test.go
+++ b/experiment/experiment_test.go
@@ -103,6 +103,7 @@ func TestOpenReportFailure(t *testing.T) {
 func TestMeasureLookupLocationFailure(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../testdata", nil, nil,
+		"../../testdata",
 	)
 	exp := experiment.New(
 		sess, "antani", "0.1.1",
@@ -168,6 +169,7 @@ func TestSaveMeasurementErrors(t *testing.T) {
 func newExperiment(ctx context.Context) (*experiment.Experiment, error) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		return nil, err

--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -24,6 +24,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/hhfm/hhfm_test.go
+++ b/experiment/hhfm/hhfm_test.go
@@ -24,6 +24,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/hirl/hirl_test.go
+++ b/experiment/hirl/hirl_test.go
@@ -24,6 +24,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/mkevent/mkevent_test.go
+++ b/experiment/mkevent/mkevent_test.go
@@ -14,6 +14,7 @@ import (
 func TestIntegrationMeasurementSuccess(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	var m model.Measurement
 	printer := handler.NewPrinterCallbacks(log.Log)
@@ -33,6 +34,7 @@ func TestIntegrationMeasurementFailure(t *testing.T) {
 	}()
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	var m model.Measurement
 	printer := handler.NewPrinterCallbacks(log.Log)
@@ -47,6 +49,7 @@ func TestIntegrationMeasurementFailure(t *testing.T) {
 func TestIntegrationLog(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	var m model.Measurement
 	printer := handler.NewPrinterCallbacks(log.Log)
@@ -76,6 +79,7 @@ func TestIntegrationLog(t *testing.T) {
 func TestIntegrationStatusProgress(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	var m model.Measurement
 	printer := handler.NewPrinterCallbacks(log.Log)
@@ -91,6 +95,7 @@ func TestIntegrationStatusProgress(t *testing.T) {
 func TestIntegrationStatusEnd(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	var m model.Measurement
 	printer := handler.NewPrinterCallbacks(log.Log)
@@ -106,6 +111,7 @@ func TestIntegrationStatusEnd(t *testing.T) {
 func TestIntegrationOtherEvent(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	var m model.Measurement
 	printer := handler.NewPrinterCallbacks(log.Log)

--- a/experiment/mkhelper/mkhelper_test.go
+++ b/experiment/mkhelper/mkhelper_test.go
@@ -13,6 +13,7 @@ import (
 func TestNoHelpers(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	var settings measurementkit.Settings
 	err := mkhelper.Set(
@@ -26,6 +27,7 @@ func TestNoHelpers(t *testing.T) {
 func TestNoSuitableHelper(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	sess.AvailableTestHelpers = map[string][]model.Service{
 		"foobar": []model.Service{
@@ -47,6 +49,7 @@ func TestNoSuitableHelper(t *testing.T) {
 func TestGoodHelper(t *testing.T) {
 	sess := session.New(
 		log.Log, "ooniprobe-engine", "0.1.0", "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	sess.AvailableTestHelpers = map[string][]model.Service{
 		"foobar": []model.Service{

--- a/experiment/mkrunner/mkrunner_test.go
+++ b/experiment/mkrunner/mkrunner_test.go
@@ -16,7 +16,7 @@ func TestIntegrationSuccess(t *testing.T) {
 		measurementkit.Settings{},
 		session.New(
 			apexlog.Log, "ooniprobe-engine", "0.1.0",
-			"../../testdata", nil, nil,
+			"../../testdata", nil, nil, "../../testdata",
 		),
 		&model.Measurement{},
 		handler.NewPrinterCallbacks(apexlog.Log),
@@ -32,7 +32,7 @@ func TestIntegrationFailure(t *testing.T) {
 		measurementkit.Settings{},
 		session.New(
 			apexlog.Log, "ooniprobe-engine", "0.1.0",
-			"../../testdata", nil, nil,
+			"../../testdata", nil, nil, "../../testdata",
 		),
 		&model.Measurement{},
 		handler.NewPrinterCallbacks(apexlog.Log),

--- a/experiment/ndt/ndt_test.go
+++ b/experiment/ndt/ndt_test.go
@@ -24,6 +24,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -20,6 +20,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/psiphon/common.go
+++ b/experiment/psiphon/common.go
@@ -1,5 +1,7 @@
 package psiphon
 
+import "errors"
+
 const (
 	testName    = "psiphon"
 	testVersion = "0.3.0"
@@ -8,9 +10,12 @@ const (
 // Config contains the experiment's configuration.
 type Config struct {
 	// ConfigFilePath is the path where Psiphon config file is located.
-	ConfigFilePath string
+	ConfigFilePath string `ooni:"configuration file path"`
 
 	// WorkDir is the directory where Psiphon should store
 	// its configuration database.
-	WorkDir string
+	WorkDir string `ooni:"experiment working directory"`
 }
+
+// ErrDisabled indicates that we disabled psiphon at compile time
+var ErrDisabled = errors.New("Psiphon disabled at compile time")

--- a/experiment/psiphon/psiphon_otherwise.go
+++ b/experiment/psiphon/psiphon_otherwise.go
@@ -4,7 +4,6 @@ package psiphon
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ooni/probe-engine/experiment"
 	"github.com/ooni/probe-engine/experiment/handler"
@@ -21,6 +20,6 @@ func NewExperiment(
 		func(c context.Context, s *session.Session, m *model.Measurement,
 			callbacks handler.Callbacks,
 		) error {
-			return errors.New("Psiphon disabled at compile time")
+			return ErrDisabled
 		})
 }

--- a/experiment/psiphon/psiphon_test.go
+++ b/experiment/psiphon/psiphon_test.go
@@ -22,6 +22,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -24,6 +24,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/web_connectivity/web_connectivity_test.go
+++ b/experiment/web_connectivity/web_connectivity_test.go
@@ -35,6 +35,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment/whatsapp/whatsapp_test.go
+++ b/experiment/whatsapp/whatsapp_test.go
@@ -24,6 +24,7 @@ func TestIntegration(t *testing.T) {
 
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../../testdata", nil, nil,
+		"../../testdata",
 	)
 	if err := sess.MaybeLookupBackends(ctx); err != nil {
 		t.Fatal(err)

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -1,8 +1,10 @@
 package engine
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/ooni/probe-engine/experiment/example"
 	"github.com/ooni/probe-engine/experiment/psiphon"
 )
 
@@ -29,10 +31,178 @@ func TestRunExample(t *testing.T) {
 	runexperimentflow(t, builder.Build())
 }
 
+func TestNeedsInput(t *testing.T) {
+	sess := newSessionForTesting(t)
+	builder, err := sess.NewExperimentBuilder("web_connectivity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if builder.NeedsInput() == false {
+		t.Fatal("web_connectivity certainly needs input")
+	}
+}
+
+func TestSetCallbacks(t *testing.T) {
+	sess := newSessionForTesting(t)
+	builder, err := sess.NewExperimentBuilder("example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := builder.SetOptionInt("SleepTime", 0); err != nil {
+		t.Fatal(err)
+	}
+	register := &registerCallbacksCalled{}
+	builder.SetCallbacks(register)
+	if _, err := builder.Build().Measure(""); err != nil {
+		t.Fatal(err)
+	}
+	if register.onDataUsageCalled == false {
+		t.Fatal("OnDataUsage not called")
+	}
+	if register.onProgressCalled == false {
+		t.Fatal("OnProgress not called")
+	}
+}
+
+type registerCallbacksCalled struct {
+	onProgressCalled  bool
+	onDataUsageCalled bool
+}
+
+func (c *registerCallbacksCalled) OnDataUsage(dloadKiB, uploadKiB float64) {
+	c.onDataUsageCalled = true
+}
+
+func (c *registerCallbacksCalled) OnProgress(percentage float64, message string) {
+	c.onProgressCalled = true
+}
+
+func TestCreateInvalidExperiment(t *testing.T) {
+	sess := newSessionForTesting(t)
+	builder, err := sess.NewExperimentBuilder("antani")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if builder != nil {
+		t.Fatal("expected a nil builder here")
+	}
+}
+
+func TestMeasurementFailure(t *testing.T) {
+	sess := newSessionForTesting(t)
+	builder, err := sess.NewExperimentBuilder("example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := builder.SetOptionBool("ReturnError", true); err != nil {
+		t.Fatal(err)
+	}
+	measurement, err := builder.Build().Measure("")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if err.Error() != "mocked error" {
+		t.Fatal("unexpected error type")
+	}
+	if measurement == nil {
+		t.Fatal("expected non nil measurement here")
+	}
+}
+
+func TestUseOptions(t *testing.T) {
+	sess := newSessionForTesting(t)
+	builder, err := sess.NewExperimentBuilder("example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	options, err := builder.Options()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var (
+		returnError bool
+		message     bool
+		sleepTime   bool
+		other       int64
+	)
+	for name, option := range options {
+		if name == "ReturnError" {
+			returnError = true
+			if option.Type != "bool" {
+				t.Fatal("ReturnError is not a bool")
+			}
+			if option.Doc != "Toogle to return a mocked error" {
+				t.Fatal("ReturnError doc is wrong")
+			}
+		} else if name == "Message" {
+			message = true
+			if option.Type != "string" {
+				t.Fatal("Message is not a string")
+			}
+			if option.Doc != "Message to emit at test completion" {
+				t.Fatal("Message doc is wrong")
+			}
+		} else if name == "SleepTime" {
+			sleepTime = true
+			if option.Type != "int64" {
+				t.Fatal("SleepTime is not an int64")
+			}
+			if option.Doc != "Amount of time to sleep for" {
+				t.Fatal("SleepTime doc is wrong")
+			}
+		} else {
+			other++
+		}
+	}
+	if other != 0 {
+		t.Fatal("found unexpected option")
+	}
+	if !returnError {
+		t.Fatal("did not find ReturnError option")
+	}
+	if !message {
+		t.Fatal("did not find Message option")
+	}
+	if !sleepTime {
+		t.Fatal("did not find SleepTime option")
+	}
+	if err := builder.SetOptionBool("ReturnError", true); err != nil {
+		t.Fatal("cannot set ReturnError field")
+	}
+	if err := builder.SetOptionInt("SleepTime", 10); err != nil {
+		t.Fatal("cannot set SleepTime field")
+	}
+	if err := builder.SetOptionString("Message", "antani"); err != nil {
+		t.Fatal("cannot set Message field")
+	}
+	config := builder.config.(*example.Config)
+	if config.ReturnError != true {
+		t.Fatal("config.ReturnError was not changed")
+	}
+	if config.SleepTime != 10 {
+		t.Fatal("config.SleepTime was not changed")
+	}
+	if config.Message != "antani" {
+		t.Fatal("config.Message was not changed")
+	}
+}
+
+func TestRunHHFM(t *testing.T) {
+	sess := newSessionForTesting(t)
+	builder, err := sess.NewExperimentBuilder("http_header_field_manipulation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runexperimentflow(t, builder.Build())
+}
+
 func runexperimentflow(t *testing.T, experiment *Experiment) {
 	err := experiment.OpenReport()
 	if err != nil {
 		t.Fatal(err)
+	}
+	if experiment.ReportID() == "" {
+		t.Fatal("reportID should not be empty here")
 	}
 	measurement, err := experiment.Measure("")
 	if err != nil {
@@ -42,6 +212,10 @@ func runexperimentflow(t *testing.T, experiment *Experiment) {
 		}
 		t.Fatal(err)
 	}
+	measurement.AddAnnotations(map[string]string{
+		"probe-engine-ci": "yes",
+	})
+	t.Log(measurement.MakeGenericTestKeys())
 	err = experiment.SubmitAndUpdateMeasurement(measurement)
 	if err != nil {
 		t.Fatal(err)
@@ -54,4 +228,115 @@ func runexperimentflow(t *testing.T, experiment *Experiment) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestMakeGenericTestKeysMarshalError(t *testing.T) {
+	m := new(Measurement)
+	out, err := m.makeGenericTestKeys(
+		func(interface{}) ([]byte, error) {
+			return nil, errors.New("mocked error")
+		},
+	)
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if out != nil {
+		t.Fatal("expected nil output here")
+	}
+}
+
+func TestOptions(t *testing.T) {
+	t.Run("when config is not a pointer", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: 17,
+		}
+		options, err := b.Options()
+		if err == nil {
+			t.Fatal("expected an error here")
+		}
+		if options != nil {
+			t.Fatal("expected nil here")
+		}
+	})
+	t.Run("when confg is not a struct", func(t *testing.T) {
+		number := 17
+		b := &ExperimentBuilder{
+			config: &number,
+		}
+		options, err := b.Options()
+		if err == nil {
+			t.Fatal("expected an error here")
+		}
+		if options != nil {
+			t.Fatal("expected nil here")
+		}
+	})
+}
+
+func TestSetOption(t *testing.T) {
+	t.Run("when config is not a pointer", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: 17,
+		}
+		if err := b.SetOptionBool("antani", false); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
+	t.Run("when config is not a struct", func(t *testing.T) {
+		number := 17
+		b := &ExperimentBuilder{
+			config: &number,
+		}
+		if err := b.SetOptionBool("antani", false); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
+	t.Run("when field is not valid", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: &ExperimentBuilder{},
+		}
+		if err := b.SetOptionBool("antani", false); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
+	t.Run("when field is not bool", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: new(example.Config),
+		}
+		if err := b.SetOptionBool("Message", false); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
+	t.Run("when field is not string", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: new(example.Config),
+		}
+		if err := b.SetOptionString("ReturnError", "xx"); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
+	t.Run("when field is not int", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: new(example.Config),
+		}
+		if err := b.SetOptionInt("ReturnError", 17); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
+	t.Run("when int field does not exist", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: new(example.Config),
+		}
+		if err := b.SetOptionInt("antani", 17); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
+	t.Run("when string field does not exist", func(t *testing.T) {
+		b := &ExperimentBuilder{
+			config: new(example.Config),
+		}
+		if err := b.SetOptionString("antani", "xx"); err == nil {
+			t.Fatal("expected an error here")
+		}
+	})
 }

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ooni/probe-engine/experiment/example"
 	"github.com/ooni/probe-engine/experiment/psiphon"
+	"github.com/ooni/probe-engine/measurementkit"
 )
 
 func TestCreateAll(t *testing.T) {
@@ -188,6 +189,9 @@ func TestUseOptions(t *testing.T) {
 }
 
 func TestRunHHFM(t *testing.T) {
+	if !measurementkit.Available() {
+		t.Skip("Measurement Kit not available; skipping")
+	}
 	sess := newSessionForTesting(t)
 	builder, err := sess.NewExperimentBuilder("http_header_field_manipulation")
 	if err != nil {

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -1,0 +1,57 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/ooni/probe-engine/experiment/psiphon"
+)
+
+func TestCreateAll(t *testing.T) {
+	sess := newSessionForTesting(t)
+	for _, name := range AllExperiments() {
+		builder, err := sess.NewExperimentBuilder(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		exp := builder.Build()
+		if exp.Name() != name {
+			t.Fatal("unexpected experiment name")
+		}
+	}
+}
+
+func TestRunExample(t *testing.T) {
+	sess := newSessionForTesting(t)
+	builder, err := sess.NewExperimentBuilder("example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runexperimentflow(t, builder.Build())
+}
+
+func runexperimentflow(t *testing.T, experiment *Experiment) {
+	err := experiment.OpenReport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	measurement, err := experiment.Measure("")
+	if err != nil {
+		if err == psiphon.ErrDisabled {
+			defer experiment.CloseReport()
+			return
+		}
+		t.Fatal(err)
+	}
+	err = experiment.SubmitAndUpdateMeasurement(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = experiment.SaveMeasurement(measurement, "/tmp/experiment.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = experiment.CloseReport()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/orchestra/testlists/testlists_test.go
+++ b/orchestra/testlists/testlists_test.go
@@ -16,6 +16,7 @@ func TestIntegration(t *testing.T) {
 		"0.1.0",
 		"../../testdata/",
 		nil, nil,
+		"../../testdata/",
 	)
 	client := testlists.NewClient(sess)
 	client.SetEnabledCategories([]string{"NEWS", "CULTR"})

--- a/session.go
+++ b/session.go
@@ -1,0 +1,148 @@
+package engine
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net/url"
+
+	"github.com/ooni/probe-engine/log"
+	"github.com/ooni/probe-engine/orchestra/testlists"
+	"github.com/ooni/probe-engine/session"
+)
+
+// SessionConfig contains the Session config
+type SessionConfig struct {
+	AssetsDir       string
+	Logger          log.Logger
+	ProxyURL        *url.URL
+	SoftwareName    string
+	SoftwareVersion string
+	TempDir         string
+	TLSConfig       *tls.Config
+}
+
+// Session is a measurement session
+type Session struct {
+	session *session.Session
+}
+
+// NewSession creates a new session or returns an error
+func NewSession(config SessionConfig) (*Session, error) {
+	if config.AssetsDir == "" {
+		return nil, errors.New("AssetsDir is empty")
+	}
+	if config.Logger == nil {
+		return nil, errors.New("Logger is empty")
+	}
+	if config.SoftwareName == "" {
+		return nil, errors.New("SoftwareName is empty")
+	}
+	if config.SoftwareVersion == "" {
+		return nil, errors.New("SoftwareVersion is empty")
+	}
+	if config.TempDir == "" {
+		return nil, errors.New("TempDir is empty")
+	}
+	sess := session.New(
+		config.Logger,
+		config.SoftwareName,
+		config.SoftwareVersion,
+		config.AssetsDir,
+		config.ProxyURL,
+		config.TLSConfig,
+		config.TempDir,
+	)
+	return &Session{session: sess}, nil
+}
+
+// AddAvailableHTTPSBouncer adds an HTTPS bouncer to the list
+// of bouncers that we'll try to contact.
+func (sess *Session) AddAvailableHTTPSBouncer(baseURL string) {
+	sess.session.AddAvailableHTTPSBouncer(baseURL)
+}
+
+// AddAvailableHTTPSCollector adds an HTTPS collector to the
+// list of collectors that we'll try to use.
+func (sess *Session) AddAvailableHTTPSCollector(baseURL string) {
+	sess.session.AddAvailableHTTPSCollector(baseURL)
+}
+
+// MaybeLookupLocation is a caching location lookup call.
+func (sess *Session) MaybeLookupLocation() error {
+	return sess.session.MaybeLookupLocation(context.Background())
+}
+
+// MaybeLookupBackends is a caching OONI backends lookup call.
+func (sess *Session) MaybeLookupBackends() error {
+	return sess.session.MaybeLookupBackends(context.Background())
+}
+
+// ProbeASN returns the ASN of the probe's network.
+func (sess *Session) ProbeASN() uint {
+	return sess.session.ProbeASN()
+}
+
+// ProbeASNString is like ProbeASN but returns the "AS<%d>" string
+// where the number is the number returned by ProbeASN.
+func (sess *Session) ProbeASNString() string {
+	return sess.session.ProbeASNString()
+}
+
+// ProbeCC returns the probe country code.
+func (sess *Session) ProbeCC() string {
+	return sess.session.ProbeCC()
+}
+
+// ProbeIP returns the probe IP.
+func (sess *Session) ProbeIP() string {
+	return sess.session.ProbeIP()
+}
+
+// ProbeNetworkName returns the probe network name.
+func (sess *Session) ProbeNetworkName() string {
+	return sess.session.ProbeNetworkName()
+}
+
+// ResolverIP returns the resolver IP.
+func (sess *Session) ResolverIP() string {
+	return sess.session.ResolverIP()
+}
+
+// SetIncludeProbeASN controls whether to include the ASN
+func (sess *Session) SetIncludeProbeASN(value bool) {
+	sess.session.PrivacySettings.IncludeASN = value
+}
+
+// SetIncludeProbeCC controls whether to include the country code
+func (sess *Session) SetIncludeProbeCC(value bool) {
+	sess.session.PrivacySettings.IncludeCountry = value
+}
+
+// SetIncludeProbeIP controls whether to include the IP
+func (sess *Session) SetIncludeProbeIP(value bool) {
+	sess.session.PrivacySettings.IncludeIP = value
+}
+
+// NewTestListsConfig returns prefilled settings for TestListsClient
+// where in particular we have set the correct country code
+func (sess *Session) NewTestListsConfig() *TestListsConfig {
+	return &TestListsConfig{
+		CountryCode: sess.session.ProbeCC(),
+	}
+}
+
+// NewTestListsClient returns a new TestListsClient that is configured
+// to perform requests in the context of this session
+func (sess *Session) NewTestListsClient() *TestListsClient {
+	return &TestListsClient{
+		client: testlists.NewClient(sess.session),
+	}
+}
+
+// NewExperimentBuilder returns a new experiment builder
+// for the experiment with the given name, or an error if
+// there's no such experiment with the given name
+func (sess *Session) NewExperimentBuilder(name string) (*ExperimentBuilder, error) {
+	return newExperimentBuilder(sess, name)
+}

--- a/session/session.go
+++ b/session/session.go
@@ -59,6 +59,9 @@ type Session struct {
 	// SoftwareVersion contains the software version.
 	SoftwareVersion string
 
+	// TempDir is the directory where to store temporary files
+	TempDir string
+
 	// TLSConfig contains the TLS config
 	TLSConfig *tls.Config
 
@@ -94,7 +97,7 @@ type Session struct {
 // of httpx.NewTransport for more information on this.
 func New(
 	logger log.Logger, softwareName, softwareVersion, assetsDir string,
-	proxy *url.URL, tlsConfig *tls.Config,
+	proxy *url.URL, tlsConfig *tls.Config, tempDir string,
 ) *Session {
 	return &Session{
 		AssetsDir:     assetsDir,
@@ -117,6 +120,7 @@ func New(
 		},
 		SoftwareName:    softwareName,
 		SoftwareVersion: softwareVersion,
+		TempDir:         tempDir,
 		TLSConfig:       tlsConfig,
 	}
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -23,6 +23,7 @@ func TestIntegration(t *testing.T) {
 	ctx := context.Background()
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../testdata", nil, nil,
+		"../../testdata/",
 	)
 
 	sess.AvailableBouncers = append(sess.AvailableBouncers, model.Service{
@@ -92,6 +93,7 @@ func TestBouncerError(t *testing.T) {
 	ctx := context.Background()
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../testdata", URL, nil,
+		"../../testdata/",
 	)
 
 	if err := sess.MaybeLookupBackends(ctx); err == nil {
@@ -108,6 +110,7 @@ func TestLookupLocationError(t *testing.T) {
 	cancel() // cause operations to fail
 	sess := session.New(
 		log.Log, softwareName, softwareVersion, "../testdata", nil, nil,
+		"../../testdata/",
 	)
 	if err := sess.MaybeLookupLocation(ctx); err == nil {
 		t.Fatal("expected an error here")

--- a/session_test.go
+++ b/session_test.go
@@ -7,8 +7,50 @@ import (
 	"github.com/apex/log"
 )
 
-func TestNewSessionBuilder(t *testing.T) {
+func TestNewSessionBuilderChecks(t *testing.T) {
+	t.Run("with no settings", func(t *testing.T) {
+		newSessionMustFail(t, SessionConfig{})
+	})
+	t.Run("with only assets dir", func(t *testing.T) {
+		newSessionMustFail(t, SessionConfig{
+			AssetsDir: "testdata",
+		})
+	})
+	t.Run("with also logger", func(t *testing.T) {
+		newSessionMustFail(t, SessionConfig{
+			AssetsDir: "testdata",
+			Logger:    log.Log,
+		})
+	})
+	t.Run("with also software name", func(t *testing.T) {
+		newSessionMustFail(t, SessionConfig{
+			AssetsDir:    "testdata",
+			Logger:       log.Log,
+			SoftwareName: "ooniprobe-engine",
+		})
+	})
+	t.Run("with also software version", func(t *testing.T) {
+		newSessionMustFail(t, SessionConfig{
+			AssetsDir:       "testdata",
+			Logger:          log.Log,
+			SoftwareName:    "ooniprobe-engine",
+			SoftwareVersion: "0.0.1",
+		})
+	})
+}
+
+func TestNewSessionBuilderGood(t *testing.T) {
 	newSessionForTesting(t)
+}
+
+func newSessionMustFail(t *testing.T, config SessionConfig) {
+	sess, err := NewSession(config)
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if sess != nil {
+		t.Fatal("expected nil session here")
+	}
 }
 
 func newSessionForTesting(t *testing.T) *Session {
@@ -26,6 +68,11 @@ func newSessionForTesting(t *testing.T) *Session {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sess.AddAvailableHTTPSBouncer("https://bouncer.ooni.io")
+	sess.AddAvailableHTTPSCollector("https://ams-ps.ooni.nu")
+	sess.SetIncludeProbeASN(true)
+	sess.SetIncludeProbeCC(true)
+	sess.SetIncludeProbeIP(false)
 	if err := sess.MaybeLookupLocation(); err != nil {
 		t.Fatal(err)
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,42 @@
+package engine
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/apex/log"
+)
+
+func TestNewSessionBuilder(t *testing.T) {
+	newSessionForTesting(t)
+}
+
+func newSessionForTesting(t *testing.T) *Session {
+	tempdir, err := ioutil.TempDir("testdata", "enginetests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess, err := NewSession(SessionConfig{
+		AssetsDir:       "testdata",
+		Logger:          log.Log,
+		SoftwareName:    "ooniprobe-engine",
+		SoftwareVersion: "0.0.1",
+		TempDir:         tempdir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sess.MaybeLookupLocation(); err != nil {
+		t.Fatal(err)
+	}
+	log.Infof("ProbeASN: %d", sess.ProbeASN())
+	log.Infof("ProbeASNString: %s", sess.ProbeASNString())
+	log.Infof("ProbeCC: %s", sess.ProbeCC())
+	log.Infof("ProbeIP: %s", sess.ProbeIP())
+	log.Infof("ProbeNetworkName: %s", sess.ProbeNetworkName())
+	log.Infof("ResolverIP: %s", sess.ResolverIP())
+	if err := sess.MaybeLookupBackends(); err != nil {
+		t.Fatal(err)
+	}
+	return sess
+}

--- a/testlists.go
+++ b/testlists.go
@@ -29,6 +29,9 @@ type URLInfo interface {
 // Fetch fetches the test list
 func (c *TestListsClient) Fetch(config *TestListsConfig) ([]URLInfo, error) {
 	var out []URLInfo
+	if config.BaseURL != "" {
+		c.client.BaseURL = config.BaseURL
+	}
 	list, err := c.client.Do(context.Background(), config.CountryCode, config.Limit)
 	if err != nil {
 		return nil, err

--- a/testlists.go
+++ b/testlists.go
@@ -1,0 +1,56 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/orchestra/testlists"
+)
+
+// TestListsConfig contains settings for TestListsClient
+type TestListsConfig struct {
+	BaseURL             string   // or use default
+	AvailableCategories []string // or ask for all
+	CountryCode         string   // set by session
+	Limit               int      // or get all
+}
+
+// TestListsClient is a test lists client
+type TestListsClient struct {
+	client *testlists.Client
+}
+
+// URLInfo contains info about URLs
+type URLInfo interface {
+	URL() string
+	CategoryCode() string
+	CountryCode() string
+}
+
+// Fetch fetches the test list
+func (c *TestListsClient) Fetch(config *TestListsConfig) ([]URLInfo, error) {
+	var out []URLInfo
+	list, err := c.client.Do(context.Background(), config.CountryCode, config.Limit)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range list {
+		out = append(out, &urlinfo{u: entry})
+	}
+	return out, nil
+}
+
+type urlinfo struct {
+	u testlists.URLInfo
+}
+
+func (u *urlinfo) URL() string {
+	return u.u.URL
+}
+
+func (u *urlinfo) CategoryCode() string {
+	return u.u.CategoryCode
+}
+
+func (u *urlinfo) CountryCode() string {
+	return u.u.CountryCode
+}

--- a/testlists_test.go
+++ b/testlists_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestLookupTestLists(t *testing.T) {
+func TestLookupTestListsSuccess(t *testing.T) {
 	sess := newSessionForTesting(t)
 	config := sess.NewTestListsConfig()
 	config.Limit = 14
@@ -15,5 +15,19 @@ func TestLookupTestLists(t *testing.T) {
 	}
 	for _, url := range urls {
 		t.Logf("%s\t%s\t%s", url.CountryCode(), url.CategoryCode(), url.URL())
+	}
+}
+
+func TestLookupTestListsFailure(t *testing.T) {
+	sess := newSessionForTesting(t)
+	config := sess.NewTestListsConfig()
+	config.BaseURL = "\t"
+	client := sess.NewTestListsClient()
+	urls, err := client.Fetch(config)
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if urls != nil {
+		t.Fatal("expected nil urls")
 	}
 }

--- a/testlists_test.go
+++ b/testlists_test.go
@@ -1,0 +1,19 @@
+package engine
+
+import (
+	"testing"
+)
+
+func TestLookupTestLists(t *testing.T) {
+	sess := newSessionForTesting(t)
+	config := sess.NewTestListsConfig()
+	config.Limit = 14
+	client := sess.NewTestListsClient()
+	urls, err := client.Fetch(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, url := range urls {
+		t.Logf("%s\t%s\t%s", url.CountryCode(), url.CategoryCode(), url.URL())
+	}
+}


### PR DESCRIPTION
This API allows to manipulate all engine things with very few structs. Also, this API introduces the possibility of querying test options and setting them rather easily.

Also, this API is very tailored to the needs of ooni/probe-cli and anticipates future usage on mobile by trying to expose something that should be easily mockable with go mobile.