### PR TITLE
orchestra: implement the authenticated update API

### DIFF
--- a/internal/orchestra/login/login_test.go
+++ b/internal/orchestra/login/login_test.go
@@ -1,4 +1,4 @@
-package login
+package login_test
 
 import (
 	"context"
@@ -6,25 +6,16 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-engine/internal/orchestra/metadata"
-	"github.com/ooni/probe-engine/internal/orchestra/register"
+	"github.com/ooni/probe-engine/internal/orchestra/login"
+	"github.com/ooni/probe-engine/internal/orchestra/testorchestra"
 )
 
-const password = "xx"
-
 func TestIntegrationSuccess(t *testing.T) {
-	clientID, err := doRegister()
+	clientID, err := testorchestra.Register()
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := Do(context.Background(), Config{
-		BaseURL:    "https://ps-test.ooni.io",
-		ClientID:   clientID,
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		Password:   password,
-		UserAgent:  "miniooni/0.1.0-dev",
-	})
+	result, err := testorchestra.Login(clientID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +32,7 @@ func TestIntegrationSuccess(t *testing.T) {
 
 func TestIntegrationFailure(t *testing.T) {
 	// This should fail because the username/password is wrong
-	result, err := Do(context.Background(), Config{
+	result, err := login.Do(context.Background(), login.Config{
 		BaseURL:    "https://ps-test.ooni.io",
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,
@@ -53,28 +44,4 @@ func TestIntegrationFailure(t *testing.T) {
 	if result != nil {
 		t.Fatal("result should be nil here")
 	}
-}
-
-func doRegister() (string, error) {
-	result, err := register.Do(context.Background(), register.Config{
-		BaseURL:    "https://ps-test.ooni.io",
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		Metadata: metadata.Metadata{
-			Platform:        "linux",
-			ProbeASN:        "AS15169",
-			ProbeCC:         "US",
-			SoftwareName:    "miniooni",
-			SoftwareVersion: "0.1.0-dev",
-			SupportedTests: []string{
-				"web_connectivity",
-			},
-		},
-		Password:  password,
-		UserAgent: "miniooni/0.1.0-dev",
-	})
-	if err != nil {
-		return "", err
-	}
-	return result.ClientID, nil
 }

--- a/internal/orchestra/register/register_test.go
+++ b/internal/orchestra/register/register_test.go
@@ -1,4 +1,4 @@
-package register
+package register_test
 
 import (
 	"context"
@@ -6,34 +6,16 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-engine/internal/orchestra/metadata"
+	"github.com/ooni/probe-engine/internal/orchestra/register"
+	"github.com/ooni/probe-engine/internal/orchestra/testorchestra"
 )
 
 func TestIntegrationSuccess(t *testing.T) {
-	result, err := Do(context.Background(), Config{
-		BaseURL:    "https://ps-test.ooni.io",
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		Metadata: metadata.Metadata{
-			Platform:        "linux",
-			ProbeASN:        "AS15169",
-			ProbeCC:         "US",
-			SoftwareName:    "miniooni",
-			SoftwareVersion: "0.1.0-dev",
-			SupportedTests: []string{
-				"web_connectivity",
-			},
-		},
-		Password:  "xx",
-		UserAgent: "miniooni/0.1.0-dev",
-	})
+	clientID, err := testorchestra.Register()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result == nil {
-		t.Fatal("result should not be nil here")
-	}
-	if result.ClientID == "" {
+	if clientID == "" {
 		t.Fatal("ClientID should not be empty")
 	}
 }
@@ -42,7 +24,7 @@ func TestIntegrationFailure(t *testing.T) {
 	// The successful integration test contains the minimal amount
 	// of fields expected by the orchestra. Any less amount of fields,
 	// such as we do here, results in the API returning error.
-	result, err := Do(context.Background(), Config{
+	result, err := register.Do(context.Background(), register.Config{
 		BaseURL:    "https://ps-test.ooni.io",
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,

--- a/internal/orchestra/testorchestra/testorchestra.go
+++ b/internal/orchestra/testorchestra/testorchestra.go
@@ -1,0 +1,71 @@
+// Package testorchestra contains code to simplify testing
+package testorchestra
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/internal/orchestra/login"
+	"github.com/ooni/probe-engine/internal/orchestra/metadata"
+	"github.com/ooni/probe-engine/internal/orchestra/register"
+	"github.com/ooni/probe-engine/internal/orchestra/update"
+)
+
+const password = "xx"
+
+// Register register a fictional probe and returns the clientID
+// on success and an error on failure.
+func Register() (string, error) {
+	result, err := register.Do(context.Background(), register.Config{
+		BaseURL:    "https://ps-test.ooni.io",
+		HTTPClient: http.DefaultClient,
+		Logger:     log.Log,
+		Metadata:   metadataFixture(),
+		Password:   password,
+		UserAgent:  "miniooni/0.1.0-dev",
+	})
+	if err != nil {
+		return "", err
+	}
+	return result.ClientID, nil
+}
+
+// Login performs a login and returns the authentication token
+// information on success, and an error on failure.
+func Login(clientID string) (*login.Auth, error) {
+	return login.Do(context.Background(), login.Config{
+		BaseURL:    "https://ps-test.ooni.io",
+		ClientID:   clientID,
+		HTTPClient: http.DefaultClient,
+		Logger:     log.Log,
+		Password:   password,
+		UserAgent:  "miniooni/0.1.0-dev",
+	})
+}
+
+// Update updates information about a probe
+func Update(auth *login.Auth, clientID string) error {
+	return update.Do(context.Background(), update.Config{
+		Auth:       auth,
+		BaseURL:    "https://ps-test.ooni.io",
+		ClientID:   clientID,
+		HTTPClient: http.DefaultClient,
+		Logger:     log.Log,
+		Metadata:   metadataFixture(),
+		UserAgent:  "miniooni/0.1.0-dev",
+	})
+}
+
+func metadataFixture() metadata.Metadata {
+	return metadata.Metadata{
+		Platform:        "linux",
+		ProbeASN:        "AS15169",
+		ProbeCC:         "US",
+		SoftwareName:    "miniooni",
+		SoftwareVersion: "0.1.0-dev",
+		SupportedTests: []string{
+			"web_connectivity",
+		},
+	}
+}

--- a/internal/orchestra/update/update.go
+++ b/internal/orchestra/update/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/log"
 )
 
-// Config contains configs for registering to OONI orchestra.
+// Config contains configs for calling the update API.
 type Config struct {
 	Auth       *login.Auth
 	BaseURL    string

--- a/internal/orchestra/update/update.go
+++ b/internal/orchestra/update/update.go
@@ -1,0 +1,51 @@
+// Package update contains code to update the probe state with orchestra
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ooni/probe-engine/httpx/jsonapi"
+	"github.com/ooni/probe-engine/internal/orchestra/login"
+	"github.com/ooni/probe-engine/internal/orchestra/metadata"
+	"github.com/ooni/probe-engine/log"
+)
+
+// Config contains configs for registering to OONI orchestra.
+type Config struct {
+	Auth       *login.Auth
+	BaseURL    string
+	ClientID   string
+	HTTPClient *http.Client
+	Logger     log.Logger
+	Metadata   metadata.Metadata
+	UserAgent  string
+}
+
+type request struct {
+	metadata.Metadata
+}
+
+// Do registers this probe with OONI orchestra
+func Do(ctx context.Context, config Config) error {
+	if config.Auth == nil {
+		return errors.New("config.Auth is nil")
+	}
+	// TODO(bassosimone): we should improve the codebase to avoid
+	// assuming that the token isn't expired, even though the default
+	// expire time is currently compatible with logging in at the
+	// beginning of every session and ignore this fact.
+	authorization := fmt.Sprintf("Bearer %s", config.Auth.Token)
+	req := &request{Metadata: config.Metadata}
+	var resp struct{}
+	urlpath := fmt.Sprintf("/api/v1/update/%s", config.ClientID)
+	return (&jsonapi.Client{
+		Authorization: authorization,
+		BaseURL:       config.BaseURL,
+		HTTPClient:    config.HTTPClient,
+		Logger:        config.Logger,
+		UserAgent:     config.UserAgent,
+	}).Update(ctx, urlpath, req, &resp)
+}

--- a/internal/orchestra/update/update_test.go
+++ b/internal/orchestra/update/update_test.go
@@ -1,0 +1,27 @@
+package update_test
+
+import (
+	"testing"
+
+	"github.com/ooni/probe-engine/internal/orchestra/testorchestra"
+)
+
+func TestIntegrationSuccess(t *testing.T) {
+	clientID, err := testorchestra.Register()
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := testorchestra.Login(clientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := testorchestra.Update(auth, clientID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntegrationFailure(t *testing.T) {
+	if err := testorchestra.Update(nil, "xx"); err == nil {
+		t.Fatal("expected an error here")
+	}
+}


### PR DESCRIPTION
We're getting closer to #148 because now we're able to call
an authenticated API successfully.

While there, avoid code duplication in tests.