### PR TITLE
orchestra/testlists/urls consistent w/ other orchestra

### DIFF
--- a/internal/orchestra/testlists/urls/urls.go
+++ b/internal/orchestra/testlists/urls/urls.go
@@ -30,7 +30,7 @@ type Result struct {
 }
 
 // Query retrieves the test list for the specified country.
-func Query(ctx context.Context, config Config) (response Result, err error) {
+func Query(ctx context.Context, config Config) (*Result, error) {
 	query := url.Values{}
 	if config.CountryCode != "" {
 		query.Set("probe_cc", config.CountryCode)
@@ -41,11 +41,15 @@ func Query(ctx context.Context, config Config) (response Result, err error) {
 	if len(config.EnabledCategories) > 0 {
 		query.Set("category_codes", strings.Join(config.EnabledCategories, ","))
 	}
-	err = (&jsonapi.Client{
+	var response Result
+	err := (&jsonapi.Client{
 		BaseURL:    config.BaseURL,
 		HTTPClient: config.HTTPClient,
 		Logger:     config.Logger,
 		UserAgent:  config.UserAgent,
 	}).ReadWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
-	return
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
 }

--- a/internal/orchestra/testlists/urls/urls_test.go
+++ b/internal/orchestra/testlists/urls/urls_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/apex/log"
 )
 
-func TestIntegration(t *testing.T) {
+func TestIntegrationSuccess(t *testing.T) {
 	config := Config{
 		BaseURL:           "https://orchestrate.ooni.io",
 		CountryCode:       "IT",
@@ -25,5 +25,25 @@ func TestIntegration(t *testing.T) {
 	}
 	if len(result.Results) < 1 {
 		t.Fatal("no results")
+	}
+}
+
+func TestIntegrationFailure(t *testing.T) {
+	config := Config{
+		BaseURL:           "\t\t\t",
+		CountryCode:       "IT",
+		EnabledCategories: []string{"NEWS", "CULTR"},
+		HTTPClient:        http.DefaultClient,
+		Limit:             17,
+		Logger:            log.Log,
+		UserAgent:         "ooniprobe-engine/v0.1.0-dev",
+	}
+	ctx := context.Background()
+	result, err := Query(ctx, config)
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if result != nil {
+		t.Fatal("expected nil result here")
 	}
 }


### PR DESCRIPTION
Make sure the code style and structure is consistent among all the
orchestra building blocks by always returning a pointer.