### PR TITLE
orchestra: implement metadata validation

### DIFF
--- a/internal/orchestra/metadata/metadata.go
+++ b/internal/orchestra/metadata/metadata.go
@@ -17,3 +17,37 @@ type Metadata struct {
 	SoftwareVersion    string   `json:"software_version"`
 	SupportedTests     []string `json:"supported_tests"`
 }
+
+// Valid returns true if metadata is valid, false otherwise. Metadata is
+// considered valid if all the mandatory fields are not empty. If a field
+// is marked `json:",omitempty"` in the structure definition, then it's
+// for sure mandatory. The "device_token" field is mandatory only if the
+// platform is "ios" or "android", because there's currently no device
+// token that we know of for desktop devices.
+func (m *Metadata) Valid() bool {
+	if m.ProbeCC == "" {
+		return false
+	}
+	if m.ProbeASN == "" {
+		return false
+	}
+	if m.Platform == "" {
+		return false
+	}
+	if m.SoftwareName == "" {
+		return false
+	}
+	if m.SoftwareVersion == "" {
+		return false
+	}
+	if len(m.SupportedTests) < 1 {
+		return false
+	}
+	switch m.Platform {
+	case "ios", "android":
+		if m.DeviceToken == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/orchestra/metadata/metadata_test.go
+++ b/internal/orchestra/metadata/metadata_test.go
@@ -1,0 +1,108 @@
+package metadata
+
+import "testing"
+
+func TestUnitValid(t *testing.T) {
+	t.Run("fail on probe_cc", func(t *testing.T) {
+		var m Metadata
+		if m.Valid() != false {
+			t.Fatal("expected false here")
+		}
+	})
+	t.Run("fail on probe_asn", func(t *testing.T) {
+		m := Metadata{
+			ProbeCC: "IT",
+		}
+		if m.Valid() != false {
+			t.Fatal("expected false here")
+		}
+	})
+	t.Run("fail on platform", func(t *testing.T) {
+		m := Metadata{
+			ProbeCC:  "IT",
+			ProbeASN: "AS1234",
+		}
+		if m.Valid() != false {
+			t.Fatal("expected false here")
+		}
+	})
+	t.Run("fail on software_name", func(t *testing.T) {
+		m := Metadata{
+			ProbeCC:  "IT",
+			ProbeASN: "AS1234",
+			Platform: "linux",
+		}
+		if m.Valid() != false {
+			t.Fatal("expected false here")
+		}
+	})
+	t.Run("fail on software_version", func(t *testing.T) {
+		m := Metadata{
+			ProbeCC:      "IT",
+			ProbeASN:     "AS1234",
+			Platform:     "linux",
+			SoftwareName: "miniooni",
+		}
+		if m.Valid() != false {
+			t.Fatal("expected false here")
+		}
+	})
+	t.Run("fail on supported_tests", func(t *testing.T) {
+		m := Metadata{
+			ProbeCC:         "IT",
+			ProbeASN:        "AS1234",
+			Platform:        "linux",
+			SoftwareName:    "miniooni",
+			SoftwareVersion: "0.1.0-dev",
+		}
+		if m.Valid() != false {
+			t.Fatal("expected false here")
+		}
+	})
+	t.Run("fail on missing device_token", func(t *testing.T) {
+		m := Metadata{
+			ProbeCC:         "IT",
+			ProbeASN:        "AS1234",
+			Platform:        "ios",
+			SoftwareName:    "miniooni",
+			SoftwareVersion: "0.1.0-dev",
+			SupportedTests: []string{
+				"web_connectivity",
+			},
+		}
+		if m.Valid() != false {
+			t.Fatal("expected false here")
+		}
+	})
+	t.Run("success for desktop", func(t *testing.T) {
+		m := Metadata{
+			ProbeCC:         "IT",
+			ProbeASN:        "AS1234",
+			Platform:        "linux",
+			SoftwareName:    "miniooni",
+			SoftwareVersion: "0.1.0-dev",
+			SupportedTests: []string{
+				"web_connectivity",
+			},
+		}
+		if m.Valid() != true {
+			t.Fatal("expected true here")
+		}
+	})
+	t.Run("success for mobile", func(t *testing.T) {
+		m := Metadata{
+			DeviceToken:     "xx-xxx-xx-xxxx",
+			ProbeCC:         "IT",
+			ProbeASN:        "AS1234",
+			Platform:        "android",
+			SoftwareName:    "miniooni",
+			SoftwareVersion: "0.1.0-dev",
+			SupportedTests: []string{
+				"web_connectivity",
+			},
+		}
+		if m.Valid() != true {
+			t.Fatal("expected true here")
+		}
+	})
+}


### PR DESCRIPTION
Follows closely the algorithm implemented by MK:

https://github.com/measurement-kit/measurement-kit/blob/ba98a20731a747ffb32e19991824c56a32f763a2/src/libmeasurement_kit/ooni/orchestrate_impl.hpp#L100

This is part of #148 