### PR TITLE
telegram/test: fix flaky test due to missing status code

### DIFF
--- a/experiment/telegram/telegram_otherwise_test.go
+++ b/experiment/telegram/telegram_otherwise_test.go
@@ -151,7 +151,8 @@ func TestUnitProcessallWithMixedResults(t *testing.T) {
 		"https://web.telegram.org/": &urlMeasurements{
 			method: "GET",
 			results: &porcelain.HTTPDoResults{
-				Error: nil,
+				Error:      nil,
+				StatusCode: 200,
 			},
 		},
 	})


### PR DESCRIPTION
This should close #142. Because maps have no stable sorting in Go, we
sometimes pick the success case first. However, such case is incomplete
because it does not set the status code as 200. Therefore, we see an
error telling us that the server returned a bad status code. Initialising
the variable to 200 should be enough to fix the bug.