### PR TITLE
psiphon: fetch and use config from OONI orchestra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-asn.mmdb
-ca-bundle.pem
-country.mmdb
-miniooni
-report.jsonl
+/asn.mmdb
+/ca-bundle.pem
+/country.mmdb
+/miniooni
+/oonipsiphon/
+/report.jsonl

--- a/experiment.go
+++ b/experiment.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"path/filepath"
 	"reflect"
 	"time"
 
@@ -348,9 +347,6 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				return psiphon.NewExperiment(session.session, *config.(*psiphon.Config))
 			},
 			config: &psiphon.Config{
-				ConfigFilePath: filepath.Join(
-					session.session.AssetsDir, "psiphon_config.json",
-				),
 				WorkDir: session.session.TempDir,
 			},
 			needsInput: false,

--- a/experiment/example/example.go
+++ b/experiment/example/example.go
@@ -50,7 +50,7 @@ func measure(
 	testkeys := &TestKeys{Success: err == nil}
 	measurement.TestKeys = testkeys
 	time.Sleep(time.Duration(config.SleepTime))
-	callbacks.OnProgress(100, config.Message)
+	callbacks.OnProgress(1.0, config.Message)
 	callbacks.OnDataUsage(0, 0)
 	return err
 }

--- a/experiment/psiphon/common.go
+++ b/experiment/psiphon/common.go
@@ -9,9 +9,6 @@ const (
 
 // Config contains the experiment's configuration.
 type Config struct {
-	// ConfigFilePath is the path where Psiphon config file is located.
-	ConfigFilePath string `ooni:"configuration file path"`
-
 	// WorkDir is the directory where Psiphon should store
 	// its configuration database.
 	WorkDir string `ooni:"experiment working directory"`


### PR DESCRIPTION
Closes #167

While there also fix the output of the example experiment and make sure session/session.go has 100% coverage of its statements, which were both very easy changes.