### PR TITLE
Join urlpaths without using filepath.Join

### DIFF
--- a/internal/orchestra/testlists/psiphon/psiphon.go
+++ b/internal/orchestra/testlists/psiphon/psiphon.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path/filepath"
 
 	"github.com/ooni/probe-engine/httpx/fetch"
 	"github.com/ooni/probe-engine/internal/orchestra/login"
+	"github.com/ooni/probe-engine/internal/urlpath"
 	"github.com/ooni/probe-engine/log"
 )
 
@@ -32,7 +32,7 @@ func Query(ctx context.Context, config Config) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	url.Path = filepath.Join(url.Path, "/api/v1/test-list/psiphon-config")
+	url.Path = urlpath.Append(url.Path, "/api/v1/test-list/psiphon-config")
 	authorization := fmt.Sprintf("Bearer %s", config.Auth.Token)
 	return (&fetch.Client{
 		Authorization: authorization,

--- a/internal/urlpath/urlpath.go
+++ b/internal/urlpath/urlpath.go
@@ -1,0 +1,17 @@
+// Package urlpath contains code to manipulate URL paths
+package urlpath
+
+import "strings"
+
+// Append appends extPath to basePath. It will properly deal
+// with `/` being or being not present respectively at the end
+// of basePath and at the beginning of extPath.
+func Append(basePath, extPath string) string {
+	if strings.HasSuffix(basePath, "/") {
+		basePath = basePath[:len(basePath)-1]
+	}
+	if !strings.HasPrefix(extPath, "/") {
+		extPath = "/" + extPath
+	}
+	return basePath + extPath
+}

--- a/internal/urlpath/urlpath_test.go
+++ b/internal/urlpath/urlpath_test.go
@@ -1,0 +1,18 @@
+package urlpath
+
+import "testing"
+
+func TestAppend(t *testing.T) {
+	if Append("/foo", "bar/baz") != "/foo/bar/baz" {
+		t.Fatal("unexpected result")
+	}
+	if Append("/foo", "/bar/baz") != "/foo/bar/baz" {
+		t.Fatal("unexpected result")
+	}
+	if Append("/foo/", "bar/baz") != "/foo/bar/baz" {
+		t.Fatal("unexpected result")
+	}
+	if Append("/foo/", "/bar/baz") != "/foo/bar/baz" {
+		t.Fatal("unexpected result")
+	}
+}


### PR DESCRIPTION
Using filepath.Join leads to wrong results on Windows where the
`\` path separator is used instead of `/`.

There was only one place where we were joining paths AFAICT but
it seems better to have a simple function for that anyway.

Closes #192.