### PR TITLE
testlists/urls: use int64 for limit

### DIFF
--- a/internal/orchestra/testlists/urls/urls.go
+++ b/internal/orchestra/testlists/urls/urls.go
@@ -19,7 +19,7 @@ type Config struct {
 	CountryCode       string
 	EnabledCategories []string
 	HTTPClient        *http.Client
-	Limit             int
+	Limit             int64
 	Logger            log.Logger
 	UserAgent         string
 }

--- a/testlists.go
+++ b/testlists.go
@@ -12,7 +12,7 @@ import (
 type TestListsURLsConfig struct {
 	BaseURL    string   // URL to use (empty means default)
 	Categories []string // Categories to query for (empty means all)
-	Limit      int      // Max number of URLs (<= 0 means no limit)
+	Limit      int64    // Max number of URLs (<= 0 means no limit)
 }
 
 // AddCategory adds a category to the list of categories to query. Not


### PR DESCRIPTION
Closes #191. Necessary to export predictable mobile API.