### PR TITLE
oonidatamodel: always take oonitemplates.Results as input

### DIFF
--- a/experiment/psiphon/psiphon.go
+++ b/experiment/psiphon/psiphon.go
@@ -133,7 +133,7 @@ func (r *runner) usetunnel(
 		r.testkeys.Queries, oonidatamodel.NewDNSQueriesList(results.TestKeys)...,
 	)
 	r.testkeys.Requests = append(
-		r.testkeys.Requests, oonidatamodel.NewRequestList(results)...,
+		r.testkeys.Requests, oonidatamodel.NewRequestList(results.TestKeys)...,
 	)
 	// TODO(bassosimone): understand if there is a way to ask
 	// the tunnel the number of bytes sent and/or received

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -72,7 +72,7 @@ func (tk *TestKeys) processone(v *urlMeasurements) error {
 		tk.Queries, oonidatamodel.NewDNSQueriesList(r.TestKeys)...,
 	)
 	tk.Requests = append(
-		tk.Requests, oonidatamodel.NewRequestList(r)...,
+		tk.Requests, oonidatamodel.NewRequestList(r.TestKeys)...,
 	)
 	tk.TCPConnect = append(
 		tk.TCPConnect,

--- a/internal/oonidatamodel/oonidatamodel.go
+++ b/internal/oonidatamodel/oonidatamodel.go
@@ -179,12 +179,9 @@ func addheaders(
 }
 
 // NewRequestList returns the list for "requests"
-func NewRequestList(httpresults *oonitemplates.HTTPDoResults) RequestList {
+func NewRequestList(results oonitemplates.Results) RequestList {
 	var out RequestList
-	if httpresults == nil {
-		return out
-	}
-	in := httpresults.TestKeys.HTTPRequests
+	in := results.HTTPRequests
 	// OONI's data format wants more recent request first
 	for idx := len(in) - 1; idx >= 0; idx-- {
 		var entry RequestEntry

--- a/internal/oonidatamodel/oonidatamodel_test.go
+++ b/internal/oonidatamodel/oonidatamodel_test.go
@@ -110,57 +110,48 @@ func TestUnitNewTCPConnectListInvalidInput(t *testing.T) {
 	}
 }
 
-func TestUnitNewRequestsListNil(t *testing.T) {
-	out := NewRequestList(nil)
-	if len(out) != 0 {
-		t.Fatal("unexpected output length")
-	}
-}
-
 func TestUnitNewRequestsListEmptyList(t *testing.T) {
-	out := NewRequestList(&oonitemplates.HTTPDoResults{})
+	out := NewRequestList(oonitemplates.Results{})
 	if len(out) != 0 {
 		t.Fatal("unexpected output length")
 	}
 }
 
 func TestUnitNewRequestsListGood(t *testing.T) {
-	out := NewRequestList(&oonitemplates.HTTPDoResults{
-		TestKeys: oonitemplates.Results{
-			HTTPRequests: []*modelx.HTTPRoundTripDoneEvent{
-				// need two requests to test that order is inverted
-				&modelx.HTTPRoundTripDoneEvent{
-					RequestBodySnap: []byte("abcdefx"),
-					RequestHeaders: http.Header{
-						"Content-Type": []string{
-							"text/plain",
-							"foobar",
-						},
-						"Content-Length": []string{
-							"17",
-						},
+	out := NewRequestList(oonitemplates.Results{
+		HTTPRequests: []*modelx.HTTPRoundTripDoneEvent{
+			// need two requests to test that order is inverted
+			&modelx.HTTPRoundTripDoneEvent{
+				RequestBodySnap: []byte("abcdefx"),
+				RequestHeaders: http.Header{
+					"Content-Type": []string{
+						"text/plain",
+						"foobar",
 					},
-					RequestMethod:    "GET",
-					RequestURL:       "http://x.org/",
-					ResponseBodySnap: []byte("abcdef"),
-					ResponseHeaders: http.Header{
-						"Content-Type": []string{
-							"application/json",
-							"foobaz",
-						},
-						"Server": []string{
-							"antani",
-						},
-						"Content-Length": []string{
-							"14",
-						},
+					"Content-Length": []string{
+						"17",
 					},
-					ResponseStatusCode: 451,
-					MaxBodySnapSize:    10,
 				},
-				&modelx.HTTPRoundTripDoneEvent{
-					Error: errors.New("antani"),
+				RequestMethod:    "GET",
+				RequestURL:       "http://x.org/",
+				ResponseBodySnap: []byte("abcdef"),
+				ResponseHeaders: http.Header{
+					"Content-Type": []string{
+						"application/json",
+						"foobaz",
+					},
+					"Server": []string{
+						"antani",
+					},
+					"Content-Length": []string{
+						"14",
+					},
 				},
+				ResponseStatusCode: 451,
+				MaxBodySnapSize:    10,
+			},
+			&modelx.HTTPRoundTripDoneEvent{
+				Error: errors.New("antani"),
 			},
 		},
 	})
@@ -332,14 +323,12 @@ func TestUnitNewRequestsListGood(t *testing.T) {
 }
 
 func TestUnitNewRequestsSnaps(t *testing.T) {
-	out := NewRequestList(&oonitemplates.HTTPDoResults{
-		TestKeys: oonitemplates.Results{
-			HTTPRequests: []*modelx.HTTPRoundTripDoneEvent{
-				&modelx.HTTPRoundTripDoneEvent{
-					RequestBodySnap:  []byte("abcd"),
-					MaxBodySnapSize:  4,
-					ResponseBodySnap: []byte("defg"),
-				},
+	out := NewRequestList(oonitemplates.Results{
+		HTTPRequests: []*modelx.HTTPRoundTripDoneEvent{
+			&modelx.HTTPRoundTripDoneEvent{
+				RequestBodySnap:  []byte("abcd"),
+				MaxBodySnapSize:  4,
+				ResponseBodySnap: []byte("defg"),
 			},
 		},
 	})


### PR DESCRIPTION
This way we pass the same argument type to all functions, which
is convenient when we have HTTP requests that are not caused by us
calling HTTPDo, e.g., when using DoH.

This is yak shaving for making #2 possible.