### PR TITLE
netxlogger: don't print response headers on error

### DIFF
--- a/internal/netxlogger/netxlogger.go
+++ b/internal/netxlogger/netxlogger.go
@@ -136,7 +136,7 @@ func (h *Handler) OnMeasurement(m modelx.Measurement) {
 			m.HTTPResponseStart.TransactionID,
 		)
 	}
-	if m.HTTPRoundTripDone != nil {
+	if m.HTTPRoundTripDone != nil && m.HTTPRoundTripDone.Error == nil {
 		h.logger.Debugf(
 			"[httpTxID: %d] < %s %d %s",
 			m.HTTPRoundTripDone.TransactionID,


### PR DESCRIPTION
When there's an error, HTTPRoundTripDone is emitted but we should
not attempt printing headers because it doesn't make sense.

This fix has been developed while working on #2.