### PR TITLE
oonitemplates.go: allow skipping TLS verification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/marusama/semaphore v0.0.0-20190110074507-6952cef993b2 // indirect
 	github.com/montanaflynn/stats v0.5.0
 	github.com/neubot/dash v0.4.1
-	github.com/ooni/netx v0.0.0-20200108142619-570799475703
+	github.com/ooni/netx v0.0.0-20200109143038-9c81a8088bb3
 	github.com/oschwald/geoip2-golang v1.3.0
 	github.com/oschwald/maxminddb-golang v1.5.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
@@ -58,4 +58,5 @@ require (
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.1-0.20180122172545-ddea229ff1df // indirect
 	go.uber.org/zap v1.10.0 // indirect
+	golang.org/x/crypto v0.0.0-20200108215511-5d647ca15757 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/ooni/netx v0.0.0-20200108142619-570799475703 h1:39Q2UKIYNzcVMmKC/5u65eZ+z4anfieOGz0JZXItsvA=
-github.com/ooni/netx v0.0.0-20200108142619-570799475703/go.mod h1:vTJ7nYH2j51lX8yvhdLaHscvwz1GvWoiB26jYKEmqyA=
+github.com/ooni/netx v0.0.0-20200109143038-9c81a8088bb3 h1:JG+to6NZin0RKty9ykNqLruph8rzfoxZvmfaVGY5GuY=
+github.com/ooni/netx v0.0.0-20200109143038-9c81a8088bb3/go.mod h1:vTJ7nYH2j51lX8yvhdLaHscvwz1GvWoiB26jYKEmqyA=
 github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c/go.mod h1:t+O9It+LKzfOAhKTT5O0ehDix+MTqbtT0T9t+7zzOvc=
 github.com/openconfig/reference v0.0.0-20190727015836-8dfd928c9696/go.mod h1:ym2A+zigScwkSEb/cVQB0/ZMpU3rqiH6X7WRRsxgOGw=
 github.com/oschwald/geoip2-golang v1.3.0 h1:D+Hsdos1NARPbzZ2aInUHZL+dApIzo8E0ErJVsWcku8=
@@ -293,6 +293,8 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 h1:sKJQZMuxjOAR/Uo2LBfU90onWEf1dF4C+0hPJCc9Mpc=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200108215511-5d647ca15757 h1:pJ9H8lzdBh301qPX4VpwJ8TRpLt1IhNK1PxVOICyP54=
+golang.org/x/crypto v0.0.0-20200108215511-5d647ca15757/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/oonitemplates/oonitemplates.go
+++ b/internal/oonitemplates/oonitemplates.go
@@ -219,16 +219,17 @@ func DNSLookup(
 
 // HTTPDoConfig contains HTTPDo settings.
 type HTTPDoConfig struct {
-	Accept           string
-	AcceptLanguage   string
-	Body             []byte
-	DNSServerAddress string
-	DNSServerNetwork string
-	Handler          modelx.Handler
-	Method           string
-	ProxyFunc        func(*http.Request) (*url.URL, error)
-	URL              string
-	UserAgent        string
+	Accept             string
+	AcceptLanguage     string
+	Body               []byte
+	DNSServerAddress   string
+	DNSServerNetwork   string
+	Handler            modelx.Handler
+	InsecureSkipVerify bool
+	Method             string
+	ProxyFunc          func(*http.Request) (*url.URL, error)
+	URL                string
+	UserAgent          string
 
 	// MaxEventsBodySnapSize controls the snap size that
 	// we're using for bodies returned as modelx.Measurement.
@@ -282,6 +283,9 @@ func HTTPDo(
 		return results
 	}
 	client.SetResolver(resolver)
+	if config.InsecureSkipVerify {
+		client.ForceSkipVerify()
+	}
 	// TODO(bassosimone): implement sending body
 	req, err := http.NewRequest(config.Method, config.URL, nil)
 	if err != nil {
@@ -329,11 +333,12 @@ func HTTPDo(
 
 // TLSConnectConfig contains TLSConnect settings.
 type TLSConnectConfig struct {
-	Address          string
-	DNSServerAddress string
-	DNSServerNetwork string
-	Handler          modelx.Handler
-	SNI              string
+	Address            string
+	DNSServerAddress   string
+	DNSServerNetwork   string
+	Handler            modelx.Handler
+	InsecureSkipVerify bool
+	SNI                string
 }
 
 // TLSConnectResults contains the results of a TLSConnect
@@ -370,6 +375,9 @@ func TLSConnect(
 		return results
 	}
 	dialer.SetResolver(resolver)
+	if config.InsecureSkipVerify {
+		dialer.ForceSkipVerify()
+	}
 	// TODO(bassosimone): can this call really fail?
 	dialer.ForceSpecificSNI(config.SNI)
 	results.TestKeys.collect(channel, config.Handler, func() {

--- a/internal/oonitemplates/oonitemplates_test.go
+++ b/internal/oonitemplates/oonitemplates_test.go
@@ -110,6 +110,17 @@ func TestIntegrationHTTPDoUnknownDNS(t *testing.T) {
 	}
 }
 
+func TestIntegrationHTTPDoForceSkipVerify(t *testing.T) {
+	ctx := context.Background()
+	results := HTTPDo(ctx, HTTPDoConfig{
+		URL:                "https://self-signed.badssl.com/",
+		InsecureSkipVerify: true,
+	})
+	if results.Error != nil {
+		t.Fatal(results.Error)
+	}
+}
+
 func TestIntegrationHTTPDoRoundTripError(t *testing.T) {
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{
@@ -182,6 +193,17 @@ func TestIntegrationTLSConnectUnknownDNS(t *testing.T) {
 	})
 	if !strings.HasSuffix(results.Error.Error(), "unsupported network value") {
 		t.Fatal("not the error that we expected")
+	}
+}
+
+func TestIntegrationTLSConnectForceSkipVerify(t *testing.T) {
+	ctx := context.Background()
+	results := TLSConnect(ctx, TLSConnectConfig{
+		Address:            "self-signed.badssl.com:443",
+		InsecureSkipVerify: true,
+	})
+	if results.Error != nil {
+		t.Fatal(results.Error)
 	}
 }
 


### PR DESCRIPTION
We're going to need this in #2 to connect to Tor's or_port.