### PR TITLE
Forward zero start time to experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode
 /asn.mmdb
 /ca-bundle.pem
 /country.mmdb

--- a/experiment/experiment.go
+++ b/experiment/experiment.go
@@ -114,22 +114,24 @@ func (e *Experiment) ReportID() string {
 }
 
 func (e *Experiment) newMeasurement(input string) model.Measurement {
+	utctimenow := time.Now().UTC()
 	return model.Measurement{
-		DataFormatVersion:    collector.DefaultDataFormatVersion,
-		Input:                input,
-		MeasurementStartTime: formatTimeNowUTC(),
-		ProbeIP:              e.Session.ProbeIP(),
-		ProbeASN:             e.Session.ProbeASNString(),
-		ProbeCC:              e.Session.ProbeCC(),
-		ReportID:             e.ReportID(),
-		ResolverASN:          e.Session.ResolverASNString(),
-		ResolverIP:           e.Session.ResolverIP(),
-		ResolverNetworkName:  e.Session.ResolverNetworkName(),
-		SoftwareName:         e.Session.SoftwareName,
-		SoftwareVersion:      e.Session.SoftwareVersion,
-		TestName:             e.TestName,
-		TestStartTime:        e.TestStartTime,
-		TestVersion:          e.TestVersion,
+		DataFormatVersion:         collector.DefaultDataFormatVersion,
+		Input:                     input,
+		MeasurementStartTime:      utctimenow.Format(dateFormat),
+		MeasurementStartTimeSaved: utctimenow,
+		ProbeIP:                   e.Session.ProbeIP(),
+		ProbeASN:                  e.Session.ProbeASNString(),
+		ProbeCC:                   e.Session.ProbeCC(),
+		ReportID:                  e.ReportID(),
+		ResolverASN:               e.Session.ResolverASNString(),
+		ResolverIP:                e.Session.ResolverIP(),
+		ResolverNetworkName:       e.Session.ResolverNetworkName(),
+		SoftwareName:              e.Session.SoftwareName,
+		SoftwareVersion:           e.Session.SoftwareVersion,
+		TestName:                  e.TestName,
+		TestStartTime:             e.TestStartTime,
+		TestVersion:               e.TestVersion,
 	}
 }
 

--- a/experiment/psiphon/psiphon_test.go
+++ b/experiment/psiphon/psiphon_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-engine/experiment/handler"
@@ -53,7 +54,7 @@ func TestUnitMeasureWithCancelledContext(t *testing.T) {
 }
 
 func TestUnitMakeWorkingDirEmptyWorkingDir(t *testing.T) {
-	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log))
+	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log), time.Now())
 	r.config.WorkDir = ""
 	workdir, err := r.makeworkingdir()
 	if err == nil {
@@ -65,7 +66,7 @@ func TestUnitMakeWorkingDirEmptyWorkingDir(t *testing.T) {
 }
 
 func TestUnitMakeWorkingDirOsRemoveAllError(t *testing.T) {
-	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log))
+	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log), time.Now())
 	expected := errors.New("mocked error")
 	r.osRemoveAll = func(path string) error {
 		return expected
@@ -80,7 +81,7 @@ func TestUnitMakeWorkingDirOsRemoveAllError(t *testing.T) {
 }
 
 func TestUnitMakeWorkingDirOsMkdirAllError(t *testing.T) {
-	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log))
+	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log), time.Now())
 	expected := errors.New("mocked error")
 	r.osMkdirAll = func(path string, perm os.FileMode) error {
 		return expected
@@ -95,7 +96,7 @@ func TestUnitMakeWorkingDirOsMkdirAllError(t *testing.T) {
 }
 
 func TestUnitRunFetchPsiphonConfigError(t *testing.T) {
-	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log))
+	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log), time.Now())
 	expected := errors.New("mocked error")
 	err := r.run(context.Background(), log.Log, func(context.Context) ([]byte, error) {
 		return nil, expected
@@ -106,7 +107,7 @@ func TestUnitRunFetchPsiphonConfigError(t *testing.T) {
 }
 
 func TestUnitRunMakeworkingdirError(t *testing.T) {
-	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log))
+	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log), time.Now())
 	expected := errors.New("mocked error")
 	r.osRemoveAll = func(path string) error {
 		return expected
@@ -122,7 +123,7 @@ func TestUnitRunMakeworkingdirError(t *testing.T) {
 }
 
 func TestUnitRunStartTunnelError(t *testing.T) {
-	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log))
+	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log), time.Now())
 	err := r.run(context.Background(), log.Log, func(context.Context) ([]byte, error) {
 		return []byte("{"), nil
 	})
@@ -164,7 +165,7 @@ func TestIntegration(t *testing.T) {
 }
 
 func TestUnitUsetunnel(t *testing.T) {
-	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log))
+	r := newRunner(makeconfig(), handler.NewPrinterCallbacks(log.Log), time.Now())
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // so should fail immediately
 	err := r.usetunnel(ctx, 8080, log.Log)

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -187,6 +187,7 @@ func (m *measurer) measure(
 			entry.results = oonitemplates.HTTPDo(ctx, oonitemplates.HTTPDoConfig{
 				Accept:         httpheader.RandomAccept(),
 				AcceptLanguage: httpheader.RandomAcceptLanguage(),
+				Beginning:      measurement.MeasurementStartTimeSaved,
 				Handler:        netxlogger.NewHandler(sess.Logger),
 				Method:         entry.method,
 				URL:            key,

--- a/model/model.go
+++ b/model/model.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 )
 
 // Measurement is a OONI measurement.
@@ -31,6 +32,11 @@ type Measurement struct {
 
 	// MeasurementStartTime is the time when the measurement started
 	MeasurementStartTime string `json:"measurement_start_time"`
+
+	// MeasurementStartTimeSaved is the moment in time when we
+	// started the measurement. This is not included into the JSON
+	// and is only used within probe-engine as a "zero" time.
+	MeasurementStartTimeSaved time.Time `json:"-"`
 
 	// MeasurementRuntime contains the measurement runtime. The JSON name
 	// is test_runtime because this is the name expected by the OONI backend


### PR DESCRIPTION
This is also functional to #12. This follows up from #218. 

While there, also ignore the `.vscode` folder.