### PR TITLE
oonitemplates.go: sanitise conn_id

### DIFF
--- a/internal/oonitemplates/oonitemplates.go
+++ b/internal/oonitemplates/oonitemplates.go
@@ -71,8 +71,45 @@ type Results struct {
 	ReceivedBytes int64
 }
 
+type connmapper struct {
+	counter int64
+	mu      sync.Mutex
+	once    sync.Once
+	table   map[int64]int64
+}
+
+// scramble maps a ConnID to a different number to avoid emitting
+// the port numbers. We preserve the sign because it's used to
+// distinguish between TCP (positive) and UDP (negative). A special
+// case is zero, which is always mapped to zero, since the zero
+// port means "unspecified" in netx code.
+func (m *connmapper) scramble(cid int64) int64 {
+	m.once.Do(func() {
+		m.table = make(map[int64]int64)
+		m.table[0] = 0 // means unspecified in netx
+	})
+	// See https://stackoverflow.com/a/38140573/4354461
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if value, found := m.table[cid]; found == true {
+		return value
+	}
+	var factor int64 = 1
+	if cid < 0 {
+		factor = -1
+	}
+	m.counter++ // we must never emit zero
+	value := factor * m.counter
+	m.table[cid] = value
+	return value
+}
+
+// cm is the global connmapper
+var cm connmapper
+
 func (r *Results) onMeasurement(m modelx.Measurement, lowLevel bool) {
 	if m.Connect != nil {
+		m.Connect.ConnID = cm.scramble(m.Connect.ConnID)
 		r.Connects = append(r.Connects, m.Connect)
 		if lowLevel {
 			r.NetworkEvents = append(r.NetworkEvents, &m)
@@ -85,15 +122,18 @@ func (r *Results) onMeasurement(m modelx.Measurement, lowLevel bool) {
 		r.Resolves = append(r.Resolves, m.ResolveDone)
 	}
 	if m.TLSHandshakeDone != nil {
+		m.TLSHandshakeDone.ConnID = cm.scramble(m.TLSHandshakeDone.ConnID)
 		r.TLSHandshakes = append(r.TLSHandshakes, m.TLSHandshakeDone)
 	}
 	if m.Read != nil {
+		m.Read.ConnID = cm.scramble(m.Read.ConnID)
 		r.ReceivedBytes += m.Read.NumBytes // overflow unlikely
 		if lowLevel {
 			r.NetworkEvents = append(r.NetworkEvents, &m)
 		}
 	}
 	if m.Write != nil {
+		m.Write.ConnID = cm.scramble(m.Write.ConnID)
 		r.SentBytes += m.Write.NumBytes // overflow unlikely
 		if lowLevel {
 			r.NetworkEvents = append(r.NetworkEvents, &m)

--- a/internal/oonitemplates/oonitemplates_test.go
+++ b/internal/oonitemplates/oonitemplates_test.go
@@ -450,3 +450,22 @@ func (txp *faketransport) ClientFactory(stateDir string) (obfs4base.ClientFactor
 func (txp *faketransport) ServerFactory(stateDir string, args *goptlib.Args) (obfs4base.ServerFactory, error) {
 	return txp.ServerFactory(stateDir, args)
 }
+
+func TestUnitConnmapper(t *testing.T) {
+	var mapper connmapper
+	if mapper.scramble(-1) >= 0 {
+		t.Fatal("unexpected value for negative input")
+	}
+	if mapper.scramble(1234) != 2 {
+		t.Fatal("unexpected first value")
+	}
+	if mapper.scramble(12) != 3 {
+		t.Fatal("unexpected second value")
+	}
+	if mapper.scramble(12) != mapper.scramble(12) {
+		t.Fatal("not idempotent")
+	}
+	if mapper.scramble(0) != 0 {
+		t.Fatal("unexpected value for zero input")
+	}
+}

--- a/internal/oonitemplates/oonitemplates_test.go
+++ b/internal/oonitemplates/oonitemplates_test.go
@@ -457,10 +457,10 @@ func TestUnitConnmapper(t *testing.T) {
 		t.Fatal("unexpected value for negative input")
 	}
 	if mapper.scramble(1234) != 2 {
-		t.Fatal("unexpected first value")
+		t.Fatal("unexpected second value")
 	}
 	if mapper.scramble(12) != 3 {
-		t.Fatal("unexpected second value")
+		t.Fatal("unexpected third value")
 	}
 	if mapper.scramble(12) != mapper.scramble(12) {
 		t.Fatal("not idempotent")


### PR DESCRIPTION
We use port numbers in netx because this is a way to make sure
that we can bind together HTTP and net traces.

We use the sign to indicate TCP or UDP.

There may be value in not scrambling the ports inside netx (I am
not sure TBH), but surely it's better to avoid doing that here.

This is also part of #12.