### PR TITLE
dependencies: update bolt and goselect because of other arch support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.torproject.org/pluggable-transports/goptlib.git v1.1.0
 	github.com/AndreasBriese/bbloom v0.0.0-20170702084017-28f7e881ca57 // indirect
 	github.com/Psiphon-Inc/rotate-safe-writer v0.0.0-20170228160301-b276127301a9 // indirect
-	github.com/Psiphon-Labs/bolt v0.0.0-20190731171712-94750aa2185e // indirect
+	github.com/Psiphon-Labs/bolt v0.0.0-20200203172706-f3d58e369264 // indirect
 	github.com/Psiphon-Labs/dns v0.0.0-20170814182607-d23cdaf67bbc // indirect
 	github.com/Psiphon-Labs/goarista v0.0.0-20160825065156-d002785f4c67 // indirect
 	github.com/Psiphon-Labs/goptlib v0.0.0-20180426172440-18963be5f9c5 // indirect
@@ -22,7 +22,7 @@ require (
 	github.com/bifurcation/mint v0.0.0-20180306135233-198357931e61 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/cognusion/go-cache-lru v0.0.0-20170419142635-f73e2280ecea // indirect
-	github.com/creack/goselect v0.0.0-20160714172859-1bd5ca702c61 // indirect
+	github.com/creack/goselect v0.1.1 // indirect
 	github.com/deckarep/golang-set v0.0.0-20171013212420-1d4478f51bed // indirect
 	github.com/dgraph-io/badger v1.5.4-0.20180815194500-3a87f6d9c273 // indirect
 	github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/Psiphon-Inc/rotate-safe-writer v0.0.0-20170228160301-b276127301a9 h1:
 github.com/Psiphon-Inc/rotate-safe-writer v0.0.0-20170228160301-b276127301a9/go.mod h1:ZdY5pBfat/WVzw3eXbIf7N1nZN0XD5H5+X8ZMDWbCs4=
 github.com/Psiphon-Labs/bolt v0.0.0-20190731171712-94750aa2185e h1:2zxppKeojJOuiO2aRjvVTD13hTPb+0RCia+TbGZX4Dg=
 github.com/Psiphon-Labs/bolt v0.0.0-20190731171712-94750aa2185e/go.mod h1:nYj8s6HxsjYV7vZjTiH3tMcVjj/x+R702DXT89PomgE=
+github.com/Psiphon-Labs/bolt v0.0.0-20200203172706-f3d58e369264 h1:HE/SqHaxiGrMq8u7/MZOVRmeFz1lkMazsXI4xA5ygGE=
+github.com/Psiphon-Labs/bolt v0.0.0-20200203172706-f3d58e369264/go.mod h1:JRYGUlpSqM4W5cdQu2oUVfNoAw1XJ79ibUQ+OHc1QiE=
 github.com/Psiphon-Labs/dns v0.0.0-20170814182607-d23cdaf67bbc h1:W+dNJivdYUujm+mhvmSDn3847jbzar8J7qzjj/w4U6I=
 github.com/Psiphon-Labs/dns v0.0.0-20170814182607-d23cdaf67bbc/go.mod h1:F1eU0RdWZXN2kn6A8cBRixr1HLyM1Va7xXp88LRhlps=
 github.com/Psiphon-Labs/goarista v0.0.0-20160825065156-d002785f4c67 h1:aQE2/masBGr/uqI63UIxN/IkRByNTxjYz2JYySw9ry8=
@@ -88,6 +90,8 @@ github.com/cognusion/go-cache-lru v0.0.0-20170419142635-f73e2280ecea h1:9C2rdYRp
 github.com/cognusion/go-cache-lru v0.0.0-20170419142635-f73e2280ecea/go.mod h1:MdyNkAe06D7xmJsf+MsLvbZKYNXuOHLKJrvw+x4LlcQ=
 github.com/creack/goselect v0.0.0-20160714172859-1bd5ca702c61 h1:T/S5GeXYV5O0wg3dbi+sxqvvSMAt2sOKodHjQkZUWNY=
 github.com/creack/goselect v0.0.0-20160714172859-1bd5ca702c61/go.mod h1:gHrIcH/9UZDn2qgeTUeW5K9eZsVYCH6/60J/FHysWyE=
+github.com/creack/goselect v0.1.1 h1:tiSSgKE1eJtxs1h/VgGQWuXUP0YS4CDIFMp6vaI1ls0=
+github.com/creack/goselect v0.1.1/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Psiphon-Inc/rotate-safe-writer v0.0.0-20170228160301-b276127301a9 h1:6IRS6D+hXUqTS/aPqYMRwj2pan6gGnEi1KuYREk5sMQ=
 github.com/Psiphon-Inc/rotate-safe-writer v0.0.0-20170228160301-b276127301a9/go.mod h1:ZdY5pBfat/WVzw3eXbIf7N1nZN0XD5H5+X8ZMDWbCs4=
-github.com/Psiphon-Labs/bolt v0.0.0-20190731171712-94750aa2185e h1:2zxppKeojJOuiO2aRjvVTD13hTPb+0RCia+TbGZX4Dg=
-github.com/Psiphon-Labs/bolt v0.0.0-20190731171712-94750aa2185e/go.mod h1:nYj8s6HxsjYV7vZjTiH3tMcVjj/x+R702DXT89PomgE=
 github.com/Psiphon-Labs/bolt v0.0.0-20200203172706-f3d58e369264 h1:HE/SqHaxiGrMq8u7/MZOVRmeFz1lkMazsXI4xA5ygGE=
 github.com/Psiphon-Labs/bolt v0.0.0-20200203172706-f3d58e369264/go.mod h1:JRYGUlpSqM4W5cdQu2oUVfNoAw1XJ79ibUQ+OHc1QiE=
 github.com/Psiphon-Labs/dns v0.0.0-20170814182607-d23cdaf67bbc h1:W+dNJivdYUujm+mhvmSDn3847jbzar8J7qzjj/w4U6I=
@@ -88,8 +86,6 @@ github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wX
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cognusion/go-cache-lru v0.0.0-20170419142635-f73e2280ecea h1:9C2rdYRp8Vzwhm3sbFX0yYfB+70zKFRjn7cnPCucHSw=
 github.com/cognusion/go-cache-lru v0.0.0-20170419142635-f73e2280ecea/go.mod h1:MdyNkAe06D7xmJsf+MsLvbZKYNXuOHLKJrvw+x4LlcQ=
-github.com/creack/goselect v0.0.0-20160714172859-1bd5ca702c61 h1:T/S5GeXYV5O0wg3dbi+sxqvvSMAt2sOKodHjQkZUWNY=
-github.com/creack/goselect v0.0.0-20160714172859-1bd5ca702c61/go.mod h1:gHrIcH/9UZDn2qgeTUeW5K9eZsVYCH6/60J/FHysWyE=
 github.com/creack/goselect v0.1.1 h1:tiSSgKE1eJtxs1h/VgGQWuXUP0YS4CDIFMp6vaI1ls0=
 github.com/creack/goselect v0.1.1/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
https://github.com/ooni/probe-engine/issues/320