### PR TITLE
oonitemplates: remove code causing crash on x86/arm64

### DIFF
--- a/internal/oonitemplates/oonitemplates_test.go
+++ b/internal/oonitemplates/oonitemplates_test.go
@@ -5,32 +5,13 @@ import (
 	"errors"
 	"net"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	goptlib "git.torproject.org/pluggable-transports/goptlib.git"
-	"github.com/ooni/netx/modelx"
 	"gitlab.com/yawning/obfs4.git/transports"
 	obfs4base "gitlab.com/yawning/obfs4.git/transports/base"
 )
-
-func TestUnitChannelHandlerWriteLateOnChannel(t *testing.T) {
-	handler := &channelHandler{
-		ch: make(chan modelx.Measurement),
-	}
-	var waitgroup sync.WaitGroup
-	waitgroup.Add(1)
-	go func() {
-		time.Sleep(1 * time.Second)
-		handler.OnMeasurement(modelx.Measurement{})
-		waitgroup.Done()
-	}()
-	waitgroup.Wait()
-	if handler.lateWrites != 1 {
-		t.Fatal("unexpected lateWrites value")
-	}
-}
 
 func TestIntegrationDNSLookupGood(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
The matter is better explained in the newly added code comment. I feel
okay removing the code, because that was a okay-lets-test-it piece of
code that was only useful for running such test.

A key takeaway from the investigation of this issue is that we really
want to simplify and streamline the way in which netx interacts with
the rest of the world, to avoid using channels where we can more easily
have (1) code that directly logs, if logging is the intent, and (2)
code that directly saves data, if that is the intent.

I will open an issue to document these changes more in depth. Here as
a general reflection, I'd just like to reiterate that if we were using
less complex/general channel based patterns, we would be reducing the
odds that we see some unexpected behaviour like in this case.

Another aspect is that we should have QA running everytime we do
generate a new Android build - see https://github.com/ooni/probe-engine/issues/358.

Closes https://github.com/ooni/probe-engine/issues/355