### PR TITLE
mkcgo: fail if we don't have the right MK version

### DIFF
--- a/.github/workflows/mk.yml
+++ b/.github/workflows/mk.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker run -v`pwd`:/mk -w/mk openobservatory/mk-alpine:latest /mk/.github/workflows/mk.sh
+      - run: docker run -v`pwd`:/mk -w/mk openobservatory/mk-alpine:20200225 /mk/.github/workflows/mk.sh

--- a/measurementkit/mkcgo/mkcgo.go
+++ b/measurementkit/mkcgo/mkcgo.go
@@ -4,7 +4,9 @@
 package mkcgo
 
 import (
+	// #include <measurement_kit/common/version.h>
 	// #include <measurement_kit/ffi.h>
+	//
 	// #include <stdlib.h>
 	//
 	// #cgo darwin,amd64 LDFLAGS: /usr/local/lib/libmeasurement_kit.a
@@ -43,6 +45,10 @@ import (
 	// #cgo linux,amd64,ooni LDFLAGS: /lib/libz.a
 	//
 	// #cgo linux,!ooni LDFLAGS: -lmeasurement_kit
+	//
+	// #if MK_VERSION_NUMERIC != 0x00000000010000101LL
+	// #error "Wrong measurement-kit version, please recompile measurement-kit"
+	// #endif
 	"C"
 	"errors"
 	"unsafe"


### PR DESCRIPTION
Closes https://github.com/ooni/probe-engine/issues/315