### PR TITLE
orchestra: register desktop clients with AS0 and ZZ

### DIFF
--- a/experiment/psiphon/psiphon_test.go
+++ b/experiment/psiphon/psiphon_test.go
@@ -48,7 +48,7 @@ func TestUnitMeasureWithCancelledContext(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
-	if !strings.HasSuffix(err.Error(), "All IP lookuppers failed") {
+	if !strings.HasSuffix(err.Error(), "context canceled") {
 		t.Fatal("not the error we expected")
 	}
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/apex/log"
@@ -118,22 +117,6 @@ func TestIntegrationNewOrchestraClient(t *testing.T) {
 	}
 	if clnt == nil {
 		t.Fatal("expected non nil client here")
-	}
-}
-
-func TestUnitNewOrchestraMaybeLookupLocationError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // so we fail immediately
-	sess := New(
-		log.Log, softwareName, softwareVersion, "../testdata", nil, nil,
-		"../../testdata/", kvstore.NewMemoryKeyValueStore(),
-	)
-	clnt, err := sess.NewOrchestraClient(ctx)
-	if !strings.HasSuffix(err.Error(), "All IP lookuppers failed") {
-		t.Fatal("not the error we expected")
-	}
-	if clnt != nil {
-		t.Fatal("expected nil client here")
 	}
 }
 


### PR DESCRIPTION
When registering, we don't need to lookup the country and the ASN. Desktop
clients only use orchestra to fetch targets for tor and psiphon. Also there
is no push notifications on desktop. Thus, it seems to me there is really
no point in doing an extra CC and ASN lookup in this code. We may need to add
a special case for mobile later, but this seems to me the best default.

This is part of the QA for https://github.com/ooni/probe/issues/1028.