### PR TITLE
sniblocking: classify failures to produce a result

### DIFF
--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -274,6 +274,8 @@ func (m *measurer) Run(
 	// TODO(bassosimone): if the user has configured DoT or DoH, here we
 	// probably want to perform the name resolution before the measurements
 	// or to make sure that the classify logic is robust to that.
+	//
+	// See https://github.com/ooni/probe-engine/issues/392.
 	maybeParsed, err := maybeURLToSNI(measurement.Input)
 	if err != nil {
 		return err

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -52,8 +52,8 @@ type Subresult struct {
 
 // TestKeys contains sniblocking test keys.
 type TestKeys struct {
-	Result  string    `json:"result"`
 	Control Subresult `json:"control"`
+	Result  string    `json:"result"`
 	Target  Subresult `json:"target"`
 }
 

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -271,6 +271,9 @@ func (m *measurer) Run(
 			m.config.ControlSNI, "443",
 		)
 	}
+	// TODO(bassosimone): if the user has configured DoT or DoH, here we
+	// probably want to perform the name resolution before the measurements
+	// or to make sure that the classify logic is robust to that.
 	maybeParsed, err := maybeURLToSNI(measurement.Input)
 	if err != nil {
 		return err

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	testName    = "sni_blocking"
-	testVersion = "0.0.3"
+	testVersion = "0.0.4"
 )
 
 // Config contains the experiment config.

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -68,9 +68,18 @@ const (
 )
 
 func (tk *TestKeys) classify() string {
+	// This implementation of classify is loosely modeled after
+	// https://github.com/ooni/spec/pull/159#discussion_r373754706
 	if tk.Target.Failure == nil {
 		return classAccessibleValidHostname
 	}
+	// TODO(bassosimone): we should write jafar tests to understand
+	// what error is returned in the case of MITM and make sure we
+	// can reliably detect and distinguish this case from other cases
+	// of TLS error. For now, the following is coded such that the
+	// MITM will result in classAnomalySSLErrror.
+	//
+	// See https://github.com/ooni/probe-engine/issues/393.
 	switch *tk.Target.Failure {
 	case modelx.FailureConnectionRefused:
 		return classAnomalyTestHelperBlocked

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -106,7 +106,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "sni_blocking" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.0.3" {
+	if measurer.ExperimentVersion() != "0.0.4" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -10,12 +10,96 @@ import (
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/internal/netxlogger"
 	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 const (
 	softwareName    = "ooniprobe-example"
 	softwareVersion = "0.0.1"
 )
+
+func TestUnitTestKeysClassify(t *testing.T) {
+	asStringPtr := func(s string) *string {
+		return &s
+	}
+	t.Run("with tk.Target.Failure == nil", func(t *testing.T) {
+		tk := new(TestKeys)
+		if tk.classify() != "accessible_valid_hostname" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == connection_refused", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureConnectionRefused)
+		if tk.classify() != "anomaly_test_helper_blocked" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == dns_nxdomain_error", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureDNSNXDOMAINError)
+		if tk.classify() != "anomaly_test_helper_blocked" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == connection_reset", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureConnectionReset)
+		if tk.classify() != "blocked_tcpip_error" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == eof_error", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureEOFError)
+		if tk.classify() != "blocked_tcpip_error" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == ssl_invalid_hostname", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureSSLInvalidHostname)
+		if tk.classify() != "accessible_invalid_hostname" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == ssl_unknown_authority", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureSSLUnknownAuthority)
+		if tk.classify() != "anomaly_ssl_error" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == ssl_invalid_certificate", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureSSLInvalidCertificate)
+		if tk.classify() != "anomaly_ssl_error" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == generic_timeout_error #1", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
+		if tk.classify() != "anomaly_timeout" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == generic_timeout_error #2", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
+		tk.Control.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
+		if tk.classify() != "anomaly_test_helper_blocked" {
+			t.Fatal("unexpected result")
+		}
+	})
+	t.Run("with tk.Target.Failure == unknown_failure", func(t *testing.T) {
+		tk := new(TestKeys)
+		tk.Target.Failure = asStringPtr("unknown_failure")
+		if tk.classify() != "anomaly_unexpected_failure" {
+			t.Fatal("unexpected result")
+		}
+	})
+}
 
 func TestUnitNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
@@ -105,7 +189,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 		"kernel.org",
 		"example.com:443",
 	)
-	if *result.Failure != "generic_timeout_error" {
+	if *result.Failure != modelx.FailureGenericTimeoutError {
 		t.Fatal("unexpected failure")
 	}
 	if result.SNI != "kernel.org" {
@@ -127,7 +211,7 @@ func TestUnitMeasureoneSuccess(t *testing.T) {
 		"kernel.org",
 		"example.com:443",
 	)
-	if *result.Failure != "ssl_invalid_hostname" {
+	if *result.Failure != modelx.FailureSSLInvalidHostname {
 		t.Fatal("unexpected failure")
 	}
 	if result.SNI != "kernel.org" {
@@ -159,7 +243,7 @@ func TestUnitMeasureonewithcacheWorks(t *testing.T) {
 		if result.Cached != expected {
 			t.Fatal("unexpected cached")
 		}
-		if *result.Failure != "ssl_invalid_hostname" {
+		if *result.Failure != modelx.FailureSSLInvalidHostname {
 			t.Fatal("unexpected failure")
 		}
 		if result.SNI != "kernel.org" {

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -24,63 +24,63 @@ func TestUnitTestKeysClassify(t *testing.T) {
 	}
 	t.Run("with tk.Target.Failure == nil", func(t *testing.T) {
 		tk := new(TestKeys)
-		if tk.classify() != "accessible_valid_hostname" {
+		if tk.classify() != classAccessibleValidHostname {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == connection_refused", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureConnectionRefused)
-		if tk.classify() != "anomaly_test_helper_blocked" {
+		if tk.classify() != classAnomalyTestHelperBlocked {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == dns_nxdomain_error", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureDNSNXDOMAINError)
-		if tk.classify() != "anomaly_test_helper_blocked" {
+		if tk.classify() != classAnomalyTestHelperBlocked {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == connection_reset", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureConnectionReset)
-		if tk.classify() != "blocked_tcpip_error" {
+		if tk.classify() != classBlockedTCPIPError {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == eof_error", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureEOFError)
-		if tk.classify() != "blocked_tcpip_error" {
+		if tk.classify() != classBlockedTCPIPError {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == ssl_invalid_hostname", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureSSLInvalidHostname)
-		if tk.classify() != "accessible_invalid_hostname" {
+		if tk.classify() != classAccessibleInvalidHostname {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == ssl_unknown_authority", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureSSLUnknownAuthority)
-		if tk.classify() != "anomaly_ssl_error" {
+		if tk.classify() != classAnomalySSLError {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == ssl_invalid_certificate", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureSSLInvalidCertificate)
-		if tk.classify() != "anomaly_ssl_error" {
+		if tk.classify() != classAnomalySSLError {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == generic_timeout_error #1", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
-		if tk.classify() != "anomaly_timeout" {
+		if tk.classify() != classAnomalyTimeout {
 			t.Fatal("unexpected result")
 		}
 	})
@@ -88,14 +88,14 @@ func TestUnitTestKeysClassify(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
 		tk.Control.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
-		if tk.classify() != "anomaly_test_helper_blocked" {
+		if tk.classify() != classAnomalyTestHelperBlocked {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == unknown_failure", func(t *testing.T) {
 		tk := new(TestKeys)
 		tk.Target.Failure = asStringPtr("unknown_failure")
-		if tk.classify() != "anomaly_unexpected_failure" {
+		if tk.classify() != classAnomalyUnexpectedFailure {
 			t.Fatal("unexpected result")
 		}
 	})

--- a/internal/oonidatamodel/oonidatamodel_test.go
+++ b/internal/oonidatamodel/oonidatamodel_test.go
@@ -66,7 +66,7 @@ func TestUnitNewTCPConnectListFailure(t *testing.T) {
 		Connects: []*modelx.ConnectEvent{
 			&modelx.ConnectEvent{
 				RemoteAddress: "8.8.8.8:53",
-				Error:         errors.New("connection_reset"),
+				Error:         errors.New(modelx.FailureConnectionReset),
 			},
 		},
 	})
@@ -79,7 +79,7 @@ func TestUnitNewTCPConnectListFailure(t *testing.T) {
 	if out[0].Port != 53 {
 		t.Fatal("unexpected out[0].Port")
 	}
-	if *out[0].Status.Failure != "connection_reset" {
+	if *out[0].Status.Failure != modelx.FailureConnectionReset {
 		t.Fatal("unexpected out[0].Failure")
 	}
 	if out[0].Status.Success != false {
@@ -92,7 +92,7 @@ func TestUnitNewTCPConnectListInvalidInput(t *testing.T) {
 		Connects: []*modelx.ConnectEvent{
 			&modelx.ConnectEvent{
 				RemoteAddress: "8.8.8.8",
-				Error:         errors.New("connection_reset"),
+				Error:         errors.New(modelx.FailureConnectionReset),
 			},
 		},
 	})
@@ -105,7 +105,7 @@ func TestUnitNewTCPConnectListInvalidInput(t *testing.T) {
 	if out[0].Port != 0 {
 		t.Fatal("unexpected out[0].Port")
 	}
-	if *out[0].Status.Failure != "connection_reset" {
+	if *out[0].Status.Failure != modelx.FailureConnectionReset {
 		t.Fatal("unexpected out[0].Failure")
 	}
 	if out[0].Status.Success != false {
@@ -648,7 +648,7 @@ func TestUnitNewDNSQueriesListSuccess(t *testing.T) {
 				TransportNetwork: "system",
 			},
 			&modelx.ResolveDoneEvent{
-				Error:            errors.New("dns_nxdomain_error"),
+				Error:            errors.New(modelx.FailureDNSNXDOMAINError),
 				Hostname:         "dns.googlex",
 				TransportNetwork: "system",
 			},
@@ -767,7 +767,7 @@ func dnscheckbad(e DNSQueryEntry) error {
 	if e.Engine != "system" {
 		return errors.New("invalid engine")
 	}
-	if *e.Failure != "dns_nxdomain_error" {
+	if *e.Failure != modelx.FailureDNSNXDOMAINError {
 		return errors.New("invalid failure")
 	}
 	if e.Hostname != "dns.googlex" {

--- a/internal/oonitemplates/oonitemplates_test.go
+++ b/internal/oonitemplates/oonitemplates_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	goptlib "git.torproject.org/pluggable-transports/goptlib.git"
+	"github.com/ooni/probe-engine/netx/modelx"
 	"gitlab.com/yawning/obfs4.git/transports"
 	obfs4base "gitlab.com/yawning/obfs4.git/transports/base"
 )
@@ -37,7 +38,7 @@ func TestIntegrationDNSLookupCancellation(t *testing.T) {
 	if results.Error == nil {
 		t.Fatal("expected an error here")
 	}
-	if results.Error.Error() != "generic_timeout_error" {
+	if results.Error.Error() != modelx.FailureGenericTimeoutError {
 		t.Fatal("not the error we expected")
 	}
 	if len(results.Addresses) > 0 {
@@ -152,7 +153,7 @@ func TestIntegrationTLSConnectCancellation(t *testing.T) {
 	if results.Error == nil {
 		t.Fatal("expected an error here")
 	}
-	if results.Error.Error() != "generic_timeout_error" {
+	if results.Error.Error() != modelx.FailureGenericTimeoutError {
 		t.Fatal("not the error we expected")
 	}
 }

--- a/netx/http_test.go
+++ b/netx/http_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/netx"
+	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 func dowithclient(t *testing.T, client *netx.HTTPClient) {
@@ -147,7 +148,7 @@ func TestIntegrationHTTPTransportTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
-	if !strings.HasSuffix(err.Error(), "generic_timeout_error") {
+	if !strings.HasSuffix(err.Error(), modelx.FailureGenericTimeoutError) {
 		t.Fatal("not the error we expected")
 	}
 	if resp != nil {

--- a/netx/internal/dialer/dnsdialer/dnsdialer_test.go
+++ b/netx/internal/dialer/dnsdialer/dnsdialer_test.go
@@ -101,11 +101,11 @@ func TestReduceErrors(t *testing.T) {
 			Failure: "unknown_error: antani",
 		}
 		err3 := &modelx.ErrWrapper{
-			Failure: "connection_refused",
+			Failure: modelx.FailureConnectionRefused,
 		}
 		err4 := errors.New("mocked error #3")
 		result := reduceErrors([]error{err1, err2, err3, err4})
-		if result.Error() != "connection_refused" {
+		if result.Error() != modelx.FailureConnectionRefused {
 			t.Fatal("wrong result")
 		}
 	})

--- a/netx/internal/errwrapper/errwrapper.go
+++ b/netx/internal/errwrapper/errwrapper.go
@@ -55,50 +55,50 @@ func toFailureString(err error) string {
 	}
 
 	if errors.Is(err, modelx.ErrDNSBogon) {
-		return "dns_bogon_error" // not in MK
+		return modelx.FailureDNSBogonError // not in MK
 	}
 
 	var x509HostnameError x509.HostnameError
 	if errors.As(err, &x509HostnameError) {
 		// Test case: https://wrong.host.badssl.com/
-		return "ssl_invalid_hostname"
+		return modelx.FailureSSLInvalidHostname
 	}
 	var x509UnknownAuthorityError x509.UnknownAuthorityError
 	if errors.As(err, &x509UnknownAuthorityError) {
 		// Test case: https://self-signed.badssl.com/. This error has
 		// never been among the ones returned by MK.
-		return "ssl_unknown_authority"
+		return modelx.FailureSSLUnknownAuthority
 	}
 	var x509CertificateInvalidError x509.CertificateInvalidError
 	if errors.As(err, &x509CertificateInvalidError) {
 		// Test case: https://expired.badssl.com/
-		return "ssl_invalid_certificate"
+		return modelx.FailureSSLInvalidCertificate
 	}
 
 	s := err.Error()
 	if strings.HasSuffix(s, "EOF") {
-		return "eof_error"
+		return modelx.FailureEOFError
 	}
 	if strings.HasSuffix(s, "connection refused") {
-		return "connection_refused"
+		return modelx.FailureConnectionRefused
 	}
 	if strings.HasSuffix(s, "connection reset by peer") {
-		return "connection_reset"
+		return modelx.FailureConnectionReset
 	}
 	if strings.HasSuffix(s, "context deadline exceeded") {
-		return "generic_timeout_error"
+		return modelx.FailureGenericTimeoutError
 	}
 	if strings.HasSuffix(s, "i/o timeout") {
-		return "generic_timeout_error"
+		return modelx.FailureGenericTimeoutError
 	}
 	if strings.HasSuffix(s, "TLS handshake timeout") {
-		return "generic_timeout_error"
+		return modelx.FailureGenericTimeoutError
 	}
 	if strings.HasSuffix(s, "no such host") {
 		// This is dns_lookup_error in MK but such error is used as a
 		// generic "hey, the lookup failed" error. Instead, this error
 		// that we return here is significantly more specific.
-		return "dns_nxdomain_error"
+		return modelx.FailureDNSNXDOMAINError
 	}
 
 	return fmt.Sprintf("unknown_failure: %s", s)

--- a/netx/internal/errwrapper/errwrapper_test.go
+++ b/netx/internal/errwrapper/errwrapper_test.go
@@ -43,45 +43,45 @@ func TestMaybeBuildFactory(t *testing.T) {
 func TestToFailureString(t *testing.T) {
 	t.Run("for already wrapped error", func(t *testing.T) {
 		err := SafeErrWrapperBuilder{Error: io.EOF}.MaybeBuild()
-		if toFailureString(err) != "eof_error" {
+		if toFailureString(err) != modelx.FailureEOFError {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for modelx.ErrDNSBogon", func(t *testing.T) {
-		if toFailureString(modelx.ErrDNSBogon) != "dns_bogon_error" {
+		if toFailureString(modelx.ErrDNSBogon) != modelx.FailureDNSBogonError {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for x509.HostnameError", func(t *testing.T) {
 		var err x509.HostnameError
-		if toFailureString(err) != "ssl_invalid_hostname" {
+		if toFailureString(err) != modelx.FailureSSLInvalidHostname {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for x509.UnknownAuthorityError", func(t *testing.T) {
 		var err x509.UnknownAuthorityError
-		if toFailureString(err) != "ssl_unknown_authority" {
+		if toFailureString(err) != modelx.FailureSSLUnknownAuthority {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for x509.CertificateInvalidError", func(t *testing.T) {
 		var err x509.CertificateInvalidError
-		if toFailureString(err) != "ssl_invalid_certificate" {
+		if toFailureString(err) != modelx.FailureSSLInvalidCertificate {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for EOF", func(t *testing.T) {
-		if toFailureString(io.EOF) != "eof_error" {
+		if toFailureString(io.EOF) != modelx.FailureEOFError {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for connection_refused", func(t *testing.T) {
-		if toFailureString(syscall.ECONNREFUSED) != "connection_refused" {
+		if toFailureString(syscall.ECONNREFUSED) != modelx.FailureConnectionRefused {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for connection_reset", func(t *testing.T) {
-		if toFailureString(syscall.ECONNRESET) != "connection_reset" {
+		if toFailureString(syscall.ECONNRESET) != modelx.FailureConnectionReset {
 			t.Fatal("unexpected results")
 		}
 	})
@@ -89,7 +89,7 @@ func TestToFailureString(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1)
 		defer cancel()
 		<-ctx.Done()
-		if toFailureString(ctx.Err()) != "generic_timeout_error" {
+		if toFailureString(ctx.Err()) != modelx.FailureGenericTimeoutError {
 			t.Fatal("unexpected results")
 		}
 	})
@@ -103,20 +103,20 @@ func TestToFailureString(t *testing.T) {
 		if conn != nil {
 			t.Fatal("expected nil connection here")
 		}
-		if toFailureString(err) != "generic_timeout_error" {
+		if toFailureString(err) != modelx.FailureGenericTimeoutError {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for TLS handshake timeout error", func(t *testing.T) {
 		err := errors.New("net/http: TLS handshake timeout")
-		if toFailureString(err) != "generic_timeout_error" {
+		if toFailureString(err) != modelx.FailureGenericTimeoutError {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for no such host", func(t *testing.T) {
 		if toFailureString(&net.DNSError{
 			Err: "no such host",
-		}) != "dns_nxdomain_error" {
+		}) != modelx.FailureDNSNXDOMAINError {
 			t.Fatal("unexpected results")
 		}
 	})

--- a/netx/internal/resolver/parentresolver/parentresolver_test.go
+++ b/netx/internal/resolver/parentresolver/parentresolver_test.go
@@ -93,7 +93,7 @@ func TestLookupHostBogonHardError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
-	if err.Error() != "dns_bogon_error" {
+	if err.Error() != modelx.FailureDNSBogonError {
 		t.Fatal("not the error that we expected")
 	}
 	if addrs != nil {

--- a/netx/internal/resolver/resolver_test.go
+++ b/netx/internal/resolver/resolver_test.go
@@ -43,7 +43,7 @@ func TestIntegrationDetectBogon(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
-	if err.Error() != "dns_bogon_error" {
+	if err.Error() != modelx.FailureDNSBogonError {
 		t.Fatal("not the error we expected to see")
 	}
 	if addrs != nil {

--- a/netx/modelx/modelx.go
+++ b/netx/modelx/modelx.go
@@ -129,7 +129,8 @@ type ErrWrapper struct {
 	// loosely backward compatible with Measurement Kit.
 	//
 	// This is either one of the FailureXXX strings or any other
-	// string representing an error not mapped to a failure.
+	// string like `unknown_failure ...`. The latter represents an
+	// error that we have not yet mapped to a failure.
 	Failure string
 
 	// Operation is the operation that failed. If possible, it

--- a/netx/modelx/modelx.go
+++ b/netx/modelx/modelx.go
@@ -85,6 +85,36 @@ type Measurement struct {
 	Extension *ExtensionEvent `json:",omitempty"`
 }
 
+const (
+	// FailureConnectionRefused means ECONNREFUSED.
+	FailureConnectionRefused = "connection_refused"
+
+	// FailureConnectionReset means ECONNRESET.
+	FailureConnectionReset = "connection_reset"
+
+	// FailureDNSBogonError means we detected bogon in DNS reply.
+	FailureDNSBogonError = "dns_bogon_error"
+
+	// FailureDNSNXDOMAINError means we got NXDOMAIN in DNS reply.
+	FailureDNSNXDOMAINError = "dns_nxdomain_error"
+
+	// FailureEOFError means we got unexpected EOF on connection.
+	FailureEOFError = "eof_error"
+
+	// FailureGenericTimeoutError means we got some timer has expired.
+	FailureGenericTimeoutError = "generic_timeout_error"
+
+	// FailureSSLInvalidHostname means we got certificate is not valid for SNI.
+	FailureSSLInvalidHostname = "ssl_invalid_hostname"
+
+	// FailureSSLUnknownAuthority means we cannot find CA validating certificate.
+	FailureSSLUnknownAuthority = "ssl_unknown_authority"
+
+	// FailureSSLInvalidCertificate means certificate experired or other
+	// sort of errors causing it to be invalid.
+	FailureSSLInvalidCertificate = "ssl_invalid_certificate"
+)
+
 // ErrWrapper is our error wrapper for Go errors. The key objective of
 // this structure is to properly set Failure, which is also returned by
 // the Error() method, so be one of the OONI defined strings.
@@ -98,18 +128,8 @@ type ErrWrapper struct {
 	// Failure is the OONI failure string. The failure strings are
 	// loosely backward compatible with Measurement Kit.
 	//
-	// Supported failure strings
-	//
-	// - `connection_refused`: ECONNREFUSED
-	// - `connection_reset`: ECONNRESET
-	// - `dns_bogon_error`: detected bogon in DNS reply
-	// - `dns_nxdomain_error`: NXDOMAIN in DNS reply
-	// - `eof_error`: unexpected EOF on connection
-	// - `generic_timeout_error`: some timer has expired
-	// - `ssl_invalid_hostname`: certificate not valid for SNI
-	// - `ssl_unknown_autority`: cannot find CA validating certificate
-	// - `ssl_invalid_certificate`: e.g. certificate expried
-	// - `unknown_failure ...`: any other error
+	// This is either one of the FailureXXX strings or any other
+	// string representing an error not mapped to a failure.
 	Failure string
 
 	// Operation is the operation that failed. If possible, it


### PR DESCRIPTION
Since in OONI we typically use a three class system (i.e. accessible,
anomaly, or blocking), I am using these three classes.

I am also adding further information that help in understanding what
is the real root cause of the failure.

Part of https://github.com/ooni/probe-engine/issues/309.

Before merging:

- [x] re-read the diff
- [x] make sure we open follow-up issues
- [x] update spec accordingly (https://github.com/ooni/spec/pull/181)