### PR TITLE
tor: use targets-list-length dependent timeout

### DIFF
--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -71,6 +71,32 @@ func TestUnitMeasurerMeasureFetchTorTargetsError(t *testing.T) {
 	}
 }
 
+func TestUnitMeasurerMeasureFetchTorTargetsEmptyList(t *testing.T) {
+	measurer := newMeasurer(Config{})
+	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
+		return new(orchestra.Client), nil
+	}
+	measurer.fetchTorTargets = func(ctx context.Context, clnt model.ExperimentOrchestraClient) (map[string]model.TorTarget, error) {
+		return nil, nil
+	}
+	measurement := new(model.Measurement)
+	err := measurer.Run(
+		context.Background(),
+		&mockable.ExperimentSession{
+			MockableLogger: log.Log,
+		},
+		measurement,
+		handler.NewPrinterCallbacks(log.Log),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk := measurement.TestKeys.(*TestKeys)
+	if len(tk.Targets) != 0 {
+		t.Fatal("expected no targets here")
+	}
+}
+
 func TestUnitMeasurerMeasureGood(t *testing.T) {
 	measurer := newMeasurer(Config{})
 	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {


### PR DESCRIPTION
Closes https://github.com/ooni/probe-engine/issues/288

While there, I figured it made sense to add one extra test to make sure
we can gracefully handle the case where the orchestra API gives us no
targets.