### PR TITLE
experiment_test.go: run ndt7 integration test

### DIFF
--- a/experiment/psiphon/psiphon_test.go
+++ b/experiment/psiphon/psiphon_test.go
@@ -19,11 +19,6 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-const (
-	softwareName    = "ooniprobe-example"
-	softwareVersion = "0.0.1"
-)
-
 func TestUnitNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	if measurer.ExperimentName() != "psiphon" {

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -14,11 +14,6 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-const (
-	softwareName    = "ooniprobe-example"
-	softwareVersion = "0.0.1"
-)
-
 func TestUnitNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	if measurer.ExperimentName() != "telegram" {

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -15,11 +15,6 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-const (
-	softwareName    = "ooniprobe-example"
-	softwareVersion = "0.0.1"
-)
-
 func TestUnitNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	if measurer.ExperimentName() != "tor" {

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -52,6 +52,16 @@ func TestRunExample(t *testing.T) {
 	runexperimentflow(t, builder.NewExperiment(), "")
 }
 
+func TestRunNdt7(t *testing.T) {
+	sess := newSessionForTesting(t)
+	defer sess.Close()
+	builder, err := sess.NewExperimentBuilder("ndt7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runexperimentflow(t, builder.NewExperiment(), "")
+}
+
 func TestRunPsiphon(t *testing.T) {
 	sess := newSessionForTesting(t)
 	defer sess.Close()


### PR DESCRIPTION
While there, cleanup code that was not used inside of a bunch
of unit tests, spotted while working on this diff.

Part of https://github.com/ooni/probe/issues/969