### PR TITLE
runner: set experiment callbacks

### DIFF
--- a/oonimkall/runner.go
+++ b/oonimkall/runner.go
@@ -121,6 +121,9 @@ func (cb *runnerCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
 }
 
 func (cb *runnerCallbacks) OnProgress(percentage float64, message string) {
+	// TODO(bassosimone): I am unsure whether this lock here is really
+	// needed. I think a future refactoring goal for probe-engine is to
+	// have much more goroutines and channesl than now.
 	cb.lock.Lock()
 	cb.emitter.Emit(statusProgress, eventStatusProgress{
 		Percentage: 0.4 + (percentage * 0.6), // open report is 40%

--- a/oonimkall/task_test.go
+++ b/oonimkall/task_test.go
@@ -3,7 +3,6 @@ package oonimkall_test
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -46,12 +45,10 @@ func TestIntegrationGood(t *testing.T) {
 	// make sure we only see task_terminated at this point
 	for {
 		eventstr := task.WaitForNextEvent()
-		fmt.Printf("%s\n", eventstr)
 		var event eventlike
 		if err := json.Unmarshal([]byte(eventstr), &event); err != nil {
 			t.Fatal(err)
 		}
-		fmt.Printf("%s\n", eventstr)
 		if event.Key != "task_terminated" {
 			t.Fatalf("unexpected event.Key: %s", event.Key)
 		}


### PR DESCRIPTION
Allow us to count bytes consumed and to see progress from the experiment.

Closes https://github.com/ooni/probe-engine/issues/353