### PR TITLE
Replace the atomic package with atomicx

### DIFF
--- a/atomicx/atomicx.go
+++ b/atomicx/atomicx.go
@@ -1,0 +1,39 @@
+// Package atomicx contains atomic extensions. The main reason for rolling out
+// this package is to avoid potential crashes when using 32 bit devices where we
+// are atomically accessing a 64 bit variable that is not aligned. The solution
+// to this issue is rather crude: use a normal variable and protect it using a
+// normal mutex. While this could be disappointing in general, it seems fine to
+// be done in our context where we mainly use atomic semantics for counting.
+package atomicx
+
+import (
+	"sync"
+)
+
+// Int64 is an int64 with atomic semantics.
+type Int64 struct {
+	mu sync.Mutex
+	v  int64
+}
+
+// NewInt64 creates a new int64 with atomic semantics.
+func NewInt64() *Int64 {
+	return new(Int64)
+}
+
+// Add behaves like atomic.AddInt64
+func (i64 *Int64) Add(delta int64) (newvalue int64) {
+	i64.mu.Lock()
+	i64.v += delta
+	newvalue = i64.v
+	i64.mu.Unlock()
+	return
+}
+
+// Load behaves like atomic.LoadInt64
+func (i64 *Int64) Load() (v int64) {
+	i64.mu.Lock()
+	v = i64.v
+	i64.mu.Unlock()
+	return
+}

--- a/atomicx/atomicx_test.go
+++ b/atomicx/atomicx_test.go
@@ -1,0 +1,29 @@
+package atomicx_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ooni/probe-engine/atomicx"
+)
+
+func TestIntegration(t *testing.T) {
+	// TODO(bassosimone): how to write tests with race conditions
+	// and be confident that they're WAI? Here I hope this test is
+	// run with `-race` and I'm doing something that AFAICT will
+	// be flagged as race if we were not be using mutexes.
+	v := atomicx.NewInt64()
+	go func() {
+		v.Add(17)
+	}()
+	go func() {
+		v.Add(14)
+	}()
+	time.Sleep(1 * time.Second)
+	if v.Add(3) != 34 {
+		t.Fatal("unexpected result")
+	}
+	if v.Load() != 34 {
+		t.Fatal("unexpected result")
+	}
+}

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -236,10 +236,10 @@ func TestUnitResultsCollectorMeasureSingleTargetGood(t *testing.T) {
 	if rc.targetresults["xx"].TargetProtocol != staticTestingTargets[0].Protocol {
 		t.Fatal("target protocol is invalid")
 	}
-	if rc.sentBytes != 10 {
+	if rc.sentBytes.Load() != 10 {
 		t.Fatal("sent bytes is invalid")
 	}
-	if rc.receivedBytes != 14 {
+	if rc.receivedBytes.Load() != 14 {
 		t.Fatal("received bytes is invalid")
 	}
 }
@@ -279,10 +279,10 @@ func TestUnitResultsCollectorMeasureSingleTargetWithFailure(t *testing.T) {
 	if rc.targetresults["xx"].TargetProtocol != staticTestingTargets[0].Protocol {
 		t.Fatal("target protocol is invalid")
 	}
-	if rc.sentBytes != 0 {
+	if rc.sentBytes.Load() != 0 {
 		t.Fatal("sent bytes is invalid")
 	}
-	if rc.receivedBytes != 0 {
+	if rc.receivedBytes.Load() != 0 {
 		t.Fatal("received bytes is invalid")
 	}
 }

--- a/internal/oonitemplates/oonitemplates.go
+++ b/internal/oonitemplates/oonitemplates.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	goptlib "git.torproject.org/pluggable-transports/goptlib.git"
@@ -29,7 +30,8 @@ import (
 )
 
 type channelHandler struct {
-	ch chan<- modelx.Measurement
+	ch         chan<- modelx.Measurement
+	lateWrites int64
 }
 
 func (h *channelHandler) OnMeasurement(m modelx.Measurement) {
@@ -41,12 +43,7 @@ func (h *channelHandler) OnMeasurement(m modelx.Measurement) {
 	select {
 	case h.ch <- m:
 	case <-time.After(100 * time.Millisecond):
-		// We use to have code here but that caused crashes on
-		// the Android simulator under x86 and on devices. We
-		// don't have a solid theory of why it happens, but we
-		// know that _not_ putting code here prevents this from
-		// happening. The issue for tracking this bug was:
-		// https://github.com/ooni/probe-engine/issues/355.
+		atomic.AddInt64(&h.lateWrites, 1)
 	}
 }
 

--- a/internal/oonitemplates/oonitemplates.go
+++ b/internal/oonitemplates/oonitemplates.go
@@ -17,10 +17,10 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	goptlib "git.torproject.org/pluggable-transports/goptlib.git"
+	"github.com/ooni/probe-engine/atomicx"
 	"github.com/ooni/probe-engine/internal/runtimex"
 	"github.com/ooni/probe-engine/netx"
 	"github.com/ooni/probe-engine/netx/handlers"
@@ -31,7 +31,14 @@ import (
 
 type channelHandler struct {
 	ch         chan<- modelx.Measurement
-	lateWrites int64
+	lateWrites *atomicx.Int64
+}
+
+func newChannelHandler(ch chan<- modelx.Measurement) *channelHandler {
+	return &channelHandler{
+		ch:         ch,
+		lateWrites: atomicx.NewInt64(),
+	}
 }
 
 func (h *channelHandler) OnMeasurement(m modelx.Measurement) {
@@ -43,7 +50,7 @@ func (h *channelHandler) OnMeasurement(m modelx.Measurement) {
 	select {
 	case h.ch <- m:
 	case <-time.After(100 * time.Millisecond):
-		atomic.AddInt64(&h.lateWrites, 1)
+		h.lateWrites.Add(1)
 	}
 }
 
@@ -244,9 +251,7 @@ func DNSLookup(
 	channel := make(chan modelx.Measurement)
 	root := &modelx.MeasurementRoot{
 		Beginning: config.Beginning,
-		Handler: &channelHandler{
-			ch: channel,
-		},
+		Handler:   newChannelHandler(channel),
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
 	resolver, err := netx.NewResolver(config.ServerNetwork, config.ServerAddress)
@@ -314,10 +319,8 @@ func HTTPDo(
 	channel := make(chan modelx.Measurement)
 	// TODO(bassosimone): tell client to use specific CA bundle?
 	root := &modelx.MeasurementRoot{
-		Beginning: config.Beginning,
-		Handler: &channelHandler{
-			ch: channel,
-		},
+		Beginning:       config.Beginning,
+		Handler:         newChannelHandler(channel),
 		MaxBodySnapSize: config.MaxEventsBodySnapSize,
 	}
 	ctx := modelx.WithMeasurementRoot(origCtx, root)
@@ -407,9 +410,7 @@ func TLSConnect(
 	channel := make(chan modelx.Measurement)
 	root := &modelx.MeasurementRoot{
 		Beginning: config.Beginning,
-		Handler: &channelHandler{
-			ch: channel,
-		},
+		Handler:   newChannelHandler(channel),
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
 	dialer := netx.NewDialer()
@@ -470,9 +471,7 @@ func TCPConnect(
 	channel := make(chan modelx.Measurement)
 	root := &modelx.MeasurementRoot{
 		Beginning: config.Beginning,
-		Handler: &channelHandler{
-			ch: channel,
-		},
+		Handler:   newChannelHandler(channel),
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
 	dialer := netx.NewDialer()
@@ -538,9 +537,7 @@ func OBFS4Connect(
 	channel := make(chan modelx.Measurement)
 	root := &modelx.MeasurementRoot{
 		Beginning: config.Beginning,
-		Handler: &channelHandler{
-			ch: channel,
-		},
+		Handler:   newChannelHandler(channel),
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
 	dialer := netx.NewDialer()

--- a/internal/oonitemplates/oonitemplates_test.go
+++ b/internal/oonitemplates/oonitemplates_test.go
@@ -16,9 +16,7 @@ import (
 )
 
 func TestUnitChannelHandlerWriteLateOnChannel(t *testing.T) {
-	handler := &channelHandler{
-		ch: make(chan modelx.Measurement),
-	}
+	handler := newChannelHandler(make(chan modelx.Measurement))
 	var waitgroup sync.WaitGroup
 	waitgroup.Add(1)
 	go func() {
@@ -27,7 +25,7 @@ func TestUnitChannelHandlerWriteLateOnChannel(t *testing.T) {
 		waitgroup.Done()
 	}()
 	waitgroup.Wait()
-	if handler.lateWrites != 1 {
+	if handler.lateWrites.Load() != 1 {
 		t.Fatal("unexpected lateWrites value")
 	}
 }

--- a/internal/oonitemplates/oonitemplates_test.go
+++ b/internal/oonitemplates/oonitemplates_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,23 @@ import (
 	"gitlab.com/yawning/obfs4.git/transports"
 	obfs4base "gitlab.com/yawning/obfs4.git/transports/base"
 )
+
+func TestUnitChannelHandlerWriteLateOnChannel(t *testing.T) {
+	handler := &channelHandler{
+		ch: make(chan modelx.Measurement),
+	}
+	var waitgroup sync.WaitGroup
+	waitgroup.Add(1)
+	go func() {
+		time.Sleep(1 * time.Second)
+		handler.OnMeasurement(modelx.Measurement{})
+		waitgroup.Done()
+	}()
+	waitgroup.Wait()
+	if handler.lateWrites != 1 {
+		t.Fatal("unexpected lateWrites value")
+	}
+}
 
 func TestIntegrationDNSLookupGood(t *testing.T) {
 	ctx := context.Background()

--- a/netx/internal/dialid/dialid.go
+++ b/netx/internal/dialid/dialid.go
@@ -2,17 +2,18 @@ package dialid
 
 import (
 	"context"
-	"sync/atomic"
+
+	"github.com/ooni/probe-engine/atomicx"
 )
 
 type contextkey struct{}
 
-var id int64
+var id = atomicx.NewInt64()
 
 // WithDialID returns a copy of ctx with DialID
 func WithDialID(ctx context.Context) context.Context {
 	return context.WithValue(
-		ctx, contextkey{}, atomic.AddInt64(&id, 1),
+		ctx, contextkey{}, id.Add(1),
 	)
 }
 

--- a/netx/internal/httptransport/tracetripper/tracetripper_test.go
+++ b/netx/internal/httptransport/tracetripper/tracetripper_test.go
@@ -61,7 +61,7 @@ func TestIntegrationReadAllFailure(t *testing.T) {
 	if resp != nil {
 		t.Fatal("expected nil response here")
 	}
-	if transport.readAllErrs <= 0 {
+	if transport.readAllErrs.Load() <= 0 {
 		t.Fatal("not the error we expected")
 	}
 	client.CloseIdleConnections()

--- a/netx/internal/resolver/brokenresolver/brokenresolver.go
+++ b/netx/internal/resolver/brokenresolver/brokenresolver.go
@@ -4,17 +4,20 @@ package brokenresolver
 import (
 	"context"
 	"net"
-	"sync/atomic"
+
+	"github.com/ooni/probe-engine/atomicx"
 )
 
 // Resolver is a broken resolver.
 type Resolver struct {
-	NumErrors int64
+	NumErrors *atomicx.Int64
 }
 
 // New creates a new broken Resolver instance.
 func New() *Resolver {
-	return &Resolver{}
+	return &Resolver{
+		NumErrors: atomicx.NewInt64(),
+	}
 }
 
 var errNotFound = &net.DNSError{
@@ -23,30 +26,30 @@ var errNotFound = &net.DNSError{
 
 // LookupAddr returns the name of the provided IP address
 func (c *Resolver) LookupAddr(ctx context.Context, addr string) ([]string, error) {
-	atomic.AddInt64(&c.NumErrors, 1)
+	c.NumErrors.Add(1)
 	return nil, errNotFound
 }
 
 // LookupCNAME returns the canonical name of a host
 func (c *Resolver) LookupCNAME(ctx context.Context, host string) (string, error) {
-	atomic.AddInt64(&c.NumErrors, 1)
+	c.NumErrors.Add(1)
 	return "", errNotFound
 }
 
 // LookupHost returns the IP addresses of a host
 func (c *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
-	atomic.AddInt64(&c.NumErrors, 1)
+	c.NumErrors.Add(1)
 	return nil, errNotFound
 }
 
 // LookupMX returns the MX records of a specific name
 func (c *Resolver) LookupMX(ctx context.Context, name string) ([]*net.MX, error) {
-	atomic.AddInt64(&c.NumErrors, 1)
+	c.NumErrors.Add(1)
 	return nil, errNotFound
 }
 
 // LookupNS returns the NS records of a specific name
 func (c *Resolver) LookupNS(ctx context.Context, name string) ([]*net.NS, error) {
-	atomic.AddInt64(&c.NumErrors, 1)
+	c.NumErrors.Add(1)
 	return nil, errNotFound
 }

--- a/netx/internal/resolver/ooniresolver/ooniresolver_test.go
+++ b/netx/internal/resolver/ooniresolver/ooniresolver_test.go
@@ -62,7 +62,7 @@ func TestLookupHostWithRetry(t *testing.T) {
 	if !strings.HasSuffix(err.Error(), "i/o timeout") {
 		t.Fatal("not the error we expected")
 	}
-	if client.ntimeouts <= 0 {
+	if client.ntimeouts.Load() <= 0 {
 		t.Fatal("no timeouts?")
 	}
 	if addrs != nil {
@@ -93,7 +93,7 @@ func TestLookupHostWithNonTimeoutError(t *testing.T) {
 	if err.Error() == "context deadline exceeded" {
 		t.Fatal("not the error we expected")
 	}
-	if client.ntimeouts != 0 {
+	if client.ntimeouts.Load() != 0 {
 		t.Fatal("we saw a timeout?")
 	}
 	if addrs != nil {

--- a/netx/internal/transactionid/transactionid.go
+++ b/netx/internal/transactionid/transactionid.go
@@ -3,17 +3,18 @@ package transactionid
 
 import (
 	"context"
-	"sync/atomic"
+
+	"github.com/ooni/probe-engine/atomicx"
 )
 
 type contextkey struct{}
 
-var id int64
+var id = atomicx.NewInt64()
 
 // WithTransactionID returns a copy of ctx with TransactionID
 func WithTransactionID(ctx context.Context) context.Context {
 	return context.WithValue(
-		ctx, contextkey{}, atomic.AddInt64(&id, 1),
+		ctx, contextkey{}, id.Add(1),
 	)
 }
 

--- a/netx/resolver_test.go
+++ b/netx/resolver_test.go
@@ -145,7 +145,7 @@ func TestIntegrationChainResolvers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err) // we don't expect error because good resolver is first
 	}
-	if primary.NumErrors < 1 {
+	if primary.NumErrors.Load() < 1 {
 		t.Fatal("primary has not been used")
 	}
 	defer conn.Close()

--- a/oonimkall/eventemitter_test.go
+++ b/oonimkall/eventemitter_test.go
@@ -75,7 +75,7 @@ func TestUnitEmitNonblocking(t *testing.T) {
 		wg.Done()
 	}()
 	wg.Wait()
-	if emitter.timeouts != 1 {
+	if emitter.timeouts.Load() != 1 {
 		t.Fatal("did not see any timeout")
 	}
 }

--- a/session_internal_test.go
+++ b/session_internal_test.go
@@ -31,5 +31,5 @@ func (s *Session) MaybeLookupTestHelpersContext(ctx context.Context) error {
 }
 
 func (s *Session) QueryBouncerCount() int64 {
-	return s.queryBouncerCount
+	return s.queryBouncerCount.Load()
 }


### PR DESCRIPTION
The atomicx package is less efficient however it completely avoids
using atomic semantics on int64, which may lead to crash if the
variable we are accessing is not properly aligned.

See https://golang.org/pkg/sync/atomic/#pkg-note-BUG, which reads:

> On x86-32, the 64-bit functions use instructions unavailable
> before the Pentium MMX.
>
> On non-Linux ARM, the 64-bit functions use instructions
> unavailable before the ARMv6k core.
>
> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility
> to arrange for 64-bit alignment of 64-bit words accessed atomically. The
> first word in a variable or in an allocated struct, array, or slice can
> be relied upon to be 64-bit aligned.

By using a separate package we are able to possibly even change the
way in which we implement the code, and surely we are able to shield
ourselves from this pitfalls by using a mutex. While in general it
may not be okay to always use a mutex, we mostly use atomic semantics
for counting. That is, we are not using it in performance critical
parts of the tree, hence this fix seems fine to me.

Related issue #399.