### PR TITLE
Now ndt is an alias for ndt7, introduce ndt5

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ooni/probe-engine/experiment/handler"
 	"github.com/ooni/probe-engine/experiment/hhfm"
 	"github.com/ooni/probe-engine/experiment/hirl"
-	"github.com/ooni/probe-engine/experiment/ndt"
+	"github.com/ooni/probe-engine/experiment/ndt5"
 	"github.com/ooni/probe-engine/experiment/ndt7"
 	"github.com/ooni/probe-engine/experiment/psiphon"
 	"github.com/ooni/probe-engine/experiment/sniblocking"
@@ -151,12 +151,13 @@ func (b *ExperimentBuilder) NewExperiment() *Experiment {
 }
 
 // canonicalizeExperimentName allows code to provide experiment names
-// in a more flexible way. There is a special case for ndt7 where we
-// get `ndt_7` but we would actually want `ndt7`.
+// in a more flexible way, where we have aliases.
 func canonicalizeExperimentName(name string) string {
 	switch name = strcase.ToSnake(name); name {
 	case "ndt_7":
-		name = "ndt7"
+		name = "ndt" // since 2020-03-18, we use ndt7 to implement ndt by default
+	case "ndt_5":
+		name = "ndt5"
 	default:
 	}
 	return name
@@ -493,20 +494,20 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 		}
 	},
 
-	"ndt": func(session *Session) *ExperimentBuilder {
+	"ndt5": func(session *Session) *ExperimentBuilder {
 		return &ExperimentBuilder{
 			build: func(config interface{}) *Experiment {
-				return NewExperiment(session, ndt.NewExperimentMeasurer(
-					*config.(*ndt.Config),
+				return NewExperiment(session, ndt5.NewExperimentMeasurer(
+					*config.(*ndt5.Config),
 				))
 			},
-			config:        &ndt.Config{},
+			config:        &ndt5.Config{},
 			interruptible: true,
 			needsInput:    false,
 		}
 	},
 
-	"ndt7": func(session *Session) *ExperimentBuilder {
+	"ndt": func(session *Session) *ExperimentBuilder {
 		return &ExperimentBuilder{
 			build: func(config interface{}) *Experiment {
 				return NewExperiment(session, ndt7.NewExperimentMeasurer(

--- a/experiment/ndt5/ndt5.go
+++ b/experiment/ndt5/ndt5.go
@@ -1,5 +1,5 @@
 // Package ndt contains the ndt network experiment.
-package ndt
+package ndt5
 
 import (
 	"context"

--- a/experiment/ndt5/ndt5_test.go
+++ b/experiment/ndt5/ndt5_test.go
@@ -1,16 +1,16 @@
-package ndt_test
+package ndt5_test
 
 import (
 	"testing"
 
 	"github.com/ooni/probe-engine/experiment/mktesting"
-	"github.com/ooni/probe-engine/experiment/ndt"
+	"github.com/ooni/probe-engine/experiment/ndt5"
 	"github.com/ooni/probe-engine/model"
 )
 
 func TestIntegration(t *testing.T) {
 	err := mktesting.Run("", func() model.ExperimentMeasurer {
-		return ndt.NewExperimentMeasurer(ndt.Config{})
+		return ndt5.NewExperimentMeasurer(ndt5.Config{})
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	testName    = "ndt7"
-	testVersion = "0.2.0"
+	testName    = "ndt"
+	testVersion = "0.4.0"
 )
 
 // Config contains the experiment settings

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -15,10 +15,10 @@ import (
 
 func TestUnitNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
-	if measurer.ExperimentName() != "ndt7" {
+	if measurer.ExperimentName() != "ndt" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.2.0" {
+	if measurer.ExperimentVersion() != "0.4.0" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -26,7 +26,14 @@ func TestCreateAll(t *testing.T) {
 			t.Fatal(err)
 		}
 		exp := builder.NewExperiment()
-		if exp.Name() != name {
+		var good bool
+		switch name {
+		case "ndt5":
+			good = (name == "ndt5" && exp.Name() == "ndt")
+		default:
+			good = (exp.Name() == name)
+		}
+		if !good {
 			t.Fatal("unexpected experiment name")
 		}
 	}


### PR DESCRIPTION
Since now, if you request for ndt, we will give you ndt7 rather than
ndt5. You can still get ndt5 if you explicitly ask for that.

Significantly bump the version number used by ndt7 such that we leave
some room to grow MK's ndt5 implementation, just in case.

Part of https://github.com/ooni/backend/issues/369.