### PR TITLE
Session now accounts for bytes sent and received

### DIFF
--- a/atomicx/atomicx.go
+++ b/atomicx/atomicx.go
@@ -37,3 +37,31 @@ func (i64 *Int64) Load() (v int64) {
 	i64.mu.Unlock()
 	return
 }
+
+// Float64 is an float64 with atomic semantics.
+type Float64 struct {
+	mu sync.Mutex
+	v  float64
+}
+
+// NewFloat64 creates a new float64 with atomic semantics.
+func NewFloat64() *Float64 {
+	return new(Float64)
+}
+
+// Add behaves like AtomicInt64.Add but for float64
+func (f64 *Float64) Add(delta float64) (newvalue float64) {
+	f64.mu.Lock()
+	f64.v += delta
+	newvalue = f64.v
+	f64.mu.Unlock()
+	return
+}
+
+// Load behaves like LoadInt64.Load buf for float64
+func (f64 *Float64) Load() (v float64) {
+	f64.mu.Lock()
+	v = f64.v
+	f64.mu.Unlock()
+	return
+}

--- a/atomicx/atomicx_test.go
+++ b/atomicx/atomicx_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ooni/probe-engine/atomicx"
 )
 
-func TestIntegration(t *testing.T) {
+func TestIntegrationInt64(t *testing.T) {
 	// TODO(bassosimone): how to write tests with race conditions
 	// and be confident that they're WAI? Here I hope this test is
 	// run with `-race` and I'm doing something that AFAICT will
@@ -24,6 +24,27 @@ func TestIntegration(t *testing.T) {
 		t.Fatal("unexpected result")
 	}
 	if v.Load() != 34 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationFloat64(t *testing.T) {
+	// TODO(bassosimone): how to write tests with race conditions
+	// and be confident that they're WAI? Here I hope this test is
+	// run with `-race` and I'm doing something that AFAICT will
+	// be flagged as race if we were not be using mutexes.
+	v := atomicx.NewFloat64()
+	go func() {
+		v.Add(17.0)
+	}()
+	go func() {
+		v.Add(14.0)
+	}()
+	time.Sleep(1 * time.Second)
+	if r := v.Add(3); r < 33.9 && r > 34.1 {
+		t.Fatal("unexpected result")
+	}
+	if v.Load() < 33.9 && v.Load() > 34.1 {
 		t.Fatal("unexpected result")
 	}
 }

--- a/cmd/miniooni/main.go
+++ b/cmd/miniooni/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/apex/log"
+	"github.com/dustin/go-humanize"
 	engine "github.com/ooni/probe-engine"
 	"github.com/pborman/getopt/v2"
 )
@@ -209,7 +210,13 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("cannot create measurement session")
 	}
-	defer sess.Close()
+	defer func() {
+		sess.Close()
+		log.Infof("whole session: recv %s, sent %s",
+			humanize.SI(sess.KiBsReceived()*1024, "byte"),
+			humanize.SI(sess.KiBsSent()*1024, "byte"),
+		)
+	}()
 
 	if globalOptions.bouncerURL != "" {
 		sess.AddAvailableHTTPSBouncer(globalOptions.bouncerURL)

--- a/experiment/handler/handler.go
+++ b/experiment/handler/handler.go
@@ -2,6 +2,7 @@
 package handler
 
 import (
+	"github.com/dustin/go-humanize"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -17,7 +18,10 @@ func NewPrinterCallbacks(logger model.Logger) PrinterCallbacks {
 
 // OnDataUsage provides information about data usage.
 func (d PrinterCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
-	d.Logger.Infof("data usage: %.1f/%.1f down/up KiB", dloadKiB, uploadKiB)
+	d.Logger.Infof("experiment: recv %s, sent %s",
+		humanize.SI(dloadKiB*1024, "byte"),
+		humanize.SI(uploadKiB*1024, "byte"),
+	)
 }
 
 // OnProgress provides information about an experiment progress.

--- a/model/model.go
+++ b/model/model.go
@@ -353,7 +353,7 @@ type ExperimentSession interface {
 	UserAgent() string
 }
 
-// ExperimentCallbacks contains event handling callbacks
+// ExperimentCallbacks contains experiment event-handling callbacks
 type ExperimentCallbacks interface {
 	// OnDataUsage provides information about data usage.
 	OnDataUsage(dloadKiB, uploadKiB float64)


### PR DESCRIPTION
Experiments still report the bytes sent and received by them. Session
has the whole view and knows both about tests and all the other interactions
that occur as part of the session itself.

When doing this, I stumbled upon issues that I've documented:

1. https://github.com/ooni/probe-engine/issues/416

2. https://github.com/ooni/probe-engine/issues/417

They will be addressed soon.