### PR TITLE
publish-android.bash: use more readable version number

### DIFF
--- a/publish-android.bash
+++ b/publish-android.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 pkgname=oonimkall
-version=$(date -u +%Y.%m.%d-%H%M%S)
+version=0.9.0-SNAPSHOT
 baseurl=https://api.bintray.com/content/ooni/android/$pkgname/$version/org/ooni/$pkgname/$version
 aarfile=./MOBILE/dist/$pkgname.aar
 pomfile=./MOBILE/dist/$pkgname-$version.pom

--- a/publish-android.bash
+++ b/publish-android.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 pkgname=oonimkall
-version=$(date -u +%Y%m%dT%H%M%SZ)
+version=$(date -u +%Y.%m.%d-%H%M%S)
 baseurl=https://api.bintray.com/content/ooni/android/$pkgname/$version/org/ooni/$pkgname/$version
 aarfile=./MOBILE/dist/$pkgname.aar
 pomfile=./MOBILE/dist/$pkgname-$version.pom

--- a/publish-android.bash
+++ b/publish-android.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 pkgname=oonimkall
-version=0.9.0-SNAPSHOT
+version=$(date -u +%Y.%m.%d-%H%M%S)
 baseurl=https://api.bintray.com/content/ooni/android/$pkgname/$version/org/ooni/$pkgname/$version
 aarfile=./MOBILE/dist/$pkgname.aar
 pomfile=./MOBILE/dist/$pkgname-$version.pom


### PR DESCRIPTION
This is related to https://github.com/ooni/probe-engine/issues/376, which actually can already be closed, it seems, because now I'm able to fetch the AAR package from bintray.