### PR TITLE
Reject all MK settings we don't support

### DIFF
--- a/oonimkall/runner.go
+++ b/oonimkall/runner.go
@@ -194,8 +194,6 @@ func (cb *runnerCallbacks) OnProgress(percentage float64, message string) {
 // when to stop when processing multiple inputs, as well as when to stop
 // experiments explicitly marked as interruptible.
 func (r *runner) Run(ctx context.Context) {
-	// TODO(bassosimone): intercept all options we ignore
-
 	logger := newChanLogger(r.emitter, r.settings.LogLevel, r.out)
 	r.emitter.Emit(statusQueued, eventEmpty{})
 	if r.hasUnsupportedSettings(logger) {
@@ -215,8 +213,6 @@ func (r *runner) Run(ctx context.Context) {
 		})
 	}()
 
-	// TODO(bassosimone): set experiment options here
-	// TODO(bassosimone): we should probably also set callbacks here?
 	builder, err := sess.NewExperimentBuilder(r.settings.Name)
 	if err != nil {
 		r.emitter.EmitFailureStartup(err.Error())

--- a/oonimkall/runner.go
+++ b/oonimkall/runner.go
@@ -56,17 +56,62 @@ func (r *runner) hasUnsupportedSettings(logger *chanLogger) (unsupported bool) {
 	if r.settings.InputFilepaths != nil {
 		sadly("InputFilepaths: not supported")
 	}
+	if r.settings.Options.AllEndpoints != nil {
+		sadly("Options.AllEndpoints: not supported")
+	}
 	if r.settings.Options.Backend != "" {
 		sadly("Options.Backend: not supported")
 	}
 	if r.settings.Options.CABundlePath != "" {
 		logger.Warn("Options.CABundlePath: not supported")
 	}
+	if r.settings.Options.ConstantBitrate != nil {
+		logger.Warn("Options.ConstantBitrate: not supported")
+	}
+	if r.settings.Options.DNSNameserver != nil {
+		logger.Warn("Options.DNSNameserver: not supported")
+	}
+	if r.settings.Options.DNSEngine != nil {
+		logger.Warn("Options.DNSEngine: not supported")
+	}
+	if r.settings.Options.ExpectedBody != nil {
+		logger.Warn("Options.ExpectedBody: not supported")
+	}
 	if r.settings.Options.GeoIPASNPath != "" {
 		logger.Warn("Options.GeoIPASNPath: not supported")
 	}
 	if r.settings.Options.GeoIPCountryPath != "" {
 		logger.Warn("Options.GeoIPCountryPath: not supported")
+	}
+	if r.settings.Options.Hostname != nil {
+		logger.Warn("Options.Hostname: not supported")
+	}
+	if r.settings.Options.IgnoreBouncerError != nil {
+		logger.Warn("Options.IgnoreBouncerError: not supported")
+	}
+	if r.settings.Options.IgnoreOpenReportError != nil {
+		logger.Warn("Options.IgnoreOpenReportError: not supported")
+	}
+	if r.settings.Options.MLabNSAddressFamily != nil {
+		logger.Warn("Options.MLabNSAddressFamily: not supported")
+	}
+	if r.settings.Options.MLabNSBaseURL != nil {
+		logger.Warn("Options.MLabNSBaseURL: not supported")
+	}
+	if r.settings.Options.MLabNSCountry != nil {
+		logger.Warn("Options.MLabNSCountry: not supported")
+	}
+	if r.settings.Options.MLabNSMetro != nil {
+		logger.Warn("Options.MLabNSMetro: not supported")
+	}
+	if r.settings.Options.MLabNSPolicy != nil {
+		logger.Warn("Options.MLabNSPolicy: not supported")
+	}
+	if r.settings.Options.MLabNSToolName != nil {
+		logger.Warn("Options.MLabNSToolName: not supported")
+	}
+	if r.settings.Options.Port != nil {
+		sadly("Options.Port: not supported")
 	}
 	if r.settings.Options.ProbeASN != "" {
 		logger.Warn("Options.ProbeASN: not supported")
@@ -82,6 +127,21 @@ func (r *runner) hasUnsupportedSettings(logger *chanLogger) (unsupported bool) {
 	}
 	if r.settings.Options.RandomizeInput != false {
 		sadly("Options.RandomizeInput: not supported")
+	}
+	if r.settings.Options.SaveRealResolverIP != nil {
+		sadly("Options.SaveRealResolverIP: not supported")
+	}
+	if r.settings.Options.Server != nil {
+		sadly("Options.Server: not supported")
+	}
+	if r.settings.Options.TestSuite != nil {
+		sadly("Options.TestSuite: not supported")
+	}
+	if r.settings.Options.Timeout != nil {
+		sadly("Options.Timeout: not supported")
+	}
+	if r.settings.Options.UUID != nil {
+		sadly("Options.UUID: not supported")
 	}
 	if r.settings.OutputFilepath != "" && r.settings.Options.NoFileReport == false {
 		sadly("OutputFilepath && !NoFileReport: not supported")

--- a/oonimkall/runner_test.go
+++ b/oonimkall/runner_test.go
@@ -13,19 +13,43 @@ import (
 
 func TestUnitRunnerHasUnsupportedSettings(t *testing.T) {
 	out := make(chan *eventRecord)
+	var falsebool bool
+	var zerodotzero float64
+	var zero int64
+	var emptystring string
 	settings := &settingsRecord{
 		InputFilepaths: []string{"foo"},
 		Options: settingsOptions{
-			Backend:          "foo",
-			CABundlePath:     "foo",
-			GeoIPASNPath:     "foo",
-			GeoIPCountryPath: "foo",
-			NoFileReport:     false,
-			ProbeASN:         "AS0",
-			ProbeCC:          "ZZ",
-			ProbeIP:          "127.0.0.1",
-			ProbeNetworkName: "XXX",
-			RandomizeInput:   true,
+			AllEndpoints:          &falsebool,
+			Backend:               "foo",
+			CABundlePath:          "foo",
+			ConstantBitrate:       &falsebool,
+			DNSNameserver:         &emptystring,
+			DNSEngine:             &emptystring,
+			ExpectedBody:          &emptystring,
+			GeoIPASNPath:          "foo",
+			GeoIPCountryPath:      "foo",
+			Hostname:              &emptystring,
+			IgnoreBouncerError:    &falsebool,
+			IgnoreOpenReportError: &falsebool,
+			MLabNSAddressFamily:   &emptystring,
+			MLabNSBaseURL:         &emptystring,
+			MLabNSCountry:         &emptystring,
+			MLabNSMetro:           &emptystring,
+			MLabNSPolicy:          &emptystring,
+			MLabNSToolName:        &emptystring,
+			NoFileReport:          false,
+			Port:                  &zero,
+			ProbeASN:              "AS0",
+			ProbeCC:               "ZZ",
+			ProbeIP:               "127.0.0.1",
+			ProbeNetworkName:      "XXX",
+			RandomizeInput:        true,
+			SaveRealResolverIP:    &falsebool,
+			Server:                &emptystring,
+			TestSuite:             &zero,
+			Timeout:               &zerodotzero,
+			UUID:                  &emptystring,
 		},
 		OutputFilepath: "foo",
 	}
@@ -56,7 +80,7 @@ func TestUnitRunnerHasUnsupportedSettings(t *testing.T) {
 			log.Fatalf("invalid key: %s", ev.Key)
 		}
 	}
-	const expected = 11
+	const expected = 31
 	if len(seen) != expected {
 		t.Fatalf("expected: %d; seen %+v", expected, seen)
 	}

--- a/oonimkall/settings.go
+++ b/oonimkall/settings.go
@@ -55,6 +55,12 @@ type settingsRecord struct {
 
 // settingsOptions contains the settings options
 type settingsOptions struct {
+	// AllEndpoints is a WhatsApp specific option indicating that we
+	// should test all endpoints rather than a random susbet. This
+	// library does not support this setting and fails if you provide
+	// it as input.
+	AllEndpoints *bool `json:"all_endpoints,omitempty"`
+
 	// Backend is a test helper for a nettest. This
 	// option is not implemented by this library. Attempting
 	// to set it will cause a startup error.
@@ -72,6 +78,23 @@ type settingsOptions struct {
 	// CollectorBaseURL contains the collector base URL
 	CollectorBaseURL string `json:"collector_base_url,omitempty"`
 
+	// ConstantBitrate was an option for the DASH experiment that
+	// this library does not support. Setting it to any value will
+	// cause the code to stop early with a startup failure.
+	ConstantBitrate *bool `json:"constant_bitrate,omitempty"`
+
+	// DNSNameserver is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	DNSNameserver *string `json:"dns_nameserver,omitempty"`
+
+	// DNSEngine is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	DNSEngine *string `json:"dns_engine,omitempty"`
+
+	// ExpectedBody is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	ExpectedBody *string `json:"expected_body,omitempty"`
+
 	// GeoIPASNPath is the ASN database path. This
 	// option is not implemented by this library. Attempting
 	// to set it will cause a startup warning, and the
@@ -84,10 +107,48 @@ type settingsOptions struct {
 	// library will otherwise ignore this setting.
 	GeoIPCountryPath string `json:"geoip_country_path,omitempty"`
 
+	// Hostname is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	Hostname *string `json:"hostname,omitempty"`
+
+	// IgnoreBouncerError is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	IgnoreBouncerError *bool `json:"ignore_bouncer_error,omitempty"`
+
+	// IgnoreOpenReportError is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	IgnoreOpenReportError *bool `json:"ignore_open_report_error,omitempty"`
+
 	// MaxRuntime is the maximum runtime expressed. A negative
-	// value for this filed disables the maximum runtime. Using
-	// a zero value will cause the task to fail quickly.
-	MaxRuntime float32 `json:"max_runtime,omitempty"`
+	// value for this field disables the maximum runtime. Using
+	// a zero value will also mean disabled. This is not the
+	// original behaviour of Measurement Kit, which used to run
+	// for zero time in such case.
+	MaxRuntime float64 `json:"max_runtime,omitempty"`
+
+	// MLabNSAddressFamily is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	MLabNSAddressFamily *string `json:"mlabns/address_family,omitempty"`
+
+	// MLabNSBaseURL is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	MLabNSBaseURL *string `json:"mlabns/base_url,omitempty"`
+
+	// MLabNSCountry is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	MLabNSCountry *string `json:"mlabns/country,omitempty"`
+
+	// MLabNSMetro is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	MLabNSMetro *string `json:"mlabns/metro,omitempty"`
+
+	// MLabNSPolicy is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	MLabNSPolicy *string `json:"mlabns/policy,omitempty"`
+
+	// MLabNSToolName is a legacy option that this library does
+	// not support. Setting it causes the experiment to fail.
+	MLabNSToolName *string `json:"mlabns_tool_name,omitempty"`
 
 	// NoBouncer indicates whether to use a bouncer
 	NoBouncer bool `json:"no_bouncer,omitempty"`
@@ -110,6 +171,10 @@ type settingsOptions struct {
 	// library fails if NoGeoIP and NoResolverLookup have different
 	// values since these two steps are performed together.
 	NoResolverLookup bool `json:"no_resolver_lookup"`
+
+	// Port is the port used by performance tests. This library does not
+	// support this option and fails if it is set by the user.
+	Port *int64 `json:"port"`
 
 	// ProbeASN is the AS number. This
 	// option is not implemented by this library. Attempting
@@ -140,14 +205,23 @@ type settingsOptions struct {
 	// to set it to true will cause a startup error.
 	RandomizeInput bool `json:"randomize_input,omitempty"`
 
-	// SaveRealProbeIP indicates whether to save the real probe IP
-	SaveRealProbeIP bool `json:"save_real_probe_ip,omitempty"`
-
 	// SaveRealProbeIP indicates whether to save the real probe ASN
 	SaveRealProbeASN bool `json:"save_real_probe_asn,omitempty"`
 
 	// SaveRealProbeCC indicates whether to save the real probe CC
 	SaveRealProbeCC bool `json:"save_real_probe_cc,omitempty"`
+
+	// SaveRealProbeIP indicates whether to save the real probe IP
+	SaveRealProbeIP bool `json:"save_real_probe_ip,omitempty"`
+
+	// SaveRealResolverIP is a legacy option that this library
+	// does not support. We will stop if you provide it.
+	SaveRealResolverIP *bool `json:"save_real_resolver_ip,omitempty"`
+
+	// Server is used by performance tests to indicate the specific
+	// hostname that shall be used for the server. This library does
+	// not support this setting and fails if you provide it.
+	Server *string `json:"server,omitempty"`
 
 	// SoftwareName is the software name. If this option is not
 	// present, then the library startup will fail.
@@ -156,4 +230,13 @@ type settingsOptions struct {
 	// SoftwareVersion is the software version. If this option is not
 	// present, then the library startup will fail.
 	SoftwareVersion string `json:"software_version,omitempty"`
+
+	// TestSuite is a legacy option that this library does not support.
+	TestSuite *int64 `json:"test_suite,omitempty"`
+
+	// Timeout is a legacy option that this library does not support.
+	Timeout *float64 `json:"timeout,omitempty"`
+
+	// UUID is a legacy option that this library does not support.
+	UUID *string `json:"uuid,omitempty"`
 }


### PR DESCRIPTION
Everything that does not matter to the OONI mobile app has not been
implemented and is explicitly rejected. We may add support for several
other options if there is demand, of course.

Closes https://github.com/ooni/probe-engine/issues/352

Closes https://github.com/ooni/probe-engine/issues/349