### PR TITLE
Android workflow only runs on the master branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,8 @@
 name: android
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   test:
     runs-on: "${{ matrix.os }}"


### PR DESCRIPTION
We are not changing the external API dramatically and we would like the
snapshots published at bintray to only be using master.

Because breaking Go mobile is difficult, this seems okay.

We could do something more complex, but I am happy with the fact that
it's possible to use the latest snapshot of master.

We already have lots of CI in place, so doing that seems okay.

Part of https://github.com/ooni/probe-engine/issues/376.