### PR TITLE
netx/dialer: reduce coupling between dnsdialer and dialerbase

### DIFF
--- a/netx/dialer/dialerbase.go
+++ b/netx/dialer/dialerbase.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/netx/internal/connid"
-	"github.com/ooni/probe-engine/netx/internal/errwrapper"
+	"github.com/ooni/probe-engine/netx/internal/dialid"
 	"github.com/ooni/probe-engine/netx/internal/transactionid"
 	"github.com/ooni/probe-engine/netx/modelx"
 )
@@ -17,7 +17,6 @@ type BaseDialer struct {
 	dialer    modelx.Dialer
 	beginning time.Time
 	handler   modelx.Handler
-	dialID    int64
 }
 
 // NewBaseDialer creates a new BaseDialer
@@ -25,13 +24,11 @@ func NewBaseDialer(
 	beginning time.Time,
 	handler modelx.Handler,
 	dialer modelx.Dialer,
-	dialID int64,
 ) *BaseDialer {
 	return &BaseDialer{
 		dialer:    dialer,
 		beginning: beginning,
 		handler:   handler,
-		dialID:    dialID,
 	}
 }
 
@@ -44,25 +41,16 @@ func (d *BaseDialer) Dial(network, address string) (net.Conn, error) {
 func (d *BaseDialer) DialContext(
 	ctx context.Context, network, address string,
 ) (net.Conn, error) {
-	// this is the same timeout used by Go's net/http.DefaultTransport
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
+	dialID := dialid.ContextDialID(ctx)
 	start := time.Now()
 	conn, err := d.dialer.DialContext(ctx, network, address)
 	stop := time.Now()
-	err = errwrapper.SafeErrWrapperBuilder{
-		// ConnID does not make any sense if we've failed and the error
-		// does not make any sense (and is nil) if we succeded.
-		DialID:    d.dialID,
-		Error:     err,
-		Operation: "connect",
-	}.MaybeBuild()
 	connID := safeConnID(network, conn)
 	txID := transactionid.ContextTransactionID(ctx)
 	d.handler.OnMeasurement(modelx.Measurement{
 		Connect: &modelx.ConnectEvent{
 			ConnID:                 connID,
-			DialID:                 d.dialID,
+			DialID:                 dialID,
 			DurationSinceBeginning: stop.Sub(d.beginning),
 			Error:                  err,
 			Network:                network,

--- a/netx/dialer/dialerbase_test.go
+++ b/netx/dialer/dialerbase_test.go
@@ -38,6 +38,6 @@ func TestIntegrationBaseDialerErrorNoConnect(t *testing.T) {
 // see whether we implement the interface
 func newBaseDialer() modelx.Dialer {
 	return NewBaseDialer(
-		time.Now(), handlers.NoHandler, new(net.Dialer), 17,
+		time.Now(), handlers.NoHandler, new(net.Dialer),
 	)
 }

--- a/netx/dialer/dnsdialer.go
+++ b/netx/dialer/dnsdialer.go
@@ -41,7 +41,6 @@ func (d *DNSDialer) DialContext(
 		return nil, err
 	}
 	ctx = dialid.WithDialID(ctx) // important to create before lookupHost
-	dialID := dialid.ContextDialID(ctx)
 	var addrs []string
 	addrs, err = d.lookupHost(ctx, onlyhost)
 	if err != nil {
@@ -50,7 +49,7 @@ func (d *DNSDialer) DialContext(
 	var errorslist []error
 	for _, addr := range addrs {
 		dialer := NewBaseDialer(
-			root.Beginning, root.Handler, d.dialer, dialID,
+			root.Beginning, root.Handler, d.dialer,
 		)
 		target := net.JoinHostPort(addr, onlyport)
 		conn, err = dialer.DialContext(ctx, network, target)

--- a/netx/dialer/tlsdialer_test.go
+++ b/netx/dialer/tlsdialer_test.go
@@ -26,7 +26,7 @@ func TestIntegrationTLSDialerSuccess(t *testing.T) {
 func TestIntegrationTLSDialerSuccessWithMeasuringConn(t *testing.T) {
 	dialer := newTLSDialer()
 	dialer.(*TLSDialer).dialer = NewBaseDialer(
-		time.Now(), handlers.NoHandler, new(net.Dialer), 17,
+		time.Now(), handlers.NoHandler, new(net.Dialer),
 	)
 	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
 	if err != nil {


### PR DESCRIPTION
This allows me in the next commits to split dialerbase in a bunch of
smaller and much more independent decorators.

Part of https://github.com/ooni/probe-engine/issues/125