### PR TITLE
netx/dialer: remove unnecessary TLSDialer timeout

### DIFF
--- a/netx/dialer/tls.go
+++ b/netx/dialer/tls.go
@@ -12,7 +12,6 @@ import (
 
 // TLSDialer is the TLS dialer
 type TLSDialer struct {
-	ConnectTimeout      time.Duration // default: 30 second
 	TLSHandshakeTimeout time.Duration // default: 10 second
 	config              *tls.Config
 	dialer              modelx.Dialer
@@ -22,7 +21,6 @@ type TLSDialer struct {
 // NewTLSDialer creates a new TLSDialer
 func NewTLSDialer(dialer modelx.Dialer, config *tls.Config) *TLSDialer {
 	return &TLSDialer{
-		ConnectTimeout:      30 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
 		config:              config,
 		dialer:              dialer,
@@ -34,8 +32,7 @@ func NewTLSDialer(dialer modelx.Dialer, config *tls.Config) *TLSDialer {
 
 // DialTLS dials a new TLS connection
 func (d *TLSDialer) DialTLS(network, address string) (net.Conn, error) {
-	ctx := context.Background()
-	return d.DialTLSContext(ctx, network, address)
+	return d.DialTLSContext(context.Background(), network, address)
 }
 
 // DialTLSContext is like DialTLS, but with context
@@ -46,8 +43,6 @@ func (d *TLSDialer) DialTLSContext(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(ctx, d.ConnectTimeout)
-	defer cancel()
 	conn, err := d.dialer.DialContext(ctx, network, address)
 	if err != nil {
 		return nil, err

--- a/netx/dialer/tls_test.go
+++ b/netx/dialer/tls_test.go
@@ -1,6 +1,7 @@
 package dialer
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"net"
@@ -47,9 +48,10 @@ func TestIntegrationTLSDialerFailureSplitHostPort(t *testing.T) {
 }
 
 func TestIntegrationTLSDialerFailureConnectTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cause immediate timeout
 	dialer := newTLSDialer()
-	dialer.(*TLSDialer).ConnectTimeout = 10 * time.Microsecond
-	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
+	conn, err := dialer.DialTLSContext(ctx, "tcp", "www.google.com:443")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}


### PR DESCRIPTION
When we construct a TLS dialer in netx/dialer.go we're already setting up
everything such that there is a connect timeout.

No need to do that twice.

Yak shaving for https://github.com/ooni/probe-engine/issues/125.