### PR TITLE
netx/dialer: don't depend on modelx for our interfaces

### DIFF
--- a/netx/dialer.go
+++ b/netx/dialer.go
@@ -69,7 +69,7 @@ func (d *Dialer) DialTLS(network, address string) (net.Conn, error) {
 	return d.DialTLSContext(context.Background(), network, address)
 }
 
-func newFullDialer(resolver modelx.DNSResolver) modelx.Dialer {
+func newFullDialer(resolver modelx.DNSResolver) dialer.Dialer {
 	return dialer.DNSDialer{
 		Dialer: dialer.MeasuringDialer{
 			Dialer: dialer.EmitterDialer{

--- a/netx/dialer/base.go
+++ b/netx/dialer/base.go
@@ -12,9 +12,22 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
+// Dialer is a dialer for network connections.
+type Dialer interface {
+	// DialContext is like Dial but with context
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Resolver is a DNS resolver. The *net.Resolver used by Go implements
+// this interface, but other implementations are possible.
+type Resolver interface {
+	// LookupHost resolves a hostname to a list of IP addresses.
+	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+}
+
 // TimeoutDialer is a wrapper for the system dialer
 type TimeoutDialer struct {
-	modelx.Dialer
+	Dialer
 	ConnectTimeout time.Duration // default: 30 seconds
 }
 
@@ -31,7 +44,7 @@ func (d TimeoutDialer) DialContext(ctx context.Context, network, address string)
 
 // ErrWrapperDialer is a dialer that performs err wrapping
 type ErrWrapperDialer struct {
-	modelx.Dialer
+	Dialer
 }
 
 // DialContext implements Dialer.DialContext
@@ -50,7 +63,7 @@ func (d ErrWrapperDialer) DialContext(ctx context.Context, network, address stri
 
 // EmitterDialer is a dialer that emits events
 type EmitterDialer struct {
-	modelx.Dialer
+	Dialer
 }
 
 // DialContext implements Dialer.DialContext
@@ -87,7 +100,7 @@ func safeConnID(network string, conn net.Conn) int64 {
 
 // MeasuringDialer is a dialer that measures the underlying connection
 type MeasuringDialer struct {
-	modelx.Dialer
+	Dialer
 }
 
 // DialContext implements Dialer.DialContext

--- a/netx/dialer/base_test.go
+++ b/netx/dialer/base_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/netx/handlers"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 func TestIntegrationBaseDialerSuccess(t *testing.T) {
@@ -36,7 +35,7 @@ func TestIntegrationBaseDialerErrorNoConnect(t *testing.T) {
 }
 
 // see whether we implement the interface
-func newBaseDialer() modelx.Dialer {
+func newBaseDialer() Dialer {
 	return MeasuringDialer{
 		Dialer: EmitterDialer{
 			Dialer: ErrWrapperDialer{

--- a/netx/dialer/dns.go
+++ b/netx/dialer/dns.go
@@ -13,8 +13,8 @@ import (
 // DNSDialer defines the dialer API. We implement the most basic form
 // of DNS, but more advanced resolutions are possible.
 type DNSDialer struct {
-	modelx.Dialer
-	Resolver modelx.DNSResolver
+	Dialer
+	Resolver Resolver
 }
 
 // DialContext is like Dial but the context allows to interrupt a

--- a/netx/dialer/dns_test.go
+++ b/netx/dialer/dns_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestIntegrationDNSDialerDial(t *testing.T) {
 	dialer := DNSDialer{Dialer: new(net.Dialer), Resolver: new(net.Resolver)}
-	conn, err := dialer.Dial("tcp", "www.google.com:80")
+	conn, err := dialer.DialContext(context.Background(), "tcp", "www.google.com:80")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +22,7 @@ func TestIntegrationDNSDialerDial(t *testing.T) {
 
 func TestIntegrationDNSDialerDialAddress(t *testing.T) {
 	dialer := DNSDialer{Dialer: new(net.Dialer), Resolver: new(net.Resolver)}
-	conn, err := dialer.Dial("tcp", "8.8.8.8:853")
+	conn, err := dialer.DialContext(context.Background(), "tcp", "8.8.8.8:853")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestIntegrationDNSDialerDialAddress(t *testing.T) {
 
 func TestIntegrationDNSDialerNoPort(t *testing.T) {
 	dialer := DNSDialer{Dialer: new(net.Dialer), Resolver: new(net.Resolver)}
-	conn, err := dialer.Dial("tcp", "antani.ooni.io")
+	conn, err := dialer.DialContext(context.Background(), "tcp", "antani.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -42,7 +42,7 @@ func TestIntegrationDNSDialerNoPort(t *testing.T) {
 
 func TestIntegrationDNSDialerLookupFailure(t *testing.T) {
 	dialer := DNSDialer{Dialer: new(net.Dialer), Resolver: new(net.Resolver)}
-	conn, err := dialer.Dial("tcp", "antani.ooni.io:443")
+	conn, err := dialer.DialContext(context.Background(), "tcp", "antani.ooni.io:443")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/netx/dialer/tls.go
+++ b/netx/dialer/tls.go
@@ -100,12 +100,12 @@ func (h TLSHandshakerEmitter) Handshake(
 // TLSDialer is the TLS dialer
 type TLSDialer struct {
 	Config        *tls.Config
-	Dialer        modelx.Dialer
+	Dialer        Dialer
 	TLSHandshaker TLSHandshaker
 }
 
 // NewTLSDialer creates a new TLSDialer
-func NewTLSDialer(dialer modelx.Dialer, config *tls.Config) TLSDialer {
+func NewTLSDialer(dialer Dialer, config *tls.Config) TLSDialer {
 	return TLSDialer{
 		Config: config,
 		Dialer: dialer,
@@ -115,11 +115,6 @@ func NewTLSDialer(dialer modelx.Dialer, config *tls.Config) TLSDialer {
 			},
 		},
 	}
-}
-
-// DialTLS dials a new TLS connection
-func (d TLSDialer) DialTLS(network, address string) (net.Conn, error) {
-	return d.DialTLSContext(context.Background(), network, address)
 }
 
 // DialTLSContext is like DialTLS, but with context

--- a/netx/dialer/tls_test.go
+++ b/netx/dialer/tls_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestIntegrationTLSDialerSuccess(t *testing.T) {
 	dialer := dialer.NewTLSDialer(new(net.Dialer), new(tls.Config))
-	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
+	conn, err := dialer.DialTLSContext(context.Background(), "tcp", "www.google.com:443")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func TestIntegrationTLSDialerSuccess(t *testing.T) {
 
 func TestIntegrationTLSDialerNilConfig(t *testing.T) {
 	dialer := dialer.NewTLSDialer(new(net.Dialer), nil)
-	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
+	conn, err := dialer.DialTLSContext(context.Background(), "tcp", "www.google.com:443")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestIntegrationTLSDialerNilConfig(t *testing.T) {
 
 func TestIntegrationTLSDialerFailureSplitHostPort(t *testing.T) {
 	dialer := dialer.NewTLSDialer(new(net.Dialer), new(tls.Config))
-	conn, err := dialer.DialTLS("tcp", "www.google.com") // missing port
+	conn, err := dialer.DialTLSContext(context.Background(), "tcp", "www.google.com") // missing port
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -66,7 +66,7 @@ func TestIntegrationTLSDialerFailureTLSHandshakeTimeout(t *testing.T) {
 			HandshakeTimeout: time.Microsecond,
 		},
 	}
-	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
+	conn, err := dialer.DialTLSContext(context.Background(), "tcp", "www.google.com:443")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -77,7 +77,7 @@ func TestIntegrationTLSDialerFailureTLSHandshakeTimeout(t *testing.T) {
 
 func TestIntegrationTLSDialerFailureTLSHandshakeFailure(t *testing.T) {
 	dialer := dialer.NewTLSDialer(new(net.Dialer), new(tls.Config))
-	conn, err := dialer.DialTLS("tcp", "self-signed.badssl.com:443")
+	conn, err := dialer.DialTLSContext(context.Background(), "tcp", "self-signed.badssl.com:443")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}


### PR DESCRIPTION
Implements the "interface defined by user" rule.

Part of https://github.com/ooni/probe-engine/issues/125