### PR TITLE
fix(netx/dialer/dns.go): use unknown_failure not unknown_error

### DIFF
--- a/netx/dialer/dns.go
+++ b/netx/dialer/dns.go
@@ -58,7 +58,7 @@ func reduceErrors(errorslist []error) error {
 	for _, err := range errorslist {
 		var wrapper *modelx.ErrWrapper
 		if errors.As(err, &wrapper) && !strings.HasPrefix(
-			err.Error(), "unknown_error",
+			err.Error(), "unknown_failure",
 		) {
 			return err
 		}

--- a/netx/dialer/dns_test.go
+++ b/netx/dialer/dns_test.go
@@ -95,7 +95,7 @@ func TestUnitReduceErrors(t *testing.T) {
 	t.Run("multiple errors with meaningful ones", func(t *testing.T) {
 		err1 := errors.New("mocked error #1")
 		err2 := &modelx.ErrWrapper{
-			Failure: "unknown_error: antani",
+			Failure: "unknown_failure: antani",
 		}
 		err3 := &modelx.ErrWrapper{
 			Failure: modelx.FailureConnectionRefused,


### PR DESCRIPTION
This ensures we're using the correct string.

Spotted when working on https://github.com/ooni/probe-engine/issues/125