### PR TITLE
Only build for Android from the mobile-staging branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: android
 on:
   push:
     branches:
-      - master
+      - mobile-staging
 jobs:
   test:
     runs-on: "${{ matrix.os }}"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ maven { url "https://dl.bintray.com/ooni/android/" }
 and
 
 ```Groovy
-implementation 'org.ooni:oonimkall:VERSION'
+implementation "org.ooni:oonimkall:VERSION"
 ```
 
 Where VERSION is like `2020.03.30-231914` corresponding to the moment in

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Omit `-tags nomk` to link with MK.
 ```
 
 When building Android bindings, we automatically omit linking with MK. We
-automatically build Android brindings whenever commits are pushed to the
+automatically build Android bindings whenever commits are pushed to the
 `mobile-staging` branch. Such builds could be integrated by using:
 
 ```Groovy

--- a/README.md
+++ b/README.md
@@ -51,7 +51,22 @@ Omit `-tags nomk` to link with MK.
 ./build-android.bash
 ```
 
-When building Android bindings, we automatically omit linking with MK.
+When building Android bindings, we automatically omit linking with MK. We
+automatically build Android brindings whenever commits are pushed to the
+`mobile-staging` branch. Such builds could be integrated by using:
+
+```Groovy
+maven { url "https://dl.bintray.com/ooni/android/" }
+```
+
+and
+
+```Groovy
+implementation 'org.ooni:oonimkall:VERSION'
+```
+
+Where VERSION is like `2020.03.30-231914` corresponding to the moment in
+time in which the version has been built.
 
 ## Release procedure
 


### PR DESCRIPTION
This strategy is like the one adopted by Psiphon where they have
a staging branch into which they merge master. Such branch is tracking
the moments in time when the client is reasonably stable.

Likewise, we'll do the same for mobile. Our master branch is anyway
generally stable, because we're already doing CI and we're going
to improve upon that in the future.

Closes https://github.com/ooni/probe-engine/issues/376