### PR TITLE
refactor(netx/dialer): don't name non-errors ErrSomething

### DIFF
--- a/netx/dialer/base.go
+++ b/netx/dialer/base.go
@@ -42,13 +42,13 @@ func (d TimeoutDialer) DialContext(ctx context.Context, network, address string)
 	return d.Dialer.DialContext(ctx, network, address)
 }
 
-// ErrWrapperDialer is a dialer that performs err wrapping
-type ErrWrapperDialer struct {
+// ErrorWrapperDialer is a dialer that performs err wrapping
+type ErrorWrapperDialer struct {
 	Dialer
 }
 
 // DialContext implements Dialer.DialContext
-func (d ErrWrapperDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (d ErrorWrapperDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	dialID := dialid.ContextDialID(ctx)
 	conn, err := d.Dialer.DialContext(ctx, network, address)
 	err = errwrapper.SafeErrWrapperBuilder{
@@ -61,17 +61,17 @@ func (d ErrWrapperDialer) DialContext(ctx context.Context, network, address stri
 	if err != nil {
 		return nil, err
 	}
-	return &ErrWrapperConn{Conn: conn, ID: safeConnID(network, conn)}, err
+	return &ErrorWrapperConn{Conn: conn, ID: safeConnID(network, conn)}, err
 }
 
-// ErrWrapperConn is a net.Conn that performs error wrapping.
-type ErrWrapperConn struct {
+// ErrorWrapperConn is a net.Conn that performs error wrapping.
+type ErrorWrapperConn struct {
 	net.Conn
 	ID int64
 }
 
 // Read reads data from the connection.
-func (c ErrWrapperConn) Read(b []byte) (n int, err error) {
+func (c ErrorWrapperConn) Read(b []byte) (n int, err error) {
 	n, err = c.Conn.Read(b)
 	err = errwrapper.SafeErrWrapperBuilder{
 		ConnID:    c.ID,
@@ -82,7 +82,7 @@ func (c ErrWrapperConn) Read(b []byte) (n int, err error) {
 }
 
 // Write writes data to the connection
-func (c ErrWrapperConn) Write(b []byte) (n int, err error) {
+func (c ErrorWrapperConn) Write(b []byte) (n int, err error) {
 	n, err = c.Conn.Write(b)
 	err = errwrapper.SafeErrWrapperBuilder{
 		ConnID:    c.ID,
@@ -93,7 +93,7 @@ func (c ErrWrapperConn) Write(b []byte) (n int, err error) {
 }
 
 // Close closes the connection
-func (c ErrWrapperConn) Close() (err error) {
+func (c ErrorWrapperConn) Close() (err error) {
 	err = c.Conn.Close()
 	err = errwrapper.SafeErrWrapperBuilder{
 		ConnID:    c.ID,

--- a/netx/dialer/base_test.go
+++ b/netx/dialer/base_test.go
@@ -43,7 +43,7 @@ func TestIntegrationBaseDialerErrorNoConnect(t *testing.T) {
 // see whether we implement the interface
 func newBaseDialer() dialer.Dialer {
 	return dialer.EmitterDialer{
-		Dialer: dialer.ErrWrapperDialer{
+		Dialer: dialer.ErrorWrapperDialer{
 			Dialer: dialer.TimeoutDialer{
 				Dialer: new(net.Dialer),
 			},

--- a/netx/dialer/dns.go
+++ b/netx/dialer/dns.go
@@ -86,7 +86,7 @@ func (d DNSDialer) lookupHost(
 //
 // - DNSDialer (topmost)
 // - EmitterDialer
-// - ErrWrapperDialer
+// - ErrorWrapperDialer
 // - TimeoutDialer
 // - ByteCountingDialer
 // - net.Dialer
@@ -95,7 +95,7 @@ func (d DNSDialer) lookupHost(
 func NewDNSDialer(resolver Resolver) DNSDialer {
 	return DNSDialer{
 		Dialer: EmitterDialer{
-			Dialer: ErrWrapperDialer{
+			Dialer: ErrorWrapperDialer{
 				Dialer: TimeoutDialer{
 					Dialer: ByteCounterDialer{
 						Dialer: new(net.Dialer),

--- a/netx/dialer/tls.go
+++ b/netx/dialer/tls.go
@@ -59,13 +59,13 @@ func (h TimeoutTLSHandshaker) Handshake(
 	return h.TLSHandshaker.Handshake(ctx, conn, config)
 }
 
-// ErrWrapperTLSHandshaker wraps the returned error to be an OONI error
-type ErrWrapperTLSHandshaker struct {
+// ErrorWrapperTLSHandshaker wraps the returned error to be an OONI error
+type ErrorWrapperTLSHandshaker struct {
 	TLSHandshaker
 }
 
 // Handshake implements Handshaker.Handshake
-func (h ErrWrapperTLSHandshaker) Handshake(
+func (h ErrorWrapperTLSHandshaker) Handshake(
 	ctx context.Context, conn net.Conn, config *tls.Config,
 ) (net.Conn, tls.ConnectionState, error) {
 	connID := connid.Compute(conn.RemoteAddr().Network(), conn.RemoteAddr().String())
@@ -118,7 +118,7 @@ type TLSDialer struct {
 // NewTLSDialer creates a new TLSDialer using:
 //
 // - EmitterTLSHandshaker (topmost)
-// - ErrWrapperTLSHandshaker
+// - ErrorWrapperTLSHandshaker
 // - TimeoutTLSHandshaker
 // - SystemTLSHandshaker
 //
@@ -128,7 +128,7 @@ func NewTLSDialer(dialer Dialer, config *tls.Config) TLSDialer {
 		Config: config,
 		Dialer: dialer,
 		TLSHandshaker: EmitterTLSHandshaker{
-			TLSHandshaker: ErrWrapperTLSHandshaker{
+			TLSHandshaker: ErrorWrapperTLSHandshaker{
 				TLSHandshaker: TimeoutTLSHandshaker{
 					TLSHandshaker: SystemTLSHandshaker{},
 				},


### PR DESCRIPTION
Usually ErrSomething is the name of an error. So use the ErrorWrapper
prefix rather than ErrWrapper to avoid any confusion.

Part of https://github.com/ooni/probe-engine/issues/125.