### PR TITLE
Experiments in Go now use contex to report bytes usage

### DIFF
--- a/cmd/miniooni/main.go
+++ b/cmd/miniooni/main.go
@@ -284,6 +284,12 @@ func main() {
 		}
 	}
 	experiment := builder.NewExperiment()
+	defer func() {
+		log.Infof("experiment: recv %s, sent %s",
+			humanize.SI(experiment.KiBsReceived()*1024, "byte"),
+			humanize.SI(experiment.KiBsSent()*1024, "byte"),
+		)
+	}()
 
 	if !globalOptions.noCollector {
 		if err := experiment.OpenReport(); err != nil {

--- a/experiment/example/example.go
+++ b/experiment/example/example.go
@@ -60,7 +60,6 @@ func (m *measurer) Run(
 	sess.Logger().Warnf("example: %s", "remember to drink")
 	sess.Logger().Infof("example: %s", "water is key to survival")
 	callbacks.OnProgress(1.0, m.config.Message)
-	callbacks.OnDataUsage(0, 0)
 	return err
 }
 

--- a/experiment/ndt7/dial.go
+++ b/experiment/ndt7/dial.go
@@ -3,10 +3,12 @@ package ndt7
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"net/url"
 
 	"github.com/gorilla/websocket"
+	"github.com/ooni/probe-engine/netx/dialer"
 )
 
 type dialManager struct {
@@ -30,6 +32,16 @@ func newDialManager(hostname string) dialManager {
 
 func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*websocket.Conn, error) {
 	dialer := websocket.Dialer{
+		NetDialContext: dialer.DNSDialer{
+			Dialer: dialer.ErrorWrapperDialer{
+				Dialer: dialer.TimeoutDialer{
+					Dialer: dialer.ByteCounterDialer{
+						Dialer: new(net.Dialer),
+					},
+				},
+			},
+			Resolver: new(net.Resolver),
+		}.DialContext,
 		ReadBufferSize:  mgr.readBufferSize,
 		TLSClientConfig: mgr.tlsConfig,
 		WriteBufferSize: mgr.writeBufferSize,

--- a/experiment/psiphon/psiphon.go
+++ b/experiment/psiphon/psiphon.go
@@ -129,12 +129,6 @@ func (r *runner) usetunnel(
 	)
 	// TODO(bassosimone): understand if there is a way to ask
 	// the tunnel the number of bytes sent and received
-	receivedBytes := results.TestKeys.ReceivedBytes
-	sentBytes := results.TestKeys.SentBytes
-	r.callbacks.OnDataUsage(
-		float64(receivedBytes)/1024.0, // downloaded
-		float64(sentBytes)/1024.0,     // uploaded
-	)
 	if results.Error != nil {
 		s := results.Error.Error()
 		r.testkeys.Failure = &s

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -195,12 +195,6 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	if result.SNI != "kernel.org" {
 		t.Fatal("unexpected SNI")
 	}
-	if result.BytesReceived != 0 {
-		t.Fatal("expected to receive bytes")
-	}
-	if result.BytesSent != 0 {
-		t.Fatal("expected to send bytes")
-	}
 }
 
 func TestUnitMeasureoneSuccess(t *testing.T) {
@@ -216,12 +210,6 @@ func TestUnitMeasureoneSuccess(t *testing.T) {
 	}
 	if result.SNI != "kernel.org" {
 		t.Fatal("unexpected SNI")
-	}
-	if result.BytesReceived <= 0 {
-		t.Fatal("expected to receive bytes")
-	}
-	if result.BytesSent <= 0 {
-		t.Fatal("expected to send bytes")
 	}
 }
 
@@ -248,18 +236,6 @@ func TestUnitMeasureonewithcacheWorks(t *testing.T) {
 		}
 		if result.SNI != "kernel.org" {
 			t.Fatal("unexpected SNI")
-		}
-		if result.BytesReceived <= 0 && !result.Cached {
-			t.Fatal("expected to receive bytes")
-		}
-		if result.BytesSent <= 0 && !result.Cached {
-			t.Fatal("expected to send bytes")
-		}
-		if result.BytesReceived != 0 && result.Cached {
-			t.Fatal("expected to not receive bytes")
-		}
-		if result.BytesSent != 0 && result.Cached {
-			t.Fatal("expected to not send bytes")
 		}
 	}
 }

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -207,10 +207,7 @@ func TestUnitResultsCollectorMeasureSingleTargetGood(t *testing.T) {
 		handler.NewPrinterCallbacks(log.Log),
 	)
 	rc.flexibleConnect = func(context.Context, model.TorTarget) (oonitemplates.Results, error) {
-		return oonitemplates.Results{
-			SentBytes:     10,
-			ReceivedBytes: 14,
-		}, nil
+		return oonitemplates.Results{}, nil
 	}
 	rc.measureSingleTarget(
 		context.Background(), keytarget{
@@ -235,12 +232,6 @@ func TestUnitResultsCollectorMeasureSingleTargetGood(t *testing.T) {
 	}
 	if rc.targetresults["xx"].TargetProtocol != staticTestingTargets[0].Protocol {
 		t.Fatal("target protocol is invalid")
-	}
-	if rc.sentBytes.Load() != 10 {
-		t.Fatal("sent bytes is invalid")
-	}
-	if rc.receivedBytes.Load() != 14 {
-		t.Fatal("received bytes is invalid")
 	}
 }
 
@@ -278,12 +269,6 @@ func TestUnitResultsCollectorMeasureSingleTargetWithFailure(t *testing.T) {
 	}
 	if rc.targetresults["xx"].TargetProtocol != staticTestingTargets[0].Protocol {
 		t.Fatal("target protocol is invalid")
-	}
-	if rc.sentBytes.Load() != 0 {
-		t.Fatal("sent bytes is invalid")
-	}
-	if rc.receivedBytes.Load() != 0 {
-		t.Fatal("received bytes is invalid")
 	}
 }
 

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -142,21 +142,17 @@ func TestSetCallbacks(t *testing.T) {
 	if _, err := builder.NewExperiment().Measure(""); err != nil {
 		t.Fatal(err)
 	}
-	if register.onDataUsageCalled == false {
-		t.Fatal("OnDataUsage not called")
-	}
 	if register.onProgressCalled == false {
 		t.Fatal("OnProgress not called")
 	}
 }
 
 type registerCallbacksCalled struct {
-	onProgressCalled  bool
-	onDataUsageCalled bool
+	onProgressCalled bool
 }
 
 func (c *registerCallbacksCalled) OnDataUsage(dloadKiB, uploadKiB float64) {
-	c.onDataUsageCalled = true
+	// nothing - unused
 }
 
 func (c *registerCallbacksCalled) OnProgress(percentage float64, message string) {

--- a/internal/oonitemplates/oonitemplates.go
+++ b/internal/oonitemplates/oonitemplates.go
@@ -68,9 +68,6 @@ type Results struct {
 	NetworkEvents []*modelx.Measurement
 	Resolves      []*modelx.ResolveDoneEvent
 	TLSHandshakes []*modelx.TLSHandshakeDoneEvent
-
-	SentBytes     int64
-	ReceivedBytes int64
 }
 
 type connmapper struct {
@@ -129,14 +126,12 @@ func (r *Results) onMeasurement(m modelx.Measurement, lowLevel bool) {
 	}
 	if m.Read != nil {
 		m.Read.ConnID = cm.scramble(m.Read.ConnID)
-		r.ReceivedBytes += m.Read.NumBytes // overflow unlikely
 		if lowLevel {
 			r.NetworkEvents = append(r.NetworkEvents, &m)
 		}
 	}
 	if m.Write != nil {
 		m.Write.ConnID = cm.scramble(m.Write.ConnID)
-		r.SentBytes += m.Write.NumBytes // overflow unlikely
 		if lowLevel {
 			r.NetworkEvents = append(r.NetworkEvents, &m)
 		}


### PR DESCRIPTION
Luckily the mechanism for registering a byte counter with the context is
idempotent, so it does not matter a great deal if by mistake we, say, register
twice the experiment. In fact, there is one slot for the experiment and one
slot for the session, so it's difficult to make big mistakes in the code.

The worst that can happen is that we forget about registering in some cases
but double registrations are generally okay as long as the proper slot - for
the experiment or the session - is picked up.

Also, the places where we need to modify the context are few, so it seems
this is not going to be a very big burden. It's true that we need to remember
to use the proper dialer, but that's anyway a problem for all tests, to be
sure that we configure dialing correctly.

So, "burn the ships" like Cortez, and entirely remove the pre-existing
byte counting mechanism for Go experiments. We need to keep the callback
for byte counting, though, until we ditch MK experiments.

With this merged, https://github.com/ooni/probe-engine/issues/125 is
mostly done, except that we need to add a bunch of TODOs and follow up
actions after one more round of code inspection.