### PR TITLE
refactor: let netx/resolver not depend on external interfaces

### DIFF
--- a/netx/modelx/modelx.go
+++ b/netx/modelx/modelx.go
@@ -705,15 +705,6 @@ type DNSResolver interface {
 	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
 }
 
-// DNSRoundTripper represents an abstract DNS transport.
-type DNSRoundTripper interface {
-	// RoundTrip sends a DNS query and receives the reply.
-	RoundTrip(ctx context.Context, query []byte) (reply []byte, err error)
-
-	// RequiresPadding return true for DoH and DoT according to RFC8467
-	RequiresPadding() bool
-}
-
 // Dialer is a dialer for network connections.
 type Dialer interface {
 	// Dial dials a new connection

--- a/netx/resolver/chain.go
+++ b/netx/resolver/chain.go
@@ -2,18 +2,16 @@ package resolver
 
 import (
 	"context"
-
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 // ChainResolver is a chain resolver.
 type ChainResolver struct {
-	primary   modelx.DNSResolver
-	secondary modelx.DNSResolver
+	primary   Resolver
+	secondary Resolver
 }
 
 // NewChainResolver creates a new chain Resolver instance.
-func NewChainResolver(primary, secondary modelx.DNSResolver) *ChainResolver {
+func NewChainResolver(primary, secondary Resolver) *ChainResolver {
 	return &ChainResolver{
 		primary:   primary,
 		secondary: secondary,

--- a/netx/resolver/dnsoverhttps.go
+++ b/netx/resolver/dnsoverhttps.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-// DNSOverHTTPS is a DNS over HTTPS modelx.DNSRoundTripper.
+// DNSOverHTTPS is a DNS over HTTPS RoundTripper.
 //
 // As a known bug, this implementation does not cache the domain
 // name in the URL for reuse, but this should be easy to fix.

--- a/netx/resolver/dnsovertcp.go
+++ b/netx/resolver/dnsovertcp.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// DNSOverTCP is a DNS over TCP/TLS modelx.DNSRoundTripper.
+// DNSOverTCP is a DNS over TCP/TLS RoundTripper.
 //
 // As a known bug, this implementation always creates a new connection
 // for each incoming query, thus increasing the response delay.

--- a/netx/resolver/dnsovertcp_test.go
+++ b/netx/resolver/dnsovertcp_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 type tlsdialer struct {
@@ -91,7 +90,7 @@ func TestUnitDNSOverTCPRoundTripWithConnFailure(t *testing.T) {
 	}
 }
 
-func threeRounds(transport modelx.DNSRoundTripper) error {
+func threeRounds(transport RoundTripper) error {
 	err := roundTrip(transport, "ooni.io.")
 	if err != nil {
 		return err
@@ -107,7 +106,7 @@ func threeRounds(transport modelx.DNSRoundTripper) error {
 	return nil
 }
 
-func roundTrip(transport modelx.DNSRoundTripper, domain string) error {
+func roundTrip(transport RoundTripper, domain string) error {
 	query := new(dns.Msg)
 	query.SetQuestion(domain, dns.TypeA)
 	data, err := query.Pack()

--- a/netx/resolver/dnsoverudp.go
+++ b/netx/resolver/dnsoverudp.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// DNSOverUDP is a DNS over UDP modelx.DNSRoundTripper.
+// DNSOverUDP is a DNS over UDP RoundTripper.
 type DNSOverUDP struct {
 	dialer  modelx.Dialer
 	address string

--- a/netx/resolver/ooni_test.go
+++ b/netx/resolver/ooni_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-func newtransport() modelx.DNSRoundTripper {
+func newtransport() RoundTripper {
 	return NewDNSOverTCP(&net.Dialer{}, "dns.quad9.net:53")
 }
 
@@ -109,7 +108,7 @@ func TestOONIRoundTripExPackFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, errors.New("mocked error")
 		},
-		func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error) {
+		func(t RoundTripper, query []byte) (reply []byte, err error) {
 			return nil, nil
 		},
 		func(msg *dns.Msg, data []byte) (err error) {
@@ -128,7 +127,7 @@ func TestOONIRoundTripExRoundTripFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, nil
 		},
-		func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error) {
+		func(t RoundTripper, query []byte) (reply []byte, err error) {
 			return nil, errors.New("mocked error")
 		},
 		func(msg *dns.Msg, data []byte) (err error) {
@@ -147,7 +146,7 @@ func TestOONIRoundTripExUnpackFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, nil
 		},
-		func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error) {
+		func(t RoundTripper, query []byte) (reply []byte, err error) {
 			return nil, nil
 		},
 		func(msg *dns.Msg, data []byte) (err error) {

--- a/netx/resolver/parent.go
+++ b/netx/resolver/parent.go
@@ -15,11 +15,11 @@ import (
 // ParentResolver is the emitter resolver
 type ParentResolver struct {
 	bogonsCount *atomicx.Int64
-	resolver    modelx.DNSResolver
+	resolver    Resolver
 }
 
 // NewParentResolver creates a new emitter resolver
-func NewParentResolver(resolver modelx.DNSResolver) *ParentResolver {
+func NewParentResolver(resolver Resolver) *ParentResolver {
 	return &ParentResolver{
 		bogonsCount: atomicx.NewInt64(),
 		resolver:    resolver,
@@ -33,7 +33,7 @@ type queryableTransport interface {
 }
 
 type queryableResolver interface {
-	Transport() modelx.DNSRoundTripper
+	Transport() RoundTripper
 }
 
 func (r *ParentResolver) queryTransport() (network string, address string) {

--- a/netx/resolver/resolver.go
+++ b/netx/resolver/resolver.go
@@ -1,11 +1,19 @@
 package resolver
 
 import (
+	"context"
 	"net"
 	"net/http"
 
 	"github.com/ooni/probe-engine/netx/modelx"
 )
+
+// Resolver is a DNS resolver. The *net.Resolver used by Go implements
+// this interface, but other implementations are possible.
+type Resolver interface {
+	// LookupHost resolves a hostname to a list of IP addresses.
+	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+}
 
 // NewResolverSystem creates a new Go/system resolver.
 func NewResolverSystem() *ParentResolver {

--- a/netx/resolver/resolver_test.go
+++ b/netx/resolver/resolver_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-func testresolverquick(t *testing.T, resolver modelx.DNSResolver) {
+func testresolverquick(t *testing.T, resolver Resolver) {
 	addrs, err := resolver.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
 		t.Fatal(err)

--- a/netx/resolver/system.go
+++ b/netx/resolver/system.go
@@ -3,17 +3,15 @@ package resolver
 import (
 	"context"
 	"errors"
-
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 // SystemResolver is the system resolver
 type SystemResolver struct {
-	resolver modelx.DNSResolver
+	resolver Resolver
 }
 
 // NewSystemResolver creates a new system resolver
-func NewSystemResolver(resolver modelx.DNSResolver) *SystemResolver {
+func NewSystemResolver(resolver Resolver) *SystemResolver {
 	return &SystemResolver{resolver: resolver}
 }
 
@@ -38,7 +36,7 @@ func (*fakeTransport) Address() string {
 }
 
 // Transport returns the transport being used
-func (r *SystemResolver) Transport() modelx.DNSRoundTripper {
+func (r *SystemResolver) Transport() RoundTripper {
 	return &fakeTransport{}
 }
 

--- a/netx/resolver/system_test.go
+++ b/netx/resolver/system_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"net"
 	"testing"
-
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 func TestCanQuery(t *testing.T) {
-	var client modelx.DNSResolver = NewSystemResolver(new(net.Resolver))
+	var client Resolver = NewSystemResolver(new(net.Resolver))
 	transport := client.(queryableResolver).Transport()
 	reply, err := transport.RoundTrip(context.Background(), nil)
 	if err == nil {


### PR DESCRIPTION
If it needs an interface, let it declare that.

Part of https://github.com/ooni/probe-engine/issues/359