### PR TITLE
refactor(netx): develop more basic building blocks

### DIFF
--- a/netx/resolver/emittingtransport.go
+++ b/netx/resolver/emittingtransport.go
@@ -1,0 +1,38 @@
+package resolver
+
+import (
+	"context"
+	"time"
+
+	"github.com/ooni/probe-engine/netx/internal/dialid"
+	"github.com/ooni/probe-engine/netx/modelx"
+)
+
+// EmittingTransport emits round trip events
+type EmittingTransport struct {
+	RoundTripper
+}
+
+// RoundTrip implements RoundTripper.RoundTrip
+func (txp EmittingTransport) RoundTrip(ctx context.Context, querydata []byte) ([]byte, error) {
+	root := modelx.ContextMeasurementRootOrDefault(ctx)
+	root.Handler.OnMeasurement(modelx.Measurement{
+		DNSQuery: &modelx.DNSQueryEvent{
+			Data:                   querydata,
+			DialID:                 dialid.ContextDialID(ctx),
+			DurationSinceBeginning: time.Now().Sub(root.Beginning),
+		},
+	})
+	replydata, err := txp.RoundTripper.RoundTrip(ctx, querydata)
+	if err != nil {
+		return nil, err
+	}
+	root.Handler.OnMeasurement(modelx.Measurement{
+		DNSReply: &modelx.DNSReplyEvent{
+			Data:                   replydata,
+			DialID:                 dialid.ContextDialID(ctx),
+			DurationSinceBeginning: time.Now().Sub(root.Beginning),
+		},
+	})
+	return replydata, nil
+}

--- a/netx/resolver/emittingtransport_test.go
+++ b/netx/resolver/emittingtransport_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Psiphon-Labs/dns"
+	"github.com/miekg/dns"
 	"github.com/ooni/probe-engine/netx/internal/dialid"
 	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/resolver"

--- a/netx/resolver/emittingtransport_test.go
+++ b/netx/resolver/emittingtransport_test.go
@@ -1,0 +1,108 @@
+package resolver_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Psiphon-Labs/dns"
+	"github.com/ooni/probe-engine/netx/internal/dialid"
+	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/resolver"
+)
+
+func TestEmittingTransportSuccess(t *testing.T) {
+	ctx := context.Background()
+	ctx = dialid.WithDialID(ctx)
+	handler := &resolver.SavingHandler{}
+	root := &modelx.MeasurementRoot{
+		Beginning: time.Now(),
+		Handler:   handler,
+	}
+	ctx = modelx.WithMeasurementRoot(ctx, root)
+	txp := resolver.EmittingTransport{RoundTripper: resolver.FakeTransport{
+		Data: resolver.GenReplySuccess(t, dns.TypeA, "8.8.8.8"),
+	}}
+	e := resolver.MiekgEncoder{}
+	querydata, err := e.Encode("www.google.com", dns.TypeAAAA, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replydata, err := txp.RoundTrip(ctx, querydata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := handler.Read()
+	if len(events) != 2 {
+		t.Fatal("unexpected number of events")
+	}
+	if events[0].DNSQuery == nil {
+		t.Fatal("missing DNSQuery field")
+	}
+	if !bytes.Equal(events[0].DNSQuery.Data, querydata) {
+		t.Fatal("invalid query data")
+	}
+	if events[0].DNSQuery.DialID == 0 {
+		t.Fatal("invalid query DialID")
+	}
+	if events[0].DNSQuery.DurationSinceBeginning <= 0 {
+		t.Fatal("invalid duration since beginning")
+	}
+	if events[1].DNSReply == nil {
+		t.Fatal("missing DNSReply field")
+	}
+	if !bytes.Equal(events[1].DNSReply.Data, replydata) {
+		t.Fatal("missing reply data")
+	}
+	if events[1].DNSReply.DialID != 1 {
+		t.Fatal("invalid query DialID")
+	}
+	if events[1].DNSReply.DurationSinceBeginning <= 0 {
+		t.Fatal("invalid duration since beginning")
+	}
+}
+
+func TestEmittingTransportFailure(t *testing.T) {
+	ctx := context.Background()
+	ctx = dialid.WithDialID(ctx)
+	handler := &resolver.SavingHandler{}
+	root := &modelx.MeasurementRoot{
+		Beginning: time.Now(),
+		Handler:   handler,
+	}
+	ctx = modelx.WithMeasurementRoot(ctx, root)
+	mocked := errors.New("mocked error")
+	txp := resolver.EmittingTransport{RoundTripper: resolver.FakeTransport{
+		Err: mocked,
+	}}
+	e := resolver.MiekgEncoder{}
+	querydata, err := e.Encode("www.google.com", dns.TypeAAAA, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replydata, err := txp.RoundTrip(ctx, querydata)
+	if !errors.Is(err, mocked) {
+		t.Fatal("not the error we expected")
+	}
+	if replydata != nil {
+		t.Fatal("expected nil replydata")
+	}
+	events := handler.Read()
+	if len(events) != 1 {
+		t.Fatal("unexpected number of events")
+	}
+	if events[0].DNSQuery == nil {
+		t.Fatal("missing DNSQuery field")
+	}
+	if !bytes.Equal(events[0].DNSQuery.Data, querydata) {
+		t.Fatal("invalid query data")
+	}
+	if events[0].DNSQuery.DialID == 0 {
+		t.Fatal("invalid query DialID")
+	}
+	if events[0].DNSQuery.DurationSinceBeginning <= 0 {
+		t.Fatal("invalid duration since beginning")
+	}
+}

--- a/netx/resolver/encoder.go
+++ b/netx/resolver/encoder.go
@@ -4,22 +4,11 @@ import "github.com/miekg/dns"
 
 // The Encoder encodes DNS queries to bytes
 type Encoder interface {
-	EncodeA(domain string, padding bool) ([]byte, error)
-	EncodeAAAA(domain string, padding bool) ([]byte, error)
+	Encode(domain string, qtype uint16, padding bool) ([]byte, error)
 }
 
 // MiekgEncoder uses github.com/miekg/dns to implement the Encoder.
 type MiekgEncoder struct{}
-
-// EncodeA implements Encoder.EncodeA
-func (e MiekgEncoder) EncodeA(domain string, padding bool) ([]byte, error) {
-	return e.encode(domain, dns.TypeA, padding)
-}
-
-// EncodeAAAA implements Encoder.EncodeAAAA
-func (e MiekgEncoder) EncodeAAAA(domain string, padding bool) ([]byte, error) {
-	return e.encode(domain, dns.TypeAAAA, padding)
-}
 
 const (
 	// PaddingDesiredBlockSize is the size that the padded query should be multiple of
@@ -32,7 +21,8 @@ const (
 	DNSSECEnabled = true
 )
 
-func (e MiekgEncoder) encode(domain string, qtype uint16, padding bool) ([]byte, error) {
+// Encode implements Encoder.Encode
+func (e MiekgEncoder) Encode(domain string, qtype uint16, padding bool) ([]byte, error) {
 	question := dns.Question{
 		Name:   dns.Fqdn(domain),
 		Qtype:  qtype,

--- a/netx/resolver/encoder_test.go
+++ b/netx/resolver/encoder_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestUnitEncoderEncodeA(t *testing.T) {
 	e := resolver.MiekgEncoder{}
-	data, err := e.EncodeA("x.org", false)
+	data, err := e.Encode("x.org", dns.TypeA, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,7 +19,7 @@ func TestUnitEncoderEncodeA(t *testing.T) {
 
 func TestUnitEncoderEncodeAAAA(t *testing.T) {
 	e := resolver.MiekgEncoder{}
-	data, err := e.EncodeAAAA("x.org", false)
+	data, err := e.Encode("x.org", dns.TypeAAAA, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,14 +69,14 @@ func TestUnitEncoderPadding(t *testing.T) {
 	// array of values we obtain the right query size.
 	getquerylen := func(domainlen int, padding bool) int {
 		e := resolver.MiekgEncoder{}
-		data, err := e.EncodeA(
+		data, err := e.Encode(
 			// This is not a valid name because it ends up being way
 			// longer than 255 octets. However, the library is allowing
 			// us to generate such name and we are not going to send
 			// it on the wire. Also, we check below that the query that
 			// we generate is long enough, so we should be good.
 			dns.Fqdn(strings.Repeat("x.", domainlen)),
-			padding,
+			dns.TypeA, padding,
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/netx/resolver/errorwrapper_test.go
+++ b/netx/resolver/errorwrapper_test.go
@@ -46,10 +46,10 @@ func TestUnitErrorWrapperFailure(t *testing.T) {
 	if errWrapper.ConnID != 0 {
 		t.Fatal("unexpected ConnID")
 	}
-	if errWrapper.DialID != 1 {
+	if errWrapper.DialID == 0 {
 		t.Fatal("unexpected DialID")
 	}
-	if errWrapper.TransactionID != 1 {
+	if errWrapper.TransactionID == 0 {
 		t.Fatal("unexpected TransactionID")
 	}
 	if errWrapper.Operation != "resolve" {

--- a/netx/resolver/faketransport_test.go
+++ b/netx/resolver/faketransport_test.go
@@ -1,0 +1,26 @@
+package resolver
+
+import "context"
+
+// FakeTransport is used by unit tests
+type FakeTransport struct {
+	Data []byte
+	Err  error
+}
+
+// RoundTrip implements RoundTripper.RoundTrip
+func (ft FakeTransport) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
+	return ft.Data, ft.Err
+}
+
+func (ft FakeTransport) RequiresPadding() bool {
+	return false
+}
+
+func (ft FakeTransport) Address() string {
+	return ""
+}
+
+func (ft FakeTransport) Network() string {
+	return "fake"
+}

--- a/netx/resolver/genreply_test.go
+++ b/netx/resolver/genreply_test.go
@@ -1,0 +1,76 @@
+package resolver
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func GenReplyError(t *testing.T, code int) []byte {
+	question := dns.Question{
+		Name:   dns.Fqdn("x.org"),
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}
+	query := new(dns.Msg)
+	query.Id = dns.Id()
+	query.RecursionDesired = true
+	query.Question = make([]dns.Question, 1)
+	query.Question[0] = question
+	reply := new(dns.Msg)
+	reply.Compress = true
+	reply.MsgHdr.RecursionAvailable = true
+	reply.SetRcode(query, code)
+	data, err := reply.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func GenReplySuccess(t *testing.T, qtype uint16, ips ...string) []byte {
+	question := dns.Question{
+		Name:   dns.Fqdn("x.org"),
+		Qtype:  qtype,
+		Qclass: dns.ClassINET,
+	}
+	query := new(dns.Msg)
+	query.Id = dns.Id()
+	query.RecursionDesired = true
+	query.Question = make([]dns.Question, 1)
+	query.Question[0] = question
+	reply := new(dns.Msg)
+	reply.Compress = true
+	reply.MsgHdr.RecursionAvailable = true
+	reply.SetReply(query)
+	for _, ip := range ips {
+		switch qtype {
+		case dns.TypeA:
+			reply.Answer = append(reply.Answer, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   dns.Fqdn("x.org"),
+					Rrtype: qtype,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				A: net.ParseIP(ip),
+			})
+		case dns.TypeAAAA:
+			reply.Answer = append(reply.Answer, &dns.AAAA{
+				Hdr: dns.RR_Header{
+					Name:   dns.Fqdn("x.org"),
+					Rrtype: qtype,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				AAAA: net.ParseIP(ip),
+			})
+		}
+	}
+	data, err := reply.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/netx/resolver/savinghandler_test.go
+++ b/netx/resolver/savinghandler_test.go
@@ -1,0 +1,29 @@
+package resolver
+
+import (
+	"sync"
+
+	"github.com/ooni/probe-engine/netx/modelx"
+)
+
+// SavingHandler saves the events
+type SavingHandler struct {
+	mu sync.Mutex
+	v  []modelx.Measurement
+}
+
+// OnMeasurement implements modelx.Handler.OnMeasurement
+func (sh *SavingHandler) OnMeasurement(ev modelx.Measurement) {
+	sh.mu.Lock()
+	sh.v = append(sh.v, ev)
+	sh.mu.Unlock()
+}
+
+// Read reads the measurements
+func (sh *SavingHandler) Read() []modelx.Measurement {
+	sh.mu.Lock()
+	v := sh.v
+	sh.v = nil
+	sh.mu.Unlock()
+	return v
+}


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/359. These changes should allow me to really split the OONI resolver in smaller composable pieces.