### PR TITLE
netx/resolver: reduce pointer receivers, curate docs and naming

### DIFF
--- a/netx/resolver.go
+++ b/netx/resolver.go
@@ -130,5 +130,5 @@ func NewResolver(network, address string) (modelx.DNSResolver, error) {
 // ChainResolvers chains a primary and a secondary resolver such that
 // we can fallback to the secondary if primary is broken.
 func ChainResolvers(primary, secondary modelx.DNSResolver) modelx.DNSResolver {
-	return resolver.ChainResolvers(primary, secondary)
+	return resolver.Chain{Primary: primary, Secondary: secondary}
 }

--- a/netx/resolver/bogon.go
+++ b/netx/resolver/bogon.go
@@ -49,7 +49,8 @@ func IsBogon(address string) bool {
 	return ip == nil || isPrivate(ip)
 }
 
-// Bogon is a bogon aware resolver.
+// Bogon is a bogon aware resolver. When a bogon is encountered in
+// a reply, this resolver will return an error.
 type Bogon struct {
 	Resolver
 }

--- a/netx/resolver/chain.go
+++ b/netx/resolver/chain.go
@@ -4,25 +4,18 @@ import (
 	"context"
 )
 
-// Chain is a chain resolver.
+// Chain is a chain resolver. The primary resolver is used first and, if that
+// fails, we then attempt with the secondary resolver.
 type Chain struct {
-	primary   Resolver
-	secondary Resolver
+	Primary   Resolver
+	Secondary Resolver
 }
 
-// ChainResolvers chains two resolvers.
-func ChainResolvers(primary, secondary Resolver) Chain {
-	return Chain{
-		primary:   primary,
-		secondary: secondary,
-	}
-}
-
-// LookupHost returns the IP addresses of a host
+// LookupHost implements Resolver.LookupHost
 func (c Chain) LookupHost(ctx context.Context, hostname string) ([]string, error) {
-	addrs, err := c.primary.LookupHost(ctx, hostname)
+	addrs, err := c.Primary.LookupHost(ctx, hostname)
 	if err != nil {
-		addrs, err = c.secondary.LookupHost(ctx, hostname)
+		addrs, err = c.Secondary.LookupHost(ctx, hostname)
 	}
 	return addrs, err
 }

--- a/netx/resolver/chain_test.go
+++ b/netx/resolver/chain_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func TestChainLookupHost(t *testing.T) {
-	client := resolver.ChainResolvers(resolver.NewMockableResolverThatFails(), new(net.Resolver))
+	client := resolver.Chain{
+		Primary:   resolver.NewMockableResolverThatFails(),
+		Secondary: new(net.Resolver),
+	}
 	addrs, err := client.LookupHost(context.Background(), "www.google.com")
 	if err != nil {
 		t.Fatal(err)

--- a/netx/resolver/decoder.go
+++ b/netx/resolver/decoder.go
@@ -6,7 +6,9 @@ import (
 	"github.com/miekg/dns"
 )
 
-// The Decoder decodes a DNS reply into A or AAAA entries
+// The Decoder decodes a DNS reply into A or AAAA entries. It will use the
+// provided qtype and only look for mathing entries. It will return error if
+// there are no entries for the requested qtype inside the reply.
 type Decoder interface {
 	Decode(qtype uint16, data []byte) ([]string, error)
 }

--- a/netx/resolver/dnsoverhttps.go
+++ b/netx/resolver/dnsoverhttps.go
@@ -8,21 +8,20 @@ import (
 	"net/http"
 )
 
-// DNSOverHTTPS is a DNS over HTTPS RoundTripper.
-//
-// As a known bug, this implementation does not cache the domain
-// name in the URL for reuse, but this should be easy to fix.
+// DNSOverHTTPS is a DNS over HTTPS RoundTripper. Requests are submitted over
+// an HTTP/HTTPS channel provided by URL using the Do function.
 type DNSOverHTTPS struct {
 	Do  func(req *http.Request) (*http.Response, error)
 	URL string
 }
 
-// NewDNSOverHTTPS creates a new Transport
+// NewDNSOverHTTPS creates a new DNSOverHTTP instance from the
+// specified http.Client and URL, as a convenience.
 func NewDNSOverHTTPS(client *http.Client, URL string) DNSOverHTTPS {
 	return DNSOverHTTPS{Do: client.Do, URL: URL}
 }
 
-// RoundTrip sends a request and receives a response.
+// RoundTrip implements RoundTripper.RoundTrip.
 func (t DNSOverHTTPS) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	req, err := http.NewRequest("POST", t.URL, bytes.NewReader(query))
 	if err != nil {

--- a/netx/resolver/dnsovertcp.go
+++ b/netx/resolver/dnsovertcp.go
@@ -9,11 +9,12 @@ import (
 	"time"
 )
 
-// DialContextFunc is a function that behaves like net.Dialer.DialContext
-// but may possibly also dial a TLS connection.
+// DialContextFunc is a generic function for dialing a connection.
 type DialContextFunc func(context.Context, string, string) (net.Conn, error)
 
-// DNSOverTCP is a DNS over TCP/TLS RoundTripper.
+// DNSOverTCP is a DNS over TCP/TLS RoundTripper. Use NewDNSOverTCP
+// and NewDNSOverTLS to create specific instances that use plaintext
+// queries or encrypted queries over TLS.
 //
 // As a known bug, this implementation always creates a new connection
 // for each incoming query, thus increasing the response delay.
@@ -24,7 +25,7 @@ type DNSOverTCP struct {
 	requiresPadding bool
 }
 
-// NewDNSOverTCP creates a new TCP Transport
+// NewDNSOverTCP creates a new DNSOverTCP transport.
 func NewDNSOverTCP(dial DialContextFunc, address string) DNSOverTCP {
 	return DNSOverTCP{
 		dial:            dial,
@@ -34,7 +35,7 @@ func NewDNSOverTCP(dial DialContextFunc, address string) DNSOverTCP {
 	}
 }
 
-// NewDNSOverTLS creates a new TLS Transport
+// NewDNSOverTLS creates a new DNSOverTLS transport.
 func NewDNSOverTLS(dial DialContextFunc, address string) DNSOverTCP {
 	return DNSOverTCP{
 		dial:            dial,
@@ -44,7 +45,7 @@ func NewDNSOverTLS(dial DialContextFunc, address string) DNSOverTCP {
 	}
 }
 
-// RoundTrip sends a request and receives a response.
+// RoundTrip implements RoundTripper.RoundTrip.
 func (t DNSOverTCP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	if len(query) > math.MaxUint16 {
 		return nil, errors.New("query too long")

--- a/netx/resolver/dnsovertcp.go
+++ b/netx/resolver/dnsovertcp.go
@@ -25,8 +25,8 @@ type DNSOverTCP struct {
 }
 
 // NewDNSOverTCP creates a new TCP Transport
-func NewDNSOverTCP(dial DialContextFunc, address string) *DNSOverTCP {
-	return &DNSOverTCP{
+func NewDNSOverTCP(dial DialContextFunc, address string) DNSOverTCP {
+	return DNSOverTCP{
 		dial:            dial,
 		address:         address,
 		network:         "tcp",
@@ -35,8 +35,8 @@ func NewDNSOverTCP(dial DialContextFunc, address string) *DNSOverTCP {
 }
 
 // NewDNSOverTLS creates a new TLS Transport
-func NewDNSOverTLS(dial DialContextFunc, address string) *DNSOverTCP {
-	return &DNSOverTCP{
+func NewDNSOverTLS(dial DialContextFunc, address string) DNSOverTCP {
+	return DNSOverTCP{
 		dial:            dial,
 		address:         address,
 		network:         "dot",
@@ -45,7 +45,7 @@ func NewDNSOverTLS(dial DialContextFunc, address string) *DNSOverTCP {
 }
 
 // RoundTrip sends a request and receives a response.
-func (t *DNSOverTCP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
+func (t DNSOverTCP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	if len(query) > math.MaxUint16 {
 		return nil, errors.New("query too long")
 	}
@@ -79,16 +79,16 @@ func (t *DNSOverTCP) RoundTrip(ctx context.Context, query []byte) ([]byte, error
 
 // RequiresPadding returns true for DoT and false for TCP
 // according to RFC8467.
-func (t *DNSOverTCP) RequiresPadding() bool {
+func (t DNSOverTCP) RequiresPadding() bool {
 	return t.requiresPadding
 }
 
 // Network returns the transport network (e.g., doh, dot)
-func (t *DNSOverTCP) Network() string {
+func (t DNSOverTCP) Network() string {
 	return t.network
 }
 
 // Address returns the upstream server address.
-func (t *DNSOverTCP) Address() string {
+func (t DNSOverTCP) Address() string {
 	return t.address
 }

--- a/netx/resolver/dnsoverudp.go
+++ b/netx/resolver/dnsoverudp.go
@@ -18,12 +18,12 @@ type DNSOverUDP struct {
 }
 
 // NewDNSOverUDP creates a new Transport
-func NewDNSOverUDP(dialer Dialer, address string) *DNSOverUDP {
-	return &DNSOverUDP{dialer: dialer, address: address}
+func NewDNSOverUDP(dialer Dialer, address string) DNSOverUDP {
+	return DNSOverUDP{dialer: dialer, address: address}
 }
 
 // RoundTrip sends a request and receives a response.
-func (t *DNSOverUDP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
+func (t DNSOverUDP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	conn, err := t.dialer.DialContext(ctx, "udp", t.address)
 	if err != nil {
 		return nil, err
@@ -47,16 +47,16 @@ func (t *DNSOverUDP) RoundTrip(ctx context.Context, query []byte) ([]byte, error
 }
 
 // RequiresPadding returns false for UDP according to RFC8467
-func (t *DNSOverUDP) RequiresPadding() bool {
+func (t DNSOverUDP) RequiresPadding() bool {
 	return false
 }
 
 // Network returns the transport network (e.g., doh, dot)
-func (t *DNSOverUDP) Network() string {
+func (t DNSOverUDP) Network() string {
 	return "udp"
 }
 
 // Address returns the upstream server address.
-func (t *DNSOverUDP) Address() string {
+func (t DNSOverUDP) Address() string {
 	return t.address
 }

--- a/netx/resolver/dnsoverudp.go
+++ b/netx/resolver/dnsoverudp.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Dialer is the network dialer as assumed by this package.
+// Dialer is the network dialer interface assumed by this package.
 type Dialer interface {
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
@@ -17,12 +17,12 @@ type DNSOverUDP struct {
 	address string
 }
 
-// NewDNSOverUDP creates a new Transport
+// NewDNSOverUDP creates a DNSOverUDP instance.
 func NewDNSOverUDP(dialer Dialer, address string) DNSOverUDP {
 	return DNSOverUDP{dialer: dialer, address: address}
 }
 
-// RoundTrip sends a request and receives a response.
+// RoundTrip implements RoundTripper.RoundTrip.
 func (t DNSOverUDP) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	conn, err := t.dialer.DialContext(ctx, "udp", t.address)
 	if err != nil {

--- a/netx/resolver/emitter.go
+++ b/netx/resolver/emitter.go
@@ -8,13 +8,13 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// EmittingTransport emits round trip events
-type EmittingTransport struct {
+// Emitter is a RoundTripper that emits events when they occur.
+type Emitter struct {
 	RoundTripper
 }
 
 // RoundTrip implements RoundTripper.RoundTrip
-func (txp EmittingTransport) RoundTrip(ctx context.Context, querydata []byte) ([]byte, error) {
+func (txp Emitter) RoundTrip(ctx context.Context, querydata []byte) ([]byte, error) {
 	root := modelx.ContextMeasurementRootOrDefault(ctx)
 	root.Handler.OnMeasurement(modelx.Measurement{
 		DNSQuery: &modelx.DNSQueryEvent{

--- a/netx/resolver/emitter_test.go
+++ b/netx/resolver/emitter_test.go
@@ -22,7 +22,7 @@ func TestEmittingTransportSuccess(t *testing.T) {
 		Handler:   handler,
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
-	txp := resolver.EmittingTransport{RoundTripper: resolver.FakeTransport{
+	txp := resolver.Emitter{RoundTripper: resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeA, "8.8.8.8"),
 	}}
 	e := resolver.MiekgEncoder{}
@@ -74,7 +74,7 @@ func TestEmittingTransportFailure(t *testing.T) {
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
 	mocked := errors.New("mocked error")
-	txp := resolver.EmittingTransport{RoundTripper: resolver.FakeTransport{
+	txp := resolver.Emitter{RoundTripper: resolver.FakeTransport{
 		Err: mocked,
 	}}
 	e := resolver.MiekgEncoder{}

--- a/netx/resolver/errorwrapper.go
+++ b/netx/resolver/errorwrapper.go
@@ -8,12 +8,12 @@ import (
 	"github.com/ooni/probe-engine/netx/internal/transactionid"
 )
 
-// ErrorWrapper is a resolver that knows about wrapping errors.
+// ErrorWrapper is a Resolver that knows about wrapping errors.
 type ErrorWrapper struct {
 	Resolver
 }
 
-// LookupHost returns the IP addresses of a host
+// LookupHost implements Resolver.LookupHost
 func (r ErrorWrapper) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	dialID := dialid.ContextDialID(ctx)
 	txID := transactionid.ContextTransactionID(ctx)

--- a/netx/resolver/mockable.go
+++ b/netx/resolver/mockable.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ooni/probe-engine/atomicx"
 )
 
-// Mockable is a broken resolver.
+// Mockable is a mockable resolver.
 type Mockable struct {
 	NumFailures *atomicx.Int64
 	err         error

--- a/netx/resolver/mockable.go
+++ b/netx/resolver/mockable.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ooni/probe-engine/atomicx"
 )
 
-// Mockable is a mockable resolver.
+// Mockable is a mockable resolver that other packages can
+// import to simulate a resolver's behaviour.
 type Mockable struct {
 	NumFailures *atomicx.Int64
 	err         error

--- a/netx/resolver/ooni.go
+++ b/netx/resolver/ooni.go
@@ -34,8 +34,8 @@ type OONI struct {
 	Txp         RoundTripper
 }
 
-// NewOONIResolver creates a new OONI Resolver instance.
-func NewOONIResolver(t RoundTripper) OONI {
+// NewOONI creates a new OONI Resolver instance.
+func NewOONI(t RoundTripper) OONI {
 	return OONI{
 		Encoder:     MiekgEncoder{},
 		Decoder:     MiekgDecoder{},
@@ -49,7 +49,7 @@ func (r OONI) Transport() RoundTripper {
 	return r.Txp
 }
 
-// LookupHost returns the IP addresses of a host
+// LookupHost implements Resolver.LookupHost.
 func (r OONI) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	var addrs []string
 	addrsA, errA := r.roundTripWithRetry(ctx, hostname, dns.TypeA)

--- a/netx/resolver/ooni_test.go
+++ b/netx/resolver/ooni_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestUnitOONIGettingTransport(t *testing.T) {
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
-	r := resolver.NewOONIResolver(txp)
+	r := resolver.NewOONI(txp)
 	rtx := r.Transport()
 	if rtx.Network() != "dot" || rtx.Address() != "8.8.8.8:853" {
 		t.Fatal("not the transport we expected")
@@ -37,7 +37,7 @@ func TestUnitOONIEncodeError(t *testing.T) {
 func TestUnitOONIRoundTripError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.FakeTransport{Err: mocked}
-	r := resolver.NewOONIResolver(txp)
+	r := resolver.NewOONI(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, mocked) {
 		t.Fatal("not the error we expected")
@@ -49,7 +49,7 @@ func TestUnitOONIRoundTripError(t *testing.T) {
 
 func TestUnitOONIWithEmptyReply(t *testing.T) {
 	txp := resolver.FakeTransport{Data: resolver.GenReplySuccess(t, dns.TypeA)}
-	r := resolver.NewOONIResolver(txp)
+	r := resolver.NewOONI(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err == nil || !strings.HasSuffix(err.Error(), "no response returned") {
 		t.Fatal("not the error we expected")
@@ -63,7 +63,7 @@ func TestUnitOONIWithAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeA, "8.8.8.8"),
 	}
-	r := resolver.NewOONIResolver(txp)
+	r := resolver.NewOONI(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestUnitOONIWithAAAAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeAAAA, "::1"),
 	}
-	r := resolver.NewOONIResolver(txp)
+	r := resolver.NewOONI(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +91,7 @@ func TestUnitOONIWithTimeout(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Err: &net.OpError{Err: syscall.ETIMEDOUT, Op: "dial"},
 	}
-	r := resolver.NewOONIResolver(txp)
+	r := resolver.NewOONI(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, syscall.ETIMEDOUT) {
 		t.Fatal("not the error we expected")

--- a/netx/resolver/ooni_test.go
+++ b/netx/resolver/ooni_test.go
@@ -15,7 +15,8 @@ import (
 func TestUnitOONIGettingTransport(t *testing.T) {
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
 	r := resolver.NewOONIResolver(txp)
-	if txp != r.Transport() {
+	rtx := r.Transport()
+	if rtx.Network() != "dot" || rtx.Address() != "8.8.8.8:853" {
 		t.Fatal("not the transport we expected")
 	}
 }

--- a/netx/resolver/resolver.go
+++ b/netx/resolver/resolver.go
@@ -19,21 +19,21 @@ func NewResolverSystem() *ParentResolver {
 
 // NewResolverUDP creates a new UDP resolver.
 func NewResolverUDP(dialer Dialer, address string) *ParentResolver {
-	return NewParentResolver(NewOONIResolver(EmittingTransport{
+	return NewParentResolver(NewOONI(Emitter{
 		RoundTripper: NewDNSOverUDP(dialer, address),
 	}))
 }
 
 // NewResolverTCP creates a new TCP resolver.
 func NewResolverTCP(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewOONIResolver(EmittingTransport{
+	return NewParentResolver(NewOONI(Emitter{
 		RoundTripper: NewDNSOverTCP(dial, address),
 	}))
 }
 
 // NewResolverTLS creates a new DoT resolver.
 func NewResolverTLS(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewOONIResolver(EmittingTransport{
+	return NewParentResolver(NewOONI(Emitter{
 		RoundTripper: NewDNSOverTLS(dial, address),
 	}))
 }
@@ -41,6 +41,6 @@ func NewResolverTLS(dial DialContextFunc, address string) *ParentResolver {
 // NewResolverHTTPS creates a new DoH resolver.
 func NewResolverHTTPS(client *http.Client, address string) *ParentResolver {
 	return NewParentResolver(
-		NewOONIResolver(NewDNSOverHTTPS(client, address)),
+		NewOONI(NewDNSOverHTTPS(client, address)),
 	)
 }

--- a/netx/resolver/savinghandler_test.go
+++ b/netx/resolver/savinghandler_test.go
@@ -6,20 +6,17 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// SavingHandler saves the events
 type SavingHandler struct {
 	mu sync.Mutex
 	v  []modelx.Measurement
 }
 
-// OnMeasurement implements modelx.Handler.OnMeasurement
 func (sh *SavingHandler) OnMeasurement(ev modelx.Measurement) {
 	sh.mu.Lock()
 	sh.v = append(sh.v, ev)
 	sh.mu.Unlock()
 }
 
-// Read reads the measurements
 func (sh *SavingHandler) Read() []modelx.Measurement {
 	sh.mu.Lock()
 	v := sh.v

--- a/netx/resolver/tls_test.go
+++ b/netx/resolver/tls_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 )
 
-// DialTLSContext is used in tests to dial TLS connections.
 func DialTLSContext(ctx context.Context, network, address string) (net.Conn, error) {
 	connch := make(chan net.Conn)
 	errch := make(chan error, 1)


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/359