### PR TITLE
netx/resolver: improve naming and enforce interface conformance 

### DIFF
--- a/netx/resolver.go
+++ b/netx/resolver.go
@@ -130,5 +130,5 @@ func NewResolver(network, address string) (modelx.DNSResolver, error) {
 // ChainResolvers chains a primary and a secondary resolver such that
 // we can fallback to the secondary if primary is broken.
 func ChainResolvers(primary, secondary modelx.DNSResolver) modelx.DNSResolver {
-	return resolver.Chain{Primary: primary, Secondary: secondary}
+	return resolver.ChainResolver{Primary: primary, Secondary: secondary}
 }

--- a/netx/resolver/bogon.go
+++ b/netx/resolver/bogon.go
@@ -49,14 +49,14 @@ func IsBogon(address string) bool {
 	return ip == nil || isPrivate(ip)
 }
 
-// Bogon is a bogon aware resolver. When a bogon is encountered in
+// BogonResolver is a bogon aware resolver. When a bogon is encountered in
 // a reply, this resolver will return an error.
-type Bogon struct {
+type BogonResolver struct {
 	Resolver
 }
 
 // LookupHost implements Resolver.LookupHost
-func (r Bogon) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+func (r BogonResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	addrs, err := r.Resolver.LookupHost(ctx, hostname)
 	for _, addr := range addrs {
 		if IsBogon(addr) == true {
@@ -65,3 +65,5 @@ func (r Bogon) LookupHost(ctx context.Context, hostname string) ([]string, error
 	}
 	return addrs, err
 }
+
+var _ Resolver = BogonResolver{}

--- a/netx/resolver/bogon_test.go
+++ b/netx/resolver/bogon_test.go
@@ -25,7 +25,7 @@ func TestUnitResolverIsBogon(t *testing.T) {
 }
 
 func TestUnitBogonAwareResolverWithBogon(t *testing.T) {
-	r := resolver.Bogon{
+	r := resolver.BogonResolver{
 		Resolver: resolver.NewMockableResolverWithResult([]string{"127.0.0.1"}),
 	}
 	addrs, err := r.LookupHost(context.Background(), "dns.google.com")
@@ -39,7 +39,7 @@ func TestUnitBogonAwareResolverWithBogon(t *testing.T) {
 
 func TestUnitBogonAwareResolverWithoutBogon(t *testing.T) {
 	orig := []string{"8.8.8.8"}
-	r := resolver.Bogon{
+	r := resolver.BogonResolver{
 		Resolver: resolver.NewMockableResolverWithResult(orig),
 	}
 	addrs, err := r.LookupHost(context.Background(), "dns.google.com")

--- a/netx/resolver/chain.go
+++ b/netx/resolver/chain.go
@@ -4,18 +4,20 @@ import (
 	"context"
 )
 
-// Chain is a chain resolver. The primary resolver is used first and, if that
+// ChainResolver is a chain resolver. The primary resolver is used first and, if that
 // fails, we then attempt with the secondary resolver.
-type Chain struct {
+type ChainResolver struct {
 	Primary   Resolver
 	Secondary Resolver
 }
 
 // LookupHost implements Resolver.LookupHost
-func (c Chain) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+func (c ChainResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	addrs, err := c.Primary.LookupHost(ctx, hostname)
 	if err != nil {
 		addrs, err = c.Secondary.LookupHost(ctx, hostname)
 	}
 	return addrs, err
 }
+
+var _ Resolver = ChainResolver{}

--- a/netx/resolver/chain_test.go
+++ b/netx/resolver/chain_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestChainLookupHost(t *testing.T) {
-	client := resolver.Chain{
+	client := resolver.ChainResolver{
 		Primary:   resolver.NewMockableResolverThatFails(),
 		Secondary: new(net.Resolver),
 	}

--- a/netx/resolver/decoder.go
+++ b/netx/resolver/decoder.go
@@ -50,3 +50,5 @@ func (d MiekgDecoder) Decode(qtype uint16, data []byte) ([]string, error) {
 	}
 	return addrs, nil
 }
+
+var _ Decoder = MiekgDecoder{}

--- a/netx/resolver/dnsoverhttps.go
+++ b/netx/resolver/dnsoverhttps.go
@@ -59,3 +59,5 @@ func (t DNSOverHTTPS) Network() string {
 func (t DNSOverHTTPS) Address() string {
 	return t.URL
 }
+
+var _ RoundTripper = DNSOverHTTPS{}

--- a/netx/resolver/dnsovertcp.go
+++ b/netx/resolver/dnsovertcp.go
@@ -93,3 +93,5 @@ func (t DNSOverTCP) Network() string {
 func (t DNSOverTCP) Address() string {
 	return t.address
 }
+
+var _ RoundTripper = DNSOverTCP{}

--- a/netx/resolver/dnsoverudp.go
+++ b/netx/resolver/dnsoverudp.go
@@ -60,3 +60,5 @@ func (t DNSOverUDP) Network() string {
 func (t DNSOverUDP) Address() string {
 	return t.address
 }
+
+var _ RoundTripper = DNSOverUDP{}

--- a/netx/resolver/emitter.go
+++ b/netx/resolver/emitter.go
@@ -8,13 +8,13 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// Emitter is a RoundTripper that emits events when they occur.
-type Emitter struct {
+// EmitterTransport is a RoundTripper that emits events when they occur.
+type EmitterTransport struct {
 	RoundTripper
 }
 
 // RoundTrip implements RoundTripper.RoundTrip
-func (txp Emitter) RoundTrip(ctx context.Context, querydata []byte) ([]byte, error) {
+func (txp EmitterTransport) RoundTrip(ctx context.Context, querydata []byte) ([]byte, error) {
 	root := modelx.ContextMeasurementRootOrDefault(ctx)
 	root.Handler.OnMeasurement(modelx.Measurement{
 		DNSQuery: &modelx.DNSQueryEvent{
@@ -36,3 +36,5 @@ func (txp Emitter) RoundTrip(ctx context.Context, querydata []byte) ([]byte, err
 	})
 	return replydata, nil
 }
+
+var _ RoundTripper = EmitterTransport{}

--- a/netx/resolver/emitter_test.go
+++ b/netx/resolver/emitter_test.go
@@ -22,7 +22,7 @@ func TestEmittingTransportSuccess(t *testing.T) {
 		Handler:   handler,
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
-	txp := resolver.Emitter{RoundTripper: resolver.FakeTransport{
+	txp := resolver.EmitterTransport{RoundTripper: resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeA, "8.8.8.8"),
 	}}
 	e := resolver.MiekgEncoder{}
@@ -74,7 +74,7 @@ func TestEmittingTransportFailure(t *testing.T) {
 	}
 	ctx = modelx.WithMeasurementRoot(ctx, root)
 	mocked := errors.New("mocked error")
-	txp := resolver.Emitter{RoundTripper: resolver.FakeTransport{
+	txp := resolver.EmitterTransport{RoundTripper: resolver.FakeTransport{
 		Err: mocked,
 	}}
 	e := resolver.MiekgEncoder{}

--- a/netx/resolver/encoder.go
+++ b/netx/resolver/encoder.go
@@ -48,3 +48,5 @@ func (e MiekgEncoder) Encode(domain string, qtype uint16, padding bool) ([]byte,
 	}
 	return query.Pack()
 }
+
+var _ Encoder = MiekgEncoder{}

--- a/netx/resolver/errorwrapper.go
+++ b/netx/resolver/errorwrapper.go
@@ -8,13 +8,13 @@ import (
 	"github.com/ooni/probe-engine/netx/internal/transactionid"
 )
 
-// ErrorWrapper is a Resolver that knows about wrapping errors.
-type ErrorWrapper struct {
+// ErrorWrapperResolver is a Resolver that knows about wrapping errors.
+type ErrorWrapperResolver struct {
 	Resolver
 }
 
 // LookupHost implements Resolver.LookupHost
-func (r ErrorWrapper) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+func (r ErrorWrapperResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	dialID := dialid.ContextDialID(ctx)
 	txID := transactionid.ContextTransactionID(ctx)
 	addrs, err := r.Resolver.LookupHost(ctx, hostname)
@@ -26,3 +26,5 @@ func (r ErrorWrapper) LookupHost(ctx context.Context, hostname string) ([]string
 	}.MaybeBuild()
 	return addrs, err
 }
+
+var _ Resolver = ErrorWrapperResolver{}

--- a/netx/resolver/errorwrapper_test.go
+++ b/netx/resolver/errorwrapper_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestUnitErrorWrapperSuccess(t *testing.T) {
 	orig := []string{"8.8.8.8"}
-	r := resolver.ErrorWrapper{
+	r := resolver.ErrorWrapperResolver{
 		Resolver: resolver.NewMockableResolverWithResult(orig),
 	}
 	addrs, err := r.LookupHost(context.Background(), "dns.google.com")
@@ -26,7 +26,7 @@ func TestUnitErrorWrapperSuccess(t *testing.T) {
 }
 
 func TestUnitErrorWrapperFailure(t *testing.T) {
-	r := resolver.ErrorWrapper{
+	r := resolver.ErrorWrapperResolver{
 		Resolver: resolver.NewMockableResolverThatFails(),
 	}
 	ctx := context.Background()

--- a/netx/resolver/mockable.go
+++ b/netx/resolver/mockable.go
@@ -7,9 +7,9 @@ import (
 	"github.com/ooni/probe-engine/atomicx"
 )
 
-// Mockable is a mockable resolver that other packages can
+// MockableResolver is a mockable resolver that other packages can
 // import to simulate a resolver's behaviour.
-type Mockable struct {
+type MockableResolver struct {
 	NumFailures *atomicx.Int64
 	err         error
 	result      []string
@@ -17,14 +17,14 @@ type Mockable struct {
 
 // NewMockableResolverThatFails creates a new MockableResolver instance
 // that always returns an error indicating NXDOMAIN.
-func NewMockableResolverThatFails() Mockable {
-	return Mockable{NumFailures: atomicx.NewInt64(), err: errNotFound}
+func NewMockableResolverThatFails() MockableResolver {
+	return MockableResolver{NumFailures: atomicx.NewInt64(), err: errNotFound}
 }
 
 // NewMockableResolverWithResult creates a new MockableResolver
 // instance that always returns the specified result.
-func NewMockableResolverWithResult(r []string) Mockable {
-	return Mockable{NumFailures: atomicx.NewInt64(), result: r}
+func NewMockableResolverWithResult(r []string) MockableResolver {
+	return MockableResolver{NumFailures: atomicx.NewInt64(), result: r}
 }
 
 var errNotFound = &net.DNSError{
@@ -32,10 +32,12 @@ var errNotFound = &net.DNSError{
 }
 
 // LookupHost returns the IP addresses of a host
-func (c Mockable) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+func (c MockableResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	if c.err != nil {
 		c.NumFailures.Add(1)
 		return nil, c.err
 	}
 	return c.result, nil
 }
+
+var _ Resolver = MockableResolver{}

--- a/netx/resolver/parent_test.go
+++ b/netx/resolver/parent_test.go
@@ -30,7 +30,7 @@ func (h *emitterchecker) OnMeasurement(m modelx.Measurement) {
 }
 
 func TestParentLookupHost(t *testing.T) {
-	client := resolver.NewParentResolver(resolver.System{})
+	client := resolver.NewParentResolver(resolver.SystemResolver{})
 	handler := new(emitterchecker)
 	ctx := modelx.WithMeasurementRoot(
 		context.Background(), &modelx.MeasurementRoot{
@@ -58,7 +58,7 @@ func TestParentLookupHost(t *testing.T) {
 }
 
 func TestParentLookupHostBogonHardError(t *testing.T) {
-	client := resolver.NewParentResolver(resolver.System{})
+	client := resolver.NewParentResolver(resolver.SystemResolver{})
 	handler := new(emitterchecker)
 	ctx := modelx.WithMeasurementRoot(
 		context.Background(), &modelx.MeasurementRoot{
@@ -85,7 +85,7 @@ func TestParentLookupHostBogonHardError(t *testing.T) {
 }
 
 func TestParentLookupHostBogonAsWarning(t *testing.T) {
-	client := resolver.NewParentResolver(resolver.System{})
+	client := resolver.NewParentResolver(resolver.SystemResolver{})
 	handler := new(emitterchecker)
 	ctx := modelx.WithMeasurementRoot(
 		context.Background(), &modelx.MeasurementRoot{

--- a/netx/resolver/resolver.go
+++ b/netx/resolver/resolver.go
@@ -19,21 +19,21 @@ func NewResolverSystem() *ParentResolver {
 
 // NewResolverUDP creates a new UDP resolver.
 func NewResolverUDP(dialer Dialer, address string) *ParentResolver {
-	return NewParentResolver(NewOONI(Emitter{
+	return NewParentResolver(NewSerial(Emitter{
 		RoundTripper: NewDNSOverUDP(dialer, address),
 	}))
 }
 
 // NewResolverTCP creates a new TCP resolver.
 func NewResolverTCP(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewOONI(Emitter{
+	return NewParentResolver(NewSerial(Emitter{
 		RoundTripper: NewDNSOverTCP(dial, address),
 	}))
 }
 
 // NewResolverTLS creates a new DoT resolver.
 func NewResolverTLS(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewOONI(Emitter{
+	return NewParentResolver(NewSerial(Emitter{
 		RoundTripper: NewDNSOverTLS(dial, address),
 	}))
 }
@@ -41,6 +41,6 @@ func NewResolverTLS(dial DialContextFunc, address string) *ParentResolver {
 // NewResolverHTTPS creates a new DoH resolver.
 func NewResolverHTTPS(client *http.Client, address string) *ParentResolver {
 	return NewParentResolver(
-		NewOONI(NewDNSOverHTTPS(client, address)),
+		NewSerial(NewDNSOverHTTPS(client, address)),
 	)
 }

--- a/netx/resolver/resolver.go
+++ b/netx/resolver/resolver.go
@@ -14,26 +14,26 @@ type Resolver interface {
 
 // NewResolverSystem creates a new Go/system resolver.
 func NewResolverSystem() *ParentResolver {
-	return NewParentResolver(System{})
+	return NewParentResolver(SystemResolver{})
 }
 
 // NewResolverUDP creates a new UDP resolver.
 func NewResolverUDP(dialer Dialer, address string) *ParentResolver {
-	return NewParentResolver(NewSerial(Emitter{
+	return NewParentResolver(NewSerial(EmitterTransport{
 		RoundTripper: NewDNSOverUDP(dialer, address),
 	}))
 }
 
 // NewResolverTCP creates a new TCP resolver.
 func NewResolverTCP(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewSerial(Emitter{
+	return NewParentResolver(NewSerial(EmitterTransport{
 		RoundTripper: NewDNSOverTCP(dial, address),
 	}))
 }
 
 // NewResolverTLS creates a new DoT resolver.
 func NewResolverTLS(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewSerial(Emitter{
+	return NewParentResolver(NewSerial(EmitterTransport{
 		RoundTripper: NewDNSOverTLS(dial, address),
 	}))
 }

--- a/netx/resolver/resolver.go
+++ b/netx/resolver/resolver.go
@@ -19,21 +19,21 @@ func NewResolverSystem() *ParentResolver {
 
 // NewResolverUDP creates a new UDP resolver.
 func NewResolverUDP(dialer Dialer, address string) *ParentResolver {
-	return NewParentResolver(NewSerial(EmitterTransport{
+	return NewParentResolver(NewSerialResolver(EmitterTransport{
 		RoundTripper: NewDNSOverUDP(dialer, address),
 	}))
 }
 
 // NewResolverTCP creates a new TCP resolver.
 func NewResolverTCP(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewSerial(EmitterTransport{
+	return NewParentResolver(NewSerialResolver(EmitterTransport{
 		RoundTripper: NewDNSOverTCP(dial, address),
 	}))
 }
 
 // NewResolverTLS creates a new DoT resolver.
 func NewResolverTLS(dial DialContextFunc, address string) *ParentResolver {
-	return NewParentResolver(NewSerial(EmitterTransport{
+	return NewParentResolver(NewSerialResolver(EmitterTransport{
 		RoundTripper: NewDNSOverTLS(dial, address),
 	}))
 }
@@ -41,6 +41,6 @@ func NewResolverTLS(dial DialContextFunc, address string) *ParentResolver {
 // NewResolverHTTPS creates a new DoH resolver.
 func NewResolverHTTPS(client *http.Client, address string) *ParentResolver {
 	return NewParentResolver(
-		NewSerial(NewDNSOverHTTPS(client, address)),
+		NewSerialResolver(NewDNSOverHTTPS(client, address)),
 	)
 }

--- a/netx/resolver/serial.go
+++ b/netx/resolver/serial.go
@@ -33,8 +33,8 @@ type SerialResolver struct {
 	Txp         RoundTripper
 }
 
-// NewSerial creates a new OONI Resolver instance.
-func NewSerial(t RoundTripper) SerialResolver {
+// NewSerialResolver creates a new OONI Resolver instance.
+func NewSerialResolver(t RoundTripper) SerialResolver {
 	return SerialResolver{
 		Encoder:     MiekgEncoder{},
 		Decoder:     MiekgDecoder{},

--- a/netx/resolver/serial_test.go
+++ b/netx/resolver/serial_test.go
@@ -24,7 +24,7 @@ func TestUnitOONIGettingTransport(t *testing.T) {
 func TestUnitOONIEncodeError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
-	r := resolver.Serial{Encoder: resolver.FakeEncoder{Err: mocked}, Txp: txp}
+	r := resolver.SerialResolver{Encoder: resolver.FakeEncoder{Err: mocked}, Txp: txp}
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, mocked) {
 		t.Fatal("not the error we expected")

--- a/netx/resolver/serial_test.go
+++ b/netx/resolver/serial_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestUnitOONIGettingTransport(t *testing.T) {
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
-	r := resolver.NewOONI(txp)
+	r := resolver.NewSerial(txp)
 	rtx := r.Transport()
 	if rtx.Network() != "dot" || rtx.Address() != "8.8.8.8:853" {
 		t.Fatal("not the transport we expected")
@@ -24,7 +24,7 @@ func TestUnitOONIGettingTransport(t *testing.T) {
 func TestUnitOONIEncodeError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
-	r := resolver.OONI{Encoder: resolver.FakeEncoder{Err: mocked}, Txp: txp}
+	r := resolver.Serial{Encoder: resolver.FakeEncoder{Err: mocked}, Txp: txp}
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, mocked) {
 		t.Fatal("not the error we expected")
@@ -37,7 +37,7 @@ func TestUnitOONIEncodeError(t *testing.T) {
 func TestUnitOONIRoundTripError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.FakeTransport{Err: mocked}
-	r := resolver.NewOONI(txp)
+	r := resolver.NewSerial(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, mocked) {
 		t.Fatal("not the error we expected")
@@ -49,7 +49,7 @@ func TestUnitOONIRoundTripError(t *testing.T) {
 
 func TestUnitOONIWithEmptyReply(t *testing.T) {
 	txp := resolver.FakeTransport{Data: resolver.GenReplySuccess(t, dns.TypeA)}
-	r := resolver.NewOONI(txp)
+	r := resolver.NewSerial(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err == nil || !strings.HasSuffix(err.Error(), "no response returned") {
 		t.Fatal("not the error we expected")
@@ -63,7 +63,7 @@ func TestUnitOONIWithAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeA, "8.8.8.8"),
 	}
-	r := resolver.NewOONI(txp)
+	r := resolver.NewSerial(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestUnitOONIWithAAAAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeAAAA, "::1"),
 	}
-	r := resolver.NewOONI(txp)
+	r := resolver.NewSerial(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +91,7 @@ func TestUnitOONIWithTimeout(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Err: &net.OpError{Err: syscall.ETIMEDOUT, Op: "dial"},
 	}
-	r := resolver.NewOONI(txp)
+	r := resolver.NewSerial(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, syscall.ETIMEDOUT) {
 		t.Fatal("not the error we expected")

--- a/netx/resolver/serial_test.go
+++ b/netx/resolver/serial_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestUnitOONIGettingTransport(t *testing.T) {
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
-	r := resolver.NewSerial(txp)
+	r := resolver.NewSerialResolver(txp)
 	rtx := r.Transport()
 	if rtx.Network() != "dot" || rtx.Address() != "8.8.8.8:853" {
 		t.Fatal("not the transport we expected")
@@ -37,7 +37,7 @@ func TestUnitOONIEncodeError(t *testing.T) {
 func TestUnitOONIRoundTripError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.FakeTransport{Err: mocked}
-	r := resolver.NewSerial(txp)
+	r := resolver.NewSerialResolver(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, mocked) {
 		t.Fatal("not the error we expected")
@@ -49,7 +49,7 @@ func TestUnitOONIRoundTripError(t *testing.T) {
 
 func TestUnitOONIWithEmptyReply(t *testing.T) {
 	txp := resolver.FakeTransport{Data: resolver.GenReplySuccess(t, dns.TypeA)}
-	r := resolver.NewSerial(txp)
+	r := resolver.NewSerialResolver(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err == nil || !strings.HasSuffix(err.Error(), "no response returned") {
 		t.Fatal("not the error we expected")
@@ -63,7 +63,7 @@ func TestUnitOONIWithAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeA, "8.8.8.8"),
 	}
-	r := resolver.NewSerial(txp)
+	r := resolver.NewSerialResolver(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestUnitOONIWithAAAAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeAAAA, "::1"),
 	}
-	r := resolver.NewSerial(txp)
+	r := resolver.NewSerialResolver(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +91,7 @@ func TestUnitOONIWithTimeout(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Err: &net.OpError{Err: syscall.ETIMEDOUT, Op: "dial"},
 	}
-	r := resolver.NewSerial(txp)
+	r := resolver.NewSerialResolver(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
 	if !errors.Is(err, syscall.ETIMEDOUT) {
 		t.Fatal("not the error we expected")

--- a/netx/resolver/system.go
+++ b/netx/resolver/system.go
@@ -6,8 +6,8 @@ import (
 	"net"
 )
 
-// System is the system resolver
-type System struct{}
+// SystemResolver is the system resolver
+type SystemResolver struct{}
 
 // SystemTransport is the fake transport for the system resolver
 type SystemTransport struct{}
@@ -33,11 +33,14 @@ func (SystemTransport) Address() string {
 }
 
 // Transport returns the transport being used
-func (r System) Transport() RoundTripper {
+func (r SystemResolver) Transport() RoundTripper {
 	return SystemTransport{}
 }
 
 // LookupHost returns the IP addresses of a host
-func (r System) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+func (r SystemResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	return net.DefaultResolver.LookupHost(ctx, hostname)
 }
+
+var _ Resolver = SystemResolver{}
+var _ RoundTripper = SystemTransport{}

--- a/netx/resolver/system_test.go
+++ b/netx/resolver/system_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUnitSystemResolverTransport(t *testing.T) {
-	r := resolver.System{}
+	r := resolver.SystemResolver{}
 	transport := r.Transport()
 	reply, err := transport.RoundTrip(context.Background(), nil)
 	if err == nil || err.Error() != "not implemented" {
@@ -29,7 +29,7 @@ func TestUnitSystemResolverTransport(t *testing.T) {
 }
 
 func TestIntegrationSystemResolverLookupHost(t *testing.T) {
-	r := resolver.System{}
+	r := resolver.SystemResolver{}
 	addrs, err := r.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/359