### PR TITLE
netx/dialer: don't allow diverting lookup host

### DIFF
--- a/netx/dialer/dns_test.go
+++ b/netx/dialer/dns_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/handlers"
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
@@ -106,27 +105,4 @@ func TestUnitReduceErrors(t *testing.T) {
 			t.Fatal("wrong result")
 		}
 	})
-}
-
-func TestIntegrationDNSDialerDivertLookupHost(t *testing.T) {
-	dialer := dialer.DNSDialer{Dialer: new(net.Dialer), Resolver: new(net.Resolver)}
-	failure := errors.New("mocked error")
-	root := &modelx.MeasurementRoot{
-		Beginning: time.Now(),
-		Handler:   handlers.NoHandler,
-		LookupHost: func(ctx context.Context, hostname string) ([]string, error) {
-			return nil, failure
-		},
-	}
-	ctx := modelx.WithMeasurementRoot(context.Background(), root)
-	conn, err := dialer.DialContext(ctx, "tcp", "google.com:443")
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if !errors.Is(err, failure) {
-		t.Fatal("not the error we expected")
-	}
-	if conn != nil {
-		t.Fatal("expected a nil conn here")
-	}
 }

--- a/netx/modelx/modelx.go
+++ b/netx/modelx/modelx.go
@@ -748,10 +748,6 @@ type MeasurementRoot struct {
 	// we use math.MaxInt64. If the value is zero, we use a
 	// reasonable large value. Otherwise, we'll use this value.
 	MaxBodySnapSize int64
-
-	// LookupHost allows to override the host lookup for all the request
-	// and dials that use this measurement root.
-	LookupHost func(ctx context.Context, hostname string) ([]string, error)
 }
 
 type measurementRootContextKey struct{}


### PR DESCRIPTION
Let's try and use the context as little as possible as said
in https://github.com/ooni/probe-engine/issues/359