### PR TITLE
netx/dialer: finish refactoring

### DIFF
--- a/netx/dialer/bytecounter.go
+++ b/netx/dialer/bytecounter.go
@@ -27,6 +27,16 @@ func NewByteCounter() *ByteCounter {
 
 // ByteCounterDialer is a byte-counting-aware dialer. To perform byte counting, you
 // should make sure that you insert this dialer in the dialing chain.
+//
+// Bug
+//
+// This implementation cannot properly account for the bytes that are sent by
+// persistent connections, because they strick to the counters set when the
+// connection was established. This typically means we miss the bytes sent and
+// received when submitting a measurement. Such bytes are specifically not
+// see by the experiment specific byte counter.
+//
+// For this reason, this implementation may be heavily changed/removed.
 type ByteCounterDialer struct {
 	Dialer
 }

--- a/netx/dialer/emitter.go
+++ b/netx/dialer/emitter.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// EmitterDialer is a dialer that emits events
+// EmitterDialer is a Dialer that emits events
 type EmitterDialer struct {
 	Dialer
 }
@@ -44,7 +44,7 @@ func (d EmitterDialer) DialContext(ctx context.Context, network, address string)
 	}, nil
 }
 
-// EmitterConn is a net.Conn used to emit measurements
+// EmitterConn is a net.Conn used to emit events
 type EmitterConn struct {
 	net.Conn
 	Beginning time.Time
@@ -52,7 +52,7 @@ type EmitterConn struct {
 	ID        int64
 }
 
-// Read reads data from the connection.
+// Read implements net.Conn.Read
 func (c EmitterConn) Read(b []byte) (n int, err error) {
 	start := time.Now()
 	n, err = c.Conn.Read(b)
@@ -69,7 +69,7 @@ func (c EmitterConn) Read(b []byte) (n int, err error) {
 	return
 }
 
-// Write writes data to the connection
+// Write implements net.Conn.Write
 func (c EmitterConn) Write(b []byte) (n int, err error) {
 	start := time.Now()
 	n, err = c.Conn.Write(b)
@@ -86,7 +86,7 @@ func (c EmitterConn) Write(b []byte) (n int, err error) {
 	return
 }
 
-// Close closes the connection
+// Close implements net.Conn.Close
 func (c EmitterConn) Close() (err error) {
 	start := time.Now()
 	err = c.Conn.Close()

--- a/netx/dialer/errorwrapper.go
+++ b/netx/dialer/errorwrapper.go
@@ -38,7 +38,7 @@ type ErrorWrapperConn struct {
 	DialID int64
 }
 
-// Read reads data from the connection.
+// Read implements net.Conn.Read
 func (c ErrorWrapperConn) Read(b []byte) (n int, err error) {
 	n, err = c.Conn.Read(b)
 	err = errwrapper.SafeErrWrapperBuilder{
@@ -50,7 +50,7 @@ func (c ErrorWrapperConn) Read(b []byte) (n int, err error) {
 	return
 }
 
-// Write writes data to the connection
+// Write implements net.Conn.Write
 func (c ErrorWrapperConn) Write(b []byte) (n int, err error) {
 	n, err = c.Conn.Write(b)
 	err = errwrapper.SafeErrWrapperBuilder{
@@ -62,7 +62,7 @@ func (c ErrorWrapperConn) Write(b []byte) (n int, err error) {
 	return
 }
 
-// Close closes the connection
+// Close implements net.Conn.Close
 func (c ErrorWrapperConn) Close() (err error) {
 	err = c.Conn.Close()
 	err = errwrapper.SafeErrWrapperBuilder{

--- a/netx/dialer/integration_test.go
+++ b/netx/dialer/integration_test.go
@@ -1,117 +1,41 @@
 package dialer_test
 
 import (
-	"context"
-	"crypto/tls"
 	"net"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/handlers"
 )
 
 func TestIntegrationTLSDialerSuccess(t *testing.T) {
-	dialer := dialer.NewTLSDialer(new(net.Dialer), new(tls.Config))
-	conn, err := dialer.DialTLSContext(context.Background(), "tcp", "www.google.com:443")
-	if err != nil {
-		t.Fatal(err)
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
 	}
-	if conn == nil {
-		t.Fatal("connection is nil")
-	}
-	conn.Close()
-}
-
-func TestIntegrationBaseDialerSuccess(t *testing.T) {
-	dialer := newBaseDialer()
-	txp := &http.Transport{
-		DialContext: dialer.DialContext,
-	}
+	dialer := dialer.TLSDialer{Dialer: new(net.Dialer),
+		TLSHandshaker: dialer.SystemTLSHandshaker{}}
+	txp := &http.Transport{DialTLSContext: dialer.DialTLSContext}
 	client := &http.Client{Transport: txp}
-	resp, err := client.Get("http://www.google.com")
+	resp, err := client.Get("https://www.google.com")
 	if err != nil {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
 }
 
-func TestIntegrationBaseDialerErrorNoConnect(t *testing.T) {
-	dialer := newBaseDialer()
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // stop immediately
-	conn, err := dialer.DialContext(ctx, "tcp", "8.8.8.8:53")
-	if err == nil {
-		t.Fatal("expected an error here")
+func TestIntegrationDNSDialerSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
 	}
-	if ctx.Err() == nil {
-		t.Fatal("expected context to be expired here")
+	dialer := dialer.DNSDialer{
+		Dialer:   new(net.Dialer),
+		Resolver: new(net.Resolver),
 	}
-	if conn != nil {
-		t.Fatal("expected nil conn here")
-	}
-}
-
-// see whether we implement the interface
-func newBaseDialer() dialer.Dialer {
-	return dialer.EmitterDialer{
-		Dialer: dialer.ErrorWrapperDialer{
-			Dialer: dialer.TimeoutDialer{
-				Dialer: new(net.Dialer),
-			},
-		},
-	}
-}
-
-func TestIntegrationEmitterConn(t *testing.T) {
-	conn := net.Conn(&dialer.EmitterConn{
-		Conn:    fakeconn{},
-		Handler: handlers.NoHandler,
-	})
-	defer conn.Close()
-	data := make([]byte, 1<<17)
-	n, err := conn.Read(data)
+	txp := &http.Transport{DialContext: dialer.DialContext}
+	client := &http.Client{Transport: txp}
+	resp, err := client.Get("http://www.google.com")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n != len(data) {
-		t.Fatal("invalid number of bytes read")
-	}
-	n, err = conn.Write(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != len(data) {
-		t.Fatal("invalid number of bytes written")
-	}
-}
-
-type fakeconn struct{}
-
-func (fakeconn) Read(b []byte) (n int, err error) {
-	n = len(b)
-	return
-}
-func (fakeconn) Write(b []byte) (n int, err error) {
-	n = len(b)
-	return
-}
-func (fakeconn) Close() (err error) {
-	return
-}
-func (fakeconn) LocalAddr() net.Addr {
-	return &net.TCPAddr{}
-}
-func (fakeconn) RemoteAddr() net.Addr {
-	return &net.TCPAddr{}
-}
-func (fakeconn) SetDeadline(t time.Time) (err error) {
-	return
-}
-func (fakeconn) SetReadDeadline(t time.Time) (err error) {
-	return
-}
-func (fakeconn) SetWriteDeadline(t time.Time) (err error) {
-	return
+	resp.Body.Close()
 }

--- a/netx/dialer/timeout.go
+++ b/netx/dialer/timeout.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// TimeoutDialer is a wrapper for the system dialer
+// TimeoutDialer is a Dialer that enforces a timeout
 type TimeoutDialer struct {
 	Dialer
 	ConnectTimeout time.Duration // default: 30 seconds

--- a/netx/dialer/tls.go
+++ b/netx/dialer/tls.go
@@ -115,29 +115,7 @@ type TLSDialer struct {
 	TLSHandshaker TLSHandshaker
 }
 
-// NewTLSDialer creates a new TLSDialer using:
-//
-// - EmitterTLSHandshaker (topmost)
-// - ErrorWrapperTLSHandshaker
-// - TimeoutTLSHandshaker
-// - SystemTLSHandshaker
-//
-// If you have others needs, manually build the chain you need.
-func NewTLSDialer(dialer Dialer, config *tls.Config) TLSDialer {
-	return TLSDialer{
-		Config: config,
-		Dialer: dialer,
-		TLSHandshaker: EmitterTLSHandshaker{
-			TLSHandshaker: ErrorWrapperTLSHandshaker{
-				TLSHandshaker: TimeoutTLSHandshaker{
-					TLSHandshaker: SystemTLSHandshaker{},
-				},
-			},
-		},
-	}
-}
-
-// DialTLSContext is like DialTLS, but with context
+// DialTLSContext is like tls.DialTLS but with the signature of net.Dialer.DialContext
 func (d TLSDialer) DialTLSContext(ctx context.Context, network, address string) (net.Conn, error) {
 	// Implementation note: when DialTLS is not set, the code in
 	// net/http will perform the handshake. Otherwise, if DialTLS


### PR DESCRIPTION
- move policy to netx/dialer.go (i.e. down one level)

- improve documentation

- make integration tests skippable

Part of https://github.com/ooni/probe-engine/issues/359