### PR TITLE
rename(netx): httptransport => oldhttptransport

### DIFF
--- a/netx/http.go
+++ b/netx/http.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/netx/handlers"
-	"github.com/ooni/probe-engine/netx/httptransport"
 	"github.com/ooni/probe-engine/netx/internal/errwrapper"
 	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/oldhttptransport"
 	"golang.org/x/net/http2"
 )
 
@@ -39,7 +39,7 @@ func newHTTPTransport(
 		TLSHandshakeTimeout:   10 * time.Second,
 		DisableKeepAlives:     disableKeepAlives,
 	}
-	ooniTransport := httptransport.New(baseTransport)
+	ooniTransport := oldhttptransport.New(baseTransport)
 	// Configure h2 and make sure that the custom TLSConfig we use for dialing
 	// is actually compatible with upgrading to h2. (This mainly means we
 	// need to make sure we include "h2" in the NextProtos array.) Because

--- a/netx/oldhttptransport/bodytracer.go
+++ b/netx/oldhttptransport/bodytracer.go
@@ -1,4 +1,4 @@
-package httptransport
+package oldhttptransport
 
 import (
 	"io"

--- a/netx/oldhttptransport/bodytracer_test.go
+++ b/netx/oldhttptransport/bodytracer_test.go
@@ -1,4 +1,4 @@
-package httptransport
+package oldhttptransport
 
 import (
 	"io/ioutil"
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func TestIntegration(t *testing.T) {
+func TestIntegrationBodyTracerSuccess(t *testing.T) {
 	client := &http.Client{
-		Transport: New(http.DefaultTransport),
+		Transport: NewBodyTracer(http.DefaultTransport),
 	}
 	resp, err := client.Get("https://www.google.com")
 	if err != nil {
@@ -22,9 +22,9 @@ func TestIntegration(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationFailure(t *testing.T) {
+func TestIntegrationBodyTracerFailure(t *testing.T) {
 	client := &http.Client{
-		Transport: New(http.DefaultTransport),
+		Transport: NewBodyTracer(http.DefaultTransport),
 	}
 	// This fails the request because we attempt to speak cleartext HTTP with
 	// a server that instead is expecting TLS.

--- a/netx/oldhttptransport/httptransport.go
+++ b/netx/oldhttptransport/httptransport.go
@@ -1,6 +1,6 @@
-// Package httptransport contains HTTP transport extensions. Here we
+// Package oldhttptransport contains HTTP transport extensions. Here we
 // define a http.Transport that emits events.
-package httptransport
+package oldhttptransport
 
 import (
 	"net/http"

--- a/netx/oldhttptransport/httptransport_test.go
+++ b/netx/oldhttptransport/httptransport_test.go
@@ -1,4 +1,4 @@
-package httptransport
+package oldhttptransport
 
 import (
 	"io/ioutil"
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-func TestIntegrationBodyTracerSuccess(t *testing.T) {
+func TestIntegration(t *testing.T) {
 	client := &http.Client{
-		Transport: NewBodyTracer(http.DefaultTransport),
+		Transport: New(http.DefaultTransport),
 	}
 	resp, err := client.Get("https://www.google.com")
 	if err != nil {
@@ -22,9 +22,9 @@ func TestIntegrationBodyTracerSuccess(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationBodyTracerFailure(t *testing.T) {
+func TestIntegrationFailure(t *testing.T) {
 	client := &http.Client{
-		Transport: NewBodyTracer(http.DefaultTransport),
+		Transport: New(http.DefaultTransport),
 	}
 	// This fails the request because we attempt to speak cleartext HTTP with
 	// a server that instead is expecting TLS.

--- a/netx/oldhttptransport/tracetripper.go
+++ b/netx/oldhttptransport/tracetripper.go
@@ -1,4 +1,4 @@
-package httptransport
+package oldhttptransport
 
 import (
 	"bytes"

--- a/netx/oldhttptransport/tracetripper_test.go
+++ b/netx/oldhttptransport/tracetripper_test.go
@@ -1,4 +1,4 @@
-package httptransport
+package oldhttptransport
 
 import (
 	"bytes"

--- a/netx/oldhttptransport/transactioner.go
+++ b/netx/oldhttptransport/transactioner.go
@@ -1,4 +1,4 @@
-package httptransport
+package oldhttptransport
 
 import (
 	"net/http"

--- a/netx/oldhttptransport/transactioner_test.go
+++ b/netx/oldhttptransport/transactioner_test.go
@@ -1,4 +1,4 @@
-package httptransport
+package oldhttptransport
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
The existing transport mechanism is working but it's relying too much
on the context, which is not what we said we wanted to do next in
https://github.com/ooni/probe-engine/issues/359. While it was relatively
quick and easy to refactor resolver and dialer, it seems more long and
complicated to wrestle with the transport.

Hence, the choice to rename the existing transport `oldtransport` and
to start afresh using different design principles.

Existing code should continue of work.

Part of https://github.com/ooni/probe-engine/issues/359.