### PR TITLE
netx/{dialer,resolver}: introduce independent logger

### DIFF
--- a/netx/dialer/integration_test.go
+++ b/netx/dialer/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/apex/log"
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
@@ -13,8 +14,13 @@ func TestIntegrationTLSDialerSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+	log.SetLevel(log.DebugLevel)
 	dialer := dialer.TLSDialer{Dialer: new(net.Dialer),
-		TLSHandshaker: dialer.SystemTLSHandshaker{}}
+		TLSHandshaker: dialer.LoggingTLSHandshaker{
+			TLSHandshaker: dialer.SystemTLSHandshaker{},
+			Logger:        log.Log,
+		},
+	}
 	txp := &http.Transport{DialTLS: func(network, address string) (net.Conn, error) {
 		// AlpineLinux edge is still using Go 1.13. We cannot switch to
 		// using DialTLSContext here as we'd like to until either Alpine
@@ -33,8 +39,12 @@ func TestIntegrationDNSDialerSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+	log.SetLevel(log.DebugLevel)
 	dialer := dialer.DNSDialer{
-		Dialer:   new(net.Dialer),
+		Dialer: dialer.LoggingDialer{
+			Dialer: new(net.Dialer),
+			Logger: log.Log,
+		},
 		Resolver: new(net.Resolver),
 	}
 	txp := &http.Transport{DialContext: dialer.DialContext}

--- a/netx/dialer/logging.go
+++ b/netx/dialer/logging.go
@@ -1,0 +1,56 @@
+package dialer
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"time"
+
+	"github.com/ooni/probe-engine/internal/tlsx"
+)
+
+// Logger is the logger assumed by this package
+type Logger interface {
+	Debugf(format string, v ...interface{})
+	Debug(message string)
+}
+
+// LoggingDialer is a Dialer with logging
+type LoggingDialer struct {
+	Dialer
+	Logger Logger
+}
+
+// DialContext implements Dialer.DialContext
+func (d LoggingDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	d.Logger.Debugf("dial %s/%s...", address, network)
+	start := time.Now()
+	conn, err := d.Dialer.DialContext(ctx, network, address)
+	stop := time.Now()
+	d.Logger.Debugf("dial %s/%s... %+v in %s", address, network, err, stop.Sub(start))
+	return conn, err
+}
+
+// LoggingTLSHandshaker is a TLSHandshaker with logging
+type LoggingTLSHandshaker struct {
+	TLSHandshaker
+	Logger Logger
+}
+
+// Handshake implements Handshaker.Handshake
+func (h LoggingTLSHandshaker) Handshake(
+	ctx context.Context, conn net.Conn, config *tls.Config,
+) (net.Conn, tls.ConnectionState, error) {
+	h.Logger.Debugf("tls {sni=%s netx=%+v}...", config.ServerName, config.NextProtos)
+	start := time.Now()
+	tlsconn, state, err := h.TLSHandshaker.Handshake(ctx, conn, config)
+	stop := time.Now()
+	h.Logger.Debugf(
+		"tls {sni=%s next=%+v}... %+v in %s {next=%s cipher=%s v=%s}", config.ServerName,
+		config.NextProtos, err, stop.Sub(start), state.NegotiatedProtocol,
+		tlsx.CipherSuiteString(state.CipherSuite), tlsx.VersionString(state.Version))
+	return tlsconn, state, err
+}
+
+var _ Dialer = LoggingDialer{}
+var _ TLSHandshaker = LoggingTLSHandshaker{}

--- a/netx/dialer/logging_test.go
+++ b/netx/dialer/logging_test.go
@@ -1,0 +1,42 @@
+package dialer_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/netx/dialer"
+)
+
+func TestUnitLoggingDialerFailure(t *testing.T) {
+	d := dialer.LoggingDialer{
+		Dialer: dialer.EOFDialer{},
+		Logger: log.Log,
+	}
+	conn, err := d.DialContext(context.Background(), "tcp", "www.google.com:443")
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("expected nil conn here")
+	}
+}
+
+func TestUnitLoggingTLSHandshakerFailure(t *testing.T) {
+	h := dialer.LoggingTLSHandshaker{
+		TLSHandshaker: dialer.EOFTLSHandshaker{},
+		Logger:        log.Log,
+	}
+	tlsconn, _, err := h.Handshake(context.Background(), dialer.EOFConn{}, &tls.Config{
+		ServerName: "www.google.com",
+	})
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if tlsconn != nil {
+		t.Fatal("expected nil tlsconn here")
+	}
+}

--- a/netx/resolver/integration_test.go
+++ b/netx/resolver/integration_test.go
@@ -1,17 +1,25 @@
-package resolver
+package resolver_test
 
 import (
 	"context"
 	"net"
 	"net/http"
 	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func testresolverquick(t *testing.T, resolver Resolver) {
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+func testresolverquick(t *testing.T, reso resolver.Resolver) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	addrs, err := resolver.LookupHost(context.Background(), "dns.google.com")
+	reso = resolver.LoggingResolver{Logger: log.Log, Resolver: reso}
+	addrs, err := reso.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,39 +38,40 @@ func testresolverquick(t *testing.T, resolver Resolver) {
 }
 
 func TestIntegrationNewResolverSystem(t *testing.T) {
-	testresolverquick(t, SystemResolver{})
+	testresolverquick(t, resolver.SystemResolver{})
 }
 
 func TestIntegrationNewResolverUDPAddress(t *testing.T) {
-	testresolverquick(t, NewSerialResolver(NewDNSOverUDP(new(net.Dialer), "8.8.8.8:53")))
+	testresolverquick(t, resolver.NewSerialResolver(
+		resolver.NewDNSOverUDP(new(net.Dialer), "8.8.8.8:53")))
 }
 
 func TestIntegrationNewResolverUDPDomain(t *testing.T) {
-	testresolverquick(
-		t, NewSerialResolver(NewDNSOverUDP(new(net.Dialer), "dns.google.com:53")))
+	testresolverquick(t, resolver.NewSerialResolver(
+		resolver.NewDNSOverUDP(new(net.Dialer), "dns.google.com:53")))
 }
 
 func TestIntegrationNewResolverTCPAddress(t *testing.T) {
-	testresolverquick(t, NewSerialResolver(NewDNSOverTCP(
-		new(net.Dialer).DialContext, "8.8.8.8:53")))
+	testresolverquick(t, resolver.NewSerialResolver(
+		resolver.NewDNSOverTCP(new(net.Dialer).DialContext, "8.8.8.8:53")))
 }
 
 func TestIntegrationNewResolverTCPDomain(t *testing.T) {
-	testresolverquick(t, NewSerialResolver(NewDNSOverTCP(
-		new(net.Dialer).DialContext, "dns.google.com:53")))
+	testresolverquick(t, resolver.NewSerialResolver(
+		resolver.NewDNSOverTCP(new(net.Dialer).DialContext, "dns.google.com:53")))
 }
 
 func TestIntegrationNewResolverDoTAddress(t *testing.T) {
-	testresolverquick(t, NewSerialResolver(NewDNSOverTLS(
-		DialTLSContext, "8.8.8.8:853")))
+	testresolverquick(t, resolver.NewSerialResolver(
+		resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")))
 }
 
 func TestIntegrationNewResolverDoTDomain(t *testing.T) {
-	testresolverquick(t, NewSerialResolver(NewDNSOverTLS(
-		DialTLSContext, "dns.google.com:853")))
+	testresolverquick(t, resolver.NewSerialResolver(
+		resolver.NewDNSOverTLS(resolver.DialTLSContext, "dns.google.com:853")))
 }
 
 func TestIntegrationNewResolverDoH(t *testing.T) {
-	testresolverquick(t, NewSerialResolver(NewDNSOverHTTPS(
-		http.DefaultClient, "https://cloudflare-dns.com/dns-query")))
+	testresolverquick(t, resolver.NewSerialResolver(
+		resolver.NewDNSOverHTTPS(http.DefaultClient, "https://cloudflare-dns.com/dns-query")))
 }

--- a/netx/resolver/logging.go
+++ b/netx/resolver/logging.go
@@ -1,0 +1,30 @@
+package resolver
+
+import (
+	"context"
+	"time"
+)
+
+// Logger is the logger assumed by this package
+type Logger interface {
+	Debugf(format string, v ...interface{})
+	Debug(message string)
+}
+
+// LoggingResolver is a resolver that emits events
+type LoggingResolver struct {
+	Resolver
+	Logger Logger
+}
+
+// LookupHost returns the IP addresses of a host
+func (r LoggingResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+	r.Logger.Debugf("resolve %s...", hostname)
+	start := time.Now()
+	addrs, err := r.Resolver.LookupHost(ctx, hostname)
+	stop := time.Now()
+	r.Logger.Debugf("resolve %s... (%+v, %+v) in %s", hostname, addrs, err, stop.Sub(start))
+	return addrs, err
+}
+
+var _ Resolver = LoggingResolver{}

--- a/netx/resolver/logging_test.go
+++ b/netx/resolver/logging_test.go
@@ -1,0 +1,23 @@
+package resolver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/netx/resolver"
+)
+
+func TestUnitLoggingResolver(t *testing.T) {
+	r := resolver.LoggingResolver{
+		Logger:   log.Log,
+		Resolver: resolver.NewFakeResolverThatFails(),
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.google.com")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if addrs != nil {
+		t.Fatal("expected nil addr here")
+	}
+}


### PR DESCRIPTION
One of the main points of https://github.com/ooni/probe-engine/issues/359
is that we should be logging independently of emitting events.

Let's start doing that of netx/{dialer,resolver}.

Part of https://github.com/ooni/probe-engine/issues/359.