### PR TITLE
netx: write new, simpler httptransport

### DIFF
--- a/cmd/miniooni/main.go
+++ b/cmd/miniooni/main.go
@@ -213,8 +213,8 @@ func main() {
 	defer func() {
 		sess.Close()
 		log.Infof("whole session: recv %s, sent %s",
-			humanize.SI(sess.KiBsReceived()*1024, "byte"),
-			humanize.SI(sess.KiBsSent()*1024, "byte"),
+			humanize.SI(sess.KibiBytesReceived()*1024, "byte"),
+			humanize.SI(sess.KibiBytesSent()*1024, "byte"),
 		)
 	}()
 
@@ -286,8 +286,8 @@ func main() {
 	experiment := builder.NewExperiment()
 	defer func() {
 		log.Infof("experiment: recv %s, sent %s",
-			humanize.SI(experiment.KiBsReceived()*1024, "byte"),
-			humanize.SI(experiment.KiBsSent()*1024, "byte"),
+			humanize.SI(experiment.KibiBytesReceived()*1024, "byte"),
+			humanize.SI(experiment.KibiBytesSent()*1024, "byte"),
 		)
 	}()
 

--- a/experiment.go
+++ b/experiment.go
@@ -202,14 +202,14 @@ func NewExperiment(sess *Session, measurer model.ExperimentMeasurer) *Experiment
 	}
 }
 
-// KiBsReceived accounts for the KiBs received by the HTTP clients
+// KibiBytesReceived accounts for the KibiBytes received by the HTTP clients
 // managed by this session so far, including experiments.
-func (e *Experiment) KiBsReceived() float64 {
+func (e *Experiment) KibiBytesReceived() float64 {
 	return e.byteCounter.KibiBytesReceived()
 }
 
-// KiBsSent is like KiBsReceived but for the bytes sent.
-func (e *Experiment) KiBsSent() float64 {
+// KibiBytesSent is like KibiBytesReceived but for the bytes sent.
+func (e *Experiment) KibiBytesSent() float64 {
 	return e.byteCounter.KibiBytesSent()
 }
 

--- a/experiment.go
+++ b/experiment.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ooni/probe-engine/experiment/web_connectivity"
 	"github.com/ooni/probe-engine/experiment/whatsapp"
 	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/bytecounter"
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
@@ -176,7 +177,7 @@ func newExperimentBuilder(session *Session, name string) (*ExperimentBuilder, er
 
 // Experiment is an experiment instance.
 type Experiment struct {
-	byteCounter   *dialer.ByteCounter
+	byteCounter   *bytecounter.Counter
 	callbacks     model.ExperimentCallbacks
 	measurer      model.ExperimentMeasurer
 	report        *collector.Report
@@ -191,7 +192,7 @@ type Experiment struct {
 // allows the programmer to create a custom, external experiment.
 func NewExperiment(sess *Session, measurer model.ExperimentMeasurer) *Experiment {
 	return &Experiment{
-		byteCounter:   dialer.NewByteCounter(),
+		byteCounter:   bytecounter.New(),
 		callbacks:     handler.NewPrinterCallbacks(sess.Logger()),
 		measurer:      measurer,
 		session:       sess,
@@ -204,12 +205,12 @@ func NewExperiment(sess *Session, measurer model.ExperimentMeasurer) *Experiment
 // KiBsReceived accounts for the KiBs received by the HTTP clients
 // managed by this session so far, including experiments.
 func (e *Experiment) KiBsReceived() float64 {
-	return e.byteCounter.Received.Load()
+	return e.byteCounter.KibiBytesReceived()
 }
 
 // KiBsSent is like KiBsReceived but for the bytes sent.
 func (e *Experiment) KiBsSent() float64 {
-	return e.byteCounter.Sent.Load()
+	return e.byteCounter.KibiBytesSent()
 }
 
 // Name returns the experiment name.
@@ -288,10 +289,10 @@ type sessionExperimentCallbacks struct {
 }
 
 func (cb *sessionExperimentCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
-	cb.sess.byteCounter.Received.Add(dloadKiB)
-	cb.exp.byteCounter.Received.Add(dloadKiB)
-	cb.sess.byteCounter.Sent.Add(uploadKiB)
-	cb.exp.byteCounter.Sent.Add(uploadKiB)
+	cb.sess.byteCounter.CountKibiBytesReceived(dloadKiB)
+	cb.exp.byteCounter.CountKibiBytesReceived(dloadKiB)
+	cb.sess.byteCounter.CountKibiBytesSent(uploadKiB)
+	cb.exp.byteCounter.CountKibiBytesSent(uploadKiB)
 	cb.inner.OnDataUsage(dloadKiB, uploadKiB)
 }
 

--- a/measurementkit/measurementkit.go
+++ b/measurementkit/measurementkit.go
@@ -145,7 +145,7 @@ func NewSettings(
 
 // EventValue are all the possible value keys
 type EventValue struct {
-	// DownloadedKB is the amount of downloaded KiBs
+	// DownloadedKB is the amount of downloaded KibiBytes
 	DownloadedKB float64 `json:"downloaded_kb,omitempty"`
 
 	// Failure is the failure that occurred
@@ -184,7 +184,7 @@ type EventValue struct {
 	// ReportID is the report ID
 	ReportID string `json:"report_id,omitempty"`
 
-	// UploadedKB is the amount of uploaded KiBs
+	// UploadedKB is the amount of uploaded KibiBytes
 	UploadedKB float64 `json:"uploaded_kb,omitempty"`
 }
 

--- a/netx/bytecounter/bytecounter.go
+++ b/netx/bytecounter/bytecounter.go
@@ -1,0 +1,44 @@
+package bytecounter
+
+import "github.com/ooni/probe-engine/atomicx"
+
+// Counter counts bytes sent and received.
+type Counter struct {
+	Received *atomicx.Int64
+	Sent     *atomicx.Int64
+}
+
+// New creates a new Counter.
+func New() *Counter {
+	return &Counter{Received: atomicx.NewInt64(), Sent: atomicx.NewInt64()}
+}
+
+// CountBytesSent adds count to the bytes sent counter.
+func (c *Counter) CountBytesSent(count int) {
+	c.Sent.Add(int64(count))
+}
+
+// BytesSent returns the bytes sent so far.
+func (c *Counter) BytesSent() int64 {
+	return c.Sent.Load()
+}
+
+// KibiBytesSent returns the KiB sent so far.
+func (c *Counter) KibiBytesSent() float64 {
+	return float64(c.BytesSent()) / 1024
+}
+
+// CountBytesReceived adds count to the bytes received counter.
+func (c *Counter) CountBytesReceived(count int) {
+	c.Received.Add(int64(count))
+}
+
+// BytesReceived returns the bytes received so far.
+func (c *Counter) BytesReceived() int64 {
+	return c.Received.Load()
+}
+
+// KibiBytesReceived returns the KiB received so far.
+func (c *Counter) KibiBytesReceived() float64 {
+	return float64(c.BytesReceived()) / 1024
+}

--- a/netx/bytecounter/bytecounter.go
+++ b/netx/bytecounter/bytecounter.go
@@ -18,6 +18,11 @@ func (c *Counter) CountBytesSent(count int) {
 	c.Sent.Add(int64(count))
 }
 
+// CountKibiBytesSent adds 1024*count to the bytes sent counter.
+func (c *Counter) CountKibiBytesSent(count float64) {
+	c.Sent.Add(int64(1024 * count))
+}
+
 // BytesSent returns the bytes sent so far.
 func (c *Counter) BytesSent() int64 {
 	return c.Sent.Load()
@@ -31,6 +36,11 @@ func (c *Counter) KibiBytesSent() float64 {
 // CountBytesReceived adds count to the bytes received counter.
 func (c *Counter) CountBytesReceived(count int) {
 	c.Received.Add(int64(count))
+}
+
+// CountKibiBytesReceived adds 1024*count to the bytes received counter.
+func (c *Counter) CountKibiBytesReceived(count float64) {
+	c.Received.Add(int64(1024 * count))
 }
 
 // BytesReceived returns the bytes received so far.

--- a/netx/bytecounter/bytecounter_test.go
+++ b/netx/bytecounter/bytecounter_test.go
@@ -9,17 +9,19 @@ import (
 func TestUnit(t *testing.T) {
 	counter := bytecounter.New()
 	counter.CountBytesReceived(16384)
+	counter.CountKibiBytesReceived(10)
 	counter.CountBytesSent(2048)
-	if counter.BytesSent() != 2048 {
+	counter.CountKibiBytesSent(10)
+	if counter.BytesSent() != 12288 {
 		t.Fatal("invalid bytes sent")
 	}
-	if counter.BytesReceived() != 16384 {
+	if counter.BytesReceived() != 26624 {
 		t.Fatal("invalid bytes received")
 	}
-	if v := counter.KibiBytesSent(); v < 1.9 && v > 2.1 {
+	if v := counter.KibiBytesSent(); v < 11.9 || v > 12.1 {
 		t.Fatal("invalid kibibytes sent")
 	}
-	if v := counter.KibiBytesReceived(); v < 15.9 && v > 16.1 {
-		t.Fatal("invalid kibibytes sent")
+	if v := counter.KibiBytesReceived(); v < 25.9 || v > 26.1 {
+		t.Fatal("invalid kibibytes received")
 	}
 }

--- a/netx/bytecounter/bytecounter_test.go
+++ b/netx/bytecounter/bytecounter_test.go
@@ -1,0 +1,25 @@
+package bytecounter_test
+
+import (
+	"testing"
+
+	"github.com/ooni/probe-engine/netx/bytecounter"
+)
+
+func TestUnit(t *testing.T) {
+	counter := bytecounter.New()
+	counter.CountBytesReceived(16384)
+	counter.CountBytesSent(2048)
+	if counter.BytesSent() != 2048 {
+		t.Fatal("invalid bytes sent")
+	}
+	if counter.BytesReceived() != 16384 {
+		t.Fatal("invalid bytes received")
+	}
+	if v := counter.KibiBytesSent(); v < 1.9 && v > 2.1 {
+		t.Fatal("invalid kibibytes sent")
+	}
+	if v := counter.KibiBytesReceived(); v < 15.9 && v > 16.1 {
+		t.Fatal("invalid kibibytes sent")
+	}
+}

--- a/netx/dialer/bytecounter.go
+++ b/netx/dialer/bytecounter.go
@@ -2,28 +2,10 @@ package dialer
 
 import (
 	"context"
-	"fmt"
 	"net"
 
-	"github.com/ooni/probe-engine/atomicx"
+	"github.com/ooni/probe-engine/netx/bytecounter"
 )
-
-// ByteCounter is the bytes counter. You should have an instance of this
-// struct per experiment and another instance in the session.
-type ByteCounter struct {
-	Received *atomicx.Float64
-	Sent     *atomicx.Float64
-}
-
-// String returns a string representation of the counter
-func (c *ByteCounter) String() string {
-	return fmt.Sprintf("received: %f; sent: %f", c.Received.Load(), c.Sent.Load())
-}
-
-// NewByteCounter creates a new bytes counter
-func NewByteCounter() *ByteCounter {
-	return &ByteCounter{Received: atomicx.NewFloat64(), Sent: atomicx.NewFloat64()}
-}
 
 // ByteCounterDialer is a byte-counting-aware dialer. To perform byte counting, you
 // should make sure that you insert this dialer in the dialing chain.
@@ -59,42 +41,42 @@ func (d ByteCounterDialer) DialContext(
 type byteCounterSessionKey struct{}
 
 // ContextSessionByteCounter retrieves the session byte counter from the context
-func ContextSessionByteCounter(ctx context.Context) *ByteCounter {
-	counter, _ := ctx.Value(byteCounterSessionKey{}).(*ByteCounter)
+func ContextSessionByteCounter(ctx context.Context) *bytecounter.Counter {
+	counter, _ := ctx.Value(byteCounterSessionKey{}).(*bytecounter.Counter)
 	return counter
 }
 
 // WithSessionByteCounter assigns the session byte counter to the context
-func WithSessionByteCounter(ctx context.Context, counter *ByteCounter) context.Context {
+func WithSessionByteCounter(ctx context.Context, counter *bytecounter.Counter) context.Context {
 	return context.WithValue(ctx, byteCounterSessionKey{}, counter)
 }
 
 type byteCounterExperimentKey struct{}
 
 // ContextExperimentByteCounter retrieves the experiment byte counter from the context
-func ContextExperimentByteCounter(ctx context.Context) *ByteCounter {
-	counter, _ := ctx.Value(byteCounterExperimentKey{}).(*ByteCounter)
+func ContextExperimentByteCounter(ctx context.Context) *bytecounter.Counter {
+	counter, _ := ctx.Value(byteCounterExperimentKey{}).(*bytecounter.Counter)
 	return counter
 }
 
 // WithExperimentByteCounter assigns the experiment byte counter to the context
-func WithExperimentByteCounter(ctx context.Context, counter *ByteCounter) context.Context {
+func WithExperimentByteCounter(ctx context.Context, counter *bytecounter.Counter) context.Context {
 	return context.WithValue(ctx, byteCounterExperimentKey{}, counter)
 }
 
 type byteCounterConnWrapper struct {
 	net.Conn
-	exp  *ByteCounter
-	sess *ByteCounter
+	exp  *bytecounter.Counter
+	sess *bytecounter.Counter
 }
 
 func (c byteCounterConnWrapper) Read(p []byte) (int, error) {
 	count, err := c.Conn.Read(p)
 	if c.exp != nil {
-		c.exp.Received.Add(float64(count) / 1024)
+		c.exp.CountBytesReceived(count)
 	}
 	if c.sess != nil {
-		c.sess.Received.Add(float64(count) / 1024)
+		c.sess.CountBytesReceived(count)
 	}
 	return count, err
 }
@@ -102,10 +84,10 @@ func (c byteCounterConnWrapper) Read(p []byte) (int, error) {
 func (c byteCounterConnWrapper) Write(p []byte) (int, error) {
 	count, err := c.Conn.Write(p)
 	if c.exp != nil {
-		c.exp.Sent.Add(float64(count) / 1024)
+		c.exp.CountBytesSent(count)
 	}
 	if c.sess != nil {
-		c.sess.Sent.Add(float64(count) / 1024)
+		c.sess.CountBytesSent(count)
 	}
 	return count, err
 }

--- a/netx/dialer/bytecounter_test.go
+++ b/netx/dialer/bytecounter_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ooni/probe-engine/netx/bytecounter"
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
@@ -36,19 +37,17 @@ func TestIntegrationByteCounterNormalUsage(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
-	sess := dialer.NewByteCounter()
+	sess := bytecounter.New()
 	ctx := context.Background()
 	ctx = dialer.WithSessionByteCounter(ctx, sess)
 	if err := dorequest(ctx, "http://www.google.com"); err != nil {
 		t.Fatal(err)
 	}
-	exp := dialer.NewByteCounter()
+	exp := bytecounter.New()
 	ctx = dialer.WithExperimentByteCounter(ctx, exp)
 	if err := dorequest(ctx, "http://facebook.com"); err != nil {
 		t.Fatal(err)
 	}
-	t.Log(sess) // keep: this causes String to be called
-	t.Log(exp)  // ditto
 	if sess.Received.Load() <= exp.Received.Load() {
 		t.Fatal("session should have received more than experiment")
 	}

--- a/netx/httptransport/bytecounter.go
+++ b/netx/httptransport/bytecounter.go
@@ -1,0 +1,74 @@
+package httptransport
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/ooni/probe-engine/netx/bytecounter"
+)
+
+// ByteCountingTransport is a RoundTripper that counts bytes.
+type ByteCountingTransport struct {
+	RoundTripper
+	Counter *bytecounter.Counter
+}
+
+// RoundTrip implements RoundTripper.RoundTrip
+func (txp ByteCountingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		req.Body = byteCountingBody{
+			ReadCloser: req.Body, Account: txp.Counter.CountBytesSent}
+	}
+	txp.estimateRequestMetadata(req)
+	resp, err := txp.RoundTripper.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	txp.estimateResponseMetadata(resp)
+	resp.Body = byteCountingBody{
+		ReadCloser: resp.Body, Account: txp.Counter.CountBytesReceived}
+	return resp, nil
+}
+
+func (txp ByteCountingTransport) estimateRequestMetadata(req *http.Request) {
+	txp.Counter.CountBytesSent(len(req.Method))
+	txp.Counter.CountBytesSent(len(req.URL.String()))
+	for key, values := range req.Header {
+		for _, value := range values {
+			txp.Counter.CountBytesSent(len(key))
+			txp.Counter.CountBytesSent(len(": "))
+			txp.Counter.CountBytesSent(len(value))
+			txp.Counter.CountBytesSent(len("\r\n"))
+		}
+	}
+	txp.Counter.CountBytesSent(len("\r\n"))
+}
+
+func (txp ByteCountingTransport) estimateResponseMetadata(resp *http.Response) {
+	txp.Counter.CountBytesReceived(len(resp.Status))
+	for key, values := range resp.Header {
+		for _, value := range values {
+			txp.Counter.CountBytesReceived(len(key))
+			txp.Counter.CountBytesReceived(len(": "))
+			txp.Counter.CountBytesReceived(len(value))
+			txp.Counter.CountBytesReceived(len("\r\n"))
+		}
+	}
+	txp.Counter.CountBytesReceived(len("\r\n"))
+}
+
+type byteCountingBody struct {
+	io.ReadCloser
+	Account func(int)
+}
+
+func (r byteCountingBody) Read(p []byte) (int, error) {
+	count, err := r.ReadCloser.Read(p)
+	if err != nil {
+		return 0, err
+	}
+	r.Account(count)
+	return count, nil
+}
+
+var _ RoundTripper = ByteCountingTransport{}

--- a/netx/httptransport/bytecounter_test.go
+++ b/netx/httptransport/bytecounter_test.go
@@ -1,0 +1,79 @@
+package httptransport_test
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ooni/probe-engine/netx/bytecounter"
+	"github.com/ooni/probe-engine/netx/httptransport"
+)
+
+func TestUnitByteCounterFailure(t *testing.T) {
+	counter := bytecounter.New()
+	txp := httptransport.ByteCountingTransport{
+		Counter: counter,
+		RoundTripper: httptransport.MockableTransport{
+			Err: io.EOF,
+		},
+	}
+	client := &http.Client{Transport: txp}
+	req, err := http.NewRequest(
+		"POST", "https://www.google.com", strings.NewReader("AAAAAA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("User-Agent", "antani-browser/1.0.0")
+	resp, err := client.Do(req)
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+	if counter.Sent.Load() != 68 {
+		t.Fatal("expected around 68 bytes sent")
+	}
+	if counter.Received.Load() != 0 {
+		t.Fatal("expected zero bytes received")
+	}
+}
+
+func TestUnitByteCounterSuccess(t *testing.T) {
+	counter := bytecounter.New()
+	txp := httptransport.ByteCountingTransport{
+		Counter: counter,
+		RoundTripper: httptransport.MockableTransport{
+			Resp: &http.Response{
+				Body: ioutil.NopCloser(strings.NewReader("1234567")),
+				Header: http.Header{
+					"Server": []string{"antani/0.1.0"},
+				},
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+			},
+		},
+	}
+	client := &http.Client{Transport: txp}
+	req, err := http.NewRequest(
+		"POST", "https://www.google.com", strings.NewReader("AAAAAA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("User-Agent", "antani-browser/1.0.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if counter.Sent.Load() != 68 {
+		t.Fatal("expected around 68 bytes sent")
+	}
+	if counter.Received.Load() != 37 {
+		t.Fatal("expected zero around 37 bytes received")
+	}
+}

--- a/netx/httptransport/httptransport.go
+++ b/netx/httptransport/httptransport.go
@@ -1,0 +1,112 @@
+// Package httptransport contains HTTP transport extensions. Here we
+// define a http.Transport that emits events.
+package httptransport
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/ooni/probe-engine/netx/bytecounter"
+	"github.com/ooni/probe-engine/netx/dialer"
+	"github.com/ooni/probe-engine/netx/resolver"
+)
+
+// Dialer is the definition of dialer assumed by this package.
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// TLSDialer is the definition of a TLS dialer assumed by this package.
+type TLSDialer interface {
+	DialTLSContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// RoundTripper is the definition of http.RoundTripper used by this package.
+type RoundTripper interface {
+	RoundTrip(req *http.Request) (*http.Response, error)
+	CloseIdleConnections()
+}
+
+// Resolver is the interface we expect from a resolver
+type Resolver interface {
+	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+}
+
+// ProxyFunc is the function used to set a proxy.
+type ProxyFunc func(*http.Request) (*url.URL, error)
+
+// Config contains configuration for creating a new transport. When any
+// field of Config is nil/empty, we will use a suitable default.
+type Config struct {
+	ByteCounter *bytecounter.Counter // default: no byte counting
+	Dialer      Dialer               // default: dialer.DNSDialer
+	Logger      Logger               // default: no logging
+	Proxy       ProxyFunc            // default: no proxy
+	Resolver    Resolver             // default: system resolver
+	TLSConfig   *tls.Config          // default: attempt using h2
+	TLSDialer   TLSDialer            // default: dialer.TLSDialer
+}
+
+type tlsHandshaker interface {
+	Handshake(ctx context.Context, conn net.Conn, config *tls.Config) (
+		net.Conn, tls.ConnectionState, error)
+}
+
+// New creates a new RoundTripper. You can further extend the returned
+// RoundTripper before wrapping it into an http.Client.
+func New(config Config) RoundTripper {
+	if config.Resolver == nil {
+		var r Resolver = resolver.ErrorWrapperResolver{
+			Resolver: resolver.BogonResolver{
+				Resolver: resolver.SystemResolver{},
+			},
+		}
+		if config.Logger != nil {
+			r = resolver.LoggingResolver{Logger: config.Logger, Resolver: r}
+		}
+		config.Resolver = r
+	}
+	if config.Dialer == nil {
+		var d Dialer = dialer.ErrorWrapperDialer{
+			Dialer: dialer.TimeoutDialer{
+				Dialer: new(net.Dialer),
+			},
+		}
+		if config.Logger != nil {
+			d = dialer.LoggingDialer{Dialer: d, Logger: config.Logger}
+		}
+		config.Dialer = dialer.DNSDialer{
+			Resolver: config.Resolver,
+			Dialer:   d,
+		}
+	}
+	if config.TLSDialer == nil {
+		var h tlsHandshaker
+		h = dialer.ErrorWrapperTLSHandshaker{
+			TLSHandshaker: dialer.TimeoutTLSHandshaker{
+				TLSHandshaker: dialer.SystemTLSHandshaker{},
+			},
+		}
+		if config.Logger != nil {
+			h = dialer.LoggingTLSHandshaker{Logger: config.Logger, TLSHandshaker: h}
+		}
+		config.TLSDialer = dialer.TLSDialer{
+			Config:        &tls.Config{NextProtos: []string{"h2", "http/1.1"}},
+			Dialer:        config.Dialer,
+			TLSHandshaker: h,
+		}
+	}
+	var txp RoundTripper
+	txp = NewSystemTransport(config.Dialer, config.TLSDialer, config.Proxy)
+	if config.ByteCounter != nil {
+		txp = ByteCountingTransport{Counter: config.ByteCounter, RoundTripper: txp}
+	}
+	if config.Logger != nil {
+		txp = LoggingTransport{Logger: config.Logger, RoundTripper: txp}
+	}
+	txp = UserAgentTransport{RoundTripper: txp}
+	return txp
+}

--- a/netx/httptransport/integration_test.go
+++ b/netx/httptransport/integration_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestIntegrationSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	log.SetLevel(log.DebugLevel)
 	counter := bytecounter.New()
 	txp := httptransport.New(httptransport.Config{

--- a/netx/httptransport/integration_test.go
+++ b/netx/httptransport/integration_test.go
@@ -1,0 +1,33 @@
+package httptransport_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/netx/bytecounter"
+	"github.com/ooni/probe-engine/netx/httptransport"
+)
+
+func TestIntegrationSuccess(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	counter := bytecounter.New()
+	txp := httptransport.New(httptransport.Config{
+		ByteCounter: counter,
+		Logger:      log.Log,
+	})
+	client := &http.Client{Transport: txp}
+	resp, err := client.Get("https://www.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = ioutil.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err = resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	t.Log(counter.Sent.Load())
+	t.Log(counter.Received.Load())
+}

--- a/netx/httptransport/logging.go
+++ b/netx/httptransport/logging.go
@@ -1,0 +1,50 @@
+package httptransport
+
+import "net/http"
+
+// Logger is the logger assumed by this package
+type Logger interface {
+	Debugf(format string, v ...interface{})
+	Debug(message string)
+}
+
+// LoggingTransport is a logging transport
+type LoggingTransport struct {
+	RoundTripper
+	Logger Logger
+}
+
+// RoundTrip implements RoundTripper.RoundTrip
+func (txp LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	req.Header.Set("Host", host) // anticipate what Go would do
+	return txp.logTrip(req)
+}
+
+func (txp LoggingTransport) logTrip(req *http.Request) (*http.Response, error) {
+	txp.Logger.Debugf("> %s %s", req.Method, req.URL.String())
+	for key, values := range req.Header {
+		for _, value := range values {
+			txp.Logger.Debugf("> %s: %s", key, value)
+		}
+	}
+	txp.Logger.Debug(">")
+	resp, err := txp.RoundTripper.RoundTrip(req)
+	if err != nil {
+		txp.Logger.Debugf("< %s", err)
+		return nil, err
+	}
+	txp.Logger.Debugf("< %d", resp.StatusCode)
+	for key, values := range resp.Header {
+		for _, value := range values {
+			txp.Logger.Debugf("< %s: %s", key, value)
+		}
+	}
+	txp.Logger.Debug("<")
+	return resp, nil
+}
+
+var _ RoundTripper = LoggingTransport{}

--- a/netx/httptransport/logging_test.go
+++ b/netx/httptransport/logging_test.go
@@ -1,0 +1,77 @@
+package httptransport_test
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/netx/httptransport"
+)
+
+func TestUnitLoggingFailure(t *testing.T) {
+	txp := httptransport.LoggingTransport{
+		Logger: log.Log,
+		RoundTripper: httptransport.MockableTransport{
+			Err: io.EOF,
+		},
+	}
+	client := &http.Client{Transport: txp}
+	resp, err := client.Get("https://www.google.com")
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+}
+
+func TestUnitLoggingFailureWithNoHostHeader(t *testing.T) {
+	txp := httptransport.LoggingTransport{
+		Logger: log.Log,
+		RoundTripper: httptransport.MockableTransport{
+			Err: io.EOF,
+		},
+	}
+	req := &http.Request{
+		Header: http.Header{},
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "www.google.com",
+			Path:   "/",
+		},
+	}
+	resp, err := txp.RoundTrip(req)
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+}
+
+func TestUnitLoggingSuccess(t *testing.T) {
+	txp := httptransport.LoggingTransport{
+		Logger: log.Log,
+		RoundTripper: httptransport.MockableTransport{
+			Resp: &http.Response{
+				Body: ioutil.NopCloser(strings.NewReader("")),
+				Header: http.Header{
+					"Server": []string{"antani/0.1.0"},
+				},
+				StatusCode: 200,
+			},
+		},
+	}
+	client := &http.Client{Transport: txp}
+	resp, err := client.Get("https://www.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+}

--- a/netx/httptransport/mockable_test.go
+++ b/netx/httptransport/mockable_test.go
@@ -1,0 +1,25 @@
+package httptransport
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+type MockableTransport struct {
+	Err  error
+	Resp *http.Response
+}
+
+func (txp MockableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		ioutil.ReadAll(req.Body)
+		req.Body.Close()
+	}
+	if txp.Err != nil {
+		return nil, txp.Err
+	}
+	txp.Resp.Request = req // non thread safe but it doesn't matter
+	return txp.Resp, nil
+}
+
+func (txp MockableTransport) CloseIdleConnections() {}

--- a/netx/httptransport/system.go
+++ b/netx/httptransport/system.go
@@ -1,0 +1,29 @@
+package httptransport
+
+import (
+	"context"
+	"net"
+	"net/http"
+)
+
+// NewSystemTransport creates a new "system" HTTP transport. That is a transport
+// using the Go standard library with custom dialer and TLS dialer.
+func NewSystemTransport(dialer Dialer, tlsDialer TLSDialer, proxy ProxyFunc) *http.Transport {
+	txp := http.DefaultTransport.(*http.Transport).Clone()
+	txp.DialContext = dialer.DialContext
+	txp.DialTLS = func(network, address string) (net.Conn, error) {
+		// Go < 1.14 does not have http.Transport.DialTLSContext
+		return tlsDialer.DialTLSContext(context.Background(), network, address)
+	}
+	// Better for Cloudflare DNS and also better because we have less
+	// noisy events and we can better understand what happened.
+	txp.MaxConnsPerHost = 1
+	// The following (1) reduces the number of headers that Go will
+	// automatically send for us and (2) ensures that we always receive
+	// back the true headers, such as Content-Length. This change is
+	// functional to OONI's goal of observing the network.
+	txp.DisableCompression = true
+	return txp
+}
+
+var _ RoundTripper = &http.Transport{}

--- a/netx/httptransport/useragent.go
+++ b/netx/httptransport/useragent.go
@@ -1,0 +1,19 @@
+package httptransport
+
+import "net/http"
+
+// UserAgentTransport is a transport that ensures that we always
+// set an OONI specific default User-Agent header.
+type UserAgentTransport struct {
+	RoundTripper
+}
+
+// RoundTrip implements RoundTripper.RoundTrip
+func (txp UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", "miniooni/0.1.0-dev")
+	}
+	return txp.RoundTripper.RoundTrip(req)
+}
+
+var _ RoundTripper = UserAgentTransport{}

--- a/netx/httptransport/useragent_test.go
+++ b/netx/httptransport/useragent_test.go
@@ -1,0 +1,51 @@
+package httptransport_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/ooni/probe-engine/netx/httptransport"
+)
+
+func TestUnitUserAgentWithDefault(t *testing.T) {
+	txp := httptransport.UserAgentTransport{
+		RoundTripper: httptransport.MockableTransport{
+			Resp: &http.Response{StatusCode: 200},
+		},
+	}
+	req := &http.Request{URL: &url.URL{
+		Scheme: "https",
+		Host:   "www.google.com",
+		Path:   "/",
+	}}
+	req.Header = http.Header{}
+	resp, err := txp.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Request.Header.Get("User-Agent") != "miniooni/0.1.0-dev" {
+		t.Fatal("not the User-Agent we expected")
+	}
+}
+
+func TestUnitUserAgentWithExplicitValue(t *testing.T) {
+	txp := httptransport.UserAgentTransport{
+		RoundTripper: httptransport.MockableTransport{
+			Resp: &http.Response{StatusCode: 200},
+		},
+	}
+	req := &http.Request{URL: &url.URL{
+		Scheme: "https",
+		Host:   "www.google.com",
+		Path:   "/",
+	}}
+	req.Header = http.Header{"User-Agent": []string{"antani-client/0.1.1"}}
+	resp, err := txp.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Request.Header.Get("User-Agent") != "antani-client/0.1.1" {
+		t.Fatal("not the User-Agent we expected")
+	}
+}

--- a/oonimkall/runner.go
+++ b/oonimkall/runner.go
@@ -208,8 +208,8 @@ func (r *runner) Run(ctx context.Context) {
 	defer func() {
 		sess.Close()
 		r.emitter.Emit(statusEnd, &eventStatusEnd{
-			DownloadedKB: sess.KiBsReceived(),
-			UploadedKB:   sess.KiBsSent(),
+			DownloadedKB: sess.KibiBytesReceived(),
+			UploadedKB:   sess.KibiBytesSent(),
 		})
 	}()
 

--- a/session.go
+++ b/session.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ooni/probe-engine/internal/runtimex"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx"
+	"github.com/ooni/probe-engine/netx/bytecounter"
 	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/modelx"
 )
@@ -45,7 +46,7 @@ type Session struct {
 	availableBouncers    []model.Service
 	availableCollectors  []model.Service
 	availableTestHelpers map[string][]model.Service
-	byteCounter          *dialer.ByteCounter
+	byteCounter          *bytecounter.Counter
 	httpDefaultClient    *http.Client
 	httpNoProxyClient    *http.Client
 	kvStore              model.KeyValueStore
@@ -112,7 +113,7 @@ func NewSession(config SessionConfig) (*Session, error) {
 	}
 	sess := &Session{
 		assetsDir:   config.AssetsDir,
-		byteCounter: dialer.NewByteCounter(),
+		byteCounter: bytecounter.New(),
 		kvStore:     config.KVStore,
 		privacySettings: model.PrivacySettings{
 			IncludeCountry: true,
@@ -157,12 +158,12 @@ func (s *Session) AddAvailableHTTPSCollector(baseURL string) {
 // KiBsReceived accounts for the KiBs received by the HTTP clients
 // managed by this session so far, including experiments.
 func (s *Session) KiBsReceived() float64 {
-	return s.byteCounter.Received.Load()
+	return s.byteCounter.KibiBytesReceived()
 }
 
 // KiBsSent is like KiBsReceived but for the bytes sent.
 func (s *Session) KiBsSent() float64 {
-	return s.byteCounter.Sent.Load()
+	return s.byteCounter.KibiBytesSent()
 }
 
 // CABundlePath is like ASNDatabasePath but for the CA bundle path.

--- a/session.go
+++ b/session.go
@@ -155,14 +155,14 @@ func (s *Session) AddAvailableHTTPSCollector(baseURL string) {
 	})
 }
 
-// KiBsReceived accounts for the KiBs received by the HTTP clients
+// KibiBytesReceived accounts for the KibiBytes received by the HTTP clients
 // managed by this session so far, including experiments.
-func (s *Session) KiBsReceived() float64 {
+func (s *Session) KibiBytesReceived() float64 {
 	return s.byteCounter.KibiBytesReceived()
 }
 
-// KiBsSent is like KiBsReceived but for the bytes sent.
-func (s *Session) KiBsSent() float64 {
+// KibiBytesSent is like KibiBytesReceived but for the bytes sent.
+func (s *Session) KibiBytesSent() float64 {
 	return s.byteCounter.KibiBytesSent()
 }
 


### PR DESCRIPTION
This httptransport does not use the context at all, features logging and
bytecounting functionality, and uses existing dialers, resolvers.

This is part of:

1. https://github.com/ooni/probe-engine/issues/359

2. https://github.com/ooni/probe-engine/issues/125

This diff also needs to consolidate a single byte counter implementation
because we probably want to keep the older byte counting for the experiments.

This diff also renames KiBs to KibiBytes, which is more obvious.