### PR TITLE
netx/httptransport/bytecounter: deal with N>0,io.EOF result

### DIFF
--- a/netx/httptransport/bytecounter.go
+++ b/netx/httptransport/bytecounter.go
@@ -64,11 +64,10 @@ type byteCountingBody struct {
 
 func (r byteCountingBody) Read(p []byte) (int, error) {
 	count, err := r.ReadCloser.Read(p)
-	if err != nil {
-		return 0, err
+	if count > 0 {
+		r.Account(count)
 	}
-	r.Account(count)
-	return count, nil
+	return count, err
 }
 
 var _ RoundTripper = ByteCountingTransport{}

--- a/netx/httptransport/bytecounter_test.go
+++ b/netx/httptransport/bytecounter_test.go
@@ -68,12 +68,61 @@ func TestUnitByteCounterSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.ReadAll(resp.Body)
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
 	resp.Body.Close()
+	if string(data) != "1234567" {
+		t.Fatal("expected a different body here")
+	}
 	if counter.Sent.Load() != 68 {
 		t.Fatal("expected around 68 bytes sent")
 	}
 	if counter.Received.Load() != 37 {
 		t.Fatal("expected zero around 37 bytes received")
 	}
+}
+
+func TestUnitByteCounterSuccessWithEOF(t *testing.T) {
+	counter := bytecounter.New()
+	txp := httptransport.ByteCountingTransport{
+		Counter: counter,
+		RoundTripper: httptransport.MockableTransport{
+			Resp: &http.Response{
+				Body: bodyReaderWithEOF{},
+				Header: http.Header{
+					"Server": []string{"antani/0.1.0"},
+				},
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+			},
+		},
+	}
+	client := &http.Client{Transport: txp}
+	resp, err := client.Get("https://www.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if string(data) != "A" {
+		t.Fatal("expected a different body here")
+	}
+}
+
+type bodyReaderWithEOF struct{}
+
+func (bodyReaderWithEOF) Read(p []byte) (int, error) {
+	if len(p) < 1 {
+		panic("should not happen")
+	}
+	p[0] = 'A'
+	return 1, io.EOF // we want code to be robust to this
+}
+func (bodyReaderWithEOF) Close() error {
+	return nil
 }


### PR DESCRIPTION
This seems to happen very often. Add also a test to catch regressions.

Part of https://github.com/ooni/probe-engine/issues/125.