### PR TITLE
engine: use the new httptransport

### DIFF
--- a/netx/httptransport/system.go
+++ b/netx/httptransport/system.go
@@ -10,6 +10,7 @@ import (
 // using the Go standard library with custom dialer and TLS dialer.
 func NewSystemTransport(dialer Dialer, tlsDialer TLSDialer, proxy ProxyFunc) *http.Transport {
 	txp := http.DefaultTransport.(*http.Transport).Clone()
+	txp.Proxy = proxy
 	txp.DialContext = dialer.DialContext
 	txp.DialTLS = func(network, address string) (net.Conn, error) {
 		// Go < 1.14 does not have http.Transport.DialTLSContext

--- a/testlists.go
+++ b/testlists.go
@@ -56,7 +56,7 @@ func (s *Session) QueryTestListsURLs(conf *TestListsURLsConfig) (*TestListsURLsR
 		BaseURL:           baseURL,
 		CountryCode:       s.ProbeCC(),
 		EnabledCategories: conf.Categories,
-		HTTPClient:        s.httpDefaultClient,
+		HTTPClient:        s.DefaultHTTPClient(),
 		Limit:             conf.Limit,
 		Logger:            s.logger,
 		UserAgent:         s.UserAgent(),


### PR DESCRIPTION
This allows us to count bytes (https://github.com/ooni/probe-engine/issues/125)
and is in line with netx simplification (https://github.com/ooni/probe-engine/issues/359).