### PR TITLE
ndt7: explicit protocol and no useless warnings

### DIFF
--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -33,6 +33,11 @@ type Summary struct {
 	Upload         float64 `json:"upload"`          // upload speed [kbit/s]
 }
 
+// ServerInfo contains information on the selected server
+type ServerInfo struct {
+	Hostname string `json:"hostname"`
+}
+
 // TestKeys contains the test keys
 type TestKeys struct {
 	// Download contains download results
@@ -43,6 +48,9 @@ type TestKeys struct {
 
 	// Protocol contains the version of the ndt protocol
 	Protocol int64 `json:"protocol"`
+
+	// Server contains information on the selected server
+	Server ServerInfo `json:"server"`
 
 	// Summary contains the measurement summary
 	Summary Summary `json:"summary"`
@@ -187,6 +195,7 @@ func (m *measurer) Run(
 		tk.Failure = failureFromError(err)
 		return err
 	}
+	tk.Server = ServerInfo{Hostname: hostname}
 	callbacks.OnProgress(0, fmt.Sprintf("downloading: %s", hostname))
 	if m.preDownloadHook != nil {
 		m.preDownloadHook()

--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -41,6 +41,9 @@ type TestKeys struct {
 	// Failure is the failure string
 	Failure *string `json:"failure"`
 
+	// Protocol contains the version of the ndt protocol
+	Protocol int64 `json:"protocol"`
+
 	// Summary contains the measurement summary
 	Summary Summary `json:"summary"`
 
@@ -177,6 +180,7 @@ func (m *measurer) Run(
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
 ) error {
 	tk := new(TestKeys)
+	tk.Protocol = 7
 	measurement.TestKeys = tk
 	hostname, err := m.discover(ctx, sess)
 	if err != nil {

--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -132,7 +132,7 @@ func (m *measurer) doDownload(
 			return nil
 		},
 	)
-	if err := mgr.run(ctx); err != nil {
+	if err := mgr.run(ctx); err != nil && err.Error() != "generic_timeout_error" {
 		sess.Logger().Warnf("download: %s", err)
 	}
 	return nil // failure is only when we cannot connect
@@ -169,7 +169,7 @@ func (m *measurer) doUpload(
 			})
 		},
 	)
-	if err := mgr.run(ctx); err != nil {
+	if err := mgr.run(ctx); err != nil && err.Error() != "generic_timeout_error" {
 		sess.Logger().Warnf("upload: %s", err)
 	}
 	return nil // failure is only when we cannot connect


### PR DESCRIPTION
Occurred to me when working on https://github.com/ooni/probe-engine/issues/259