### PR TITLE
Don't build mkcgo with `-tags nomk`

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -14,8 +14,6 @@ jobs:
           go-version: ${{ matrix.go }}
       - uses: actions/checkout@v2
       - run: go test -tags nomk -v -coverprofile=probe-engine.cov -coverpkg=./... ./...
-        env:
-          CGO_ENABLED: 0
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: probe-engine.cov

--- a/measurementkit/mkcgo/mkcgo.go
+++ b/measurementkit/mkcgo/mkcgo.go
@@ -1,4 +1,4 @@
-// +build cgo
+// +build !nomk
 
 // Package mkcgo contains CGO bindings to Measurement Kit.
 package mkcgo


### PR DESCRIPTION
This seems more consistent. Making mkcgo conditional on CGO is
a relic of when one needed to disable CGO to disable MK.

Spotted when working on something else.