### PR TITLE
SubmitAndUpdateMeasurements: don't count bytes using context

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -320,8 +320,7 @@ func (e *Experiment) SubmitAndUpdateMeasurement(measurement *model.Measurement) 
 	if e.report == nil {
 		return errors.New("Report is not open")
 	}
-	ctx := dialer.WithExperimentByteCounter(context.Background(), e.byteCounter)
-	return e.report.SubmitMeasurement(ctx, measurement)
+	return e.report.SubmitMeasurement(context.Background(), measurement)
 }
 
 // CloseReport is an idempotent method that closes an open report


### PR DESCRIPTION
This is wrong because there may be persistent connection that we
may be missing. For this reason, we count at HTTP level.

Closes https://github.com/ooni/probe-engine/issues/484