### PR TITLE
dash: make sure we correctly count bytes

### DIFF
--- a/experiment/dash/client.go
+++ b/experiment/dash/client.go
@@ -160,8 +160,7 @@ func (c *client) negotiate(ctx context.Context) (negotiateResponse, error) {
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "")
-	req = req.WithContext(ctx)
-	resp, err := c.deps.HTTPClientDo(req)
+	resp, err := c.deps.HTTPClientDo(req.WithContext(ctx))
 	if err != nil {
 		return negotiateResp, err
 	}
@@ -210,9 +209,8 @@ func (c *client) download(
 	current.ServerURL = URL.String()
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("Authorization", authorization)
-	req = req.WithContext(ctx)
 	savedTicks := time.Now()
-	resp, err := c.deps.HTTPClientDo(req)
+	resp, err := c.deps.HTTPClientDo(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -258,8 +256,7 @@ func (c *client) collect(ctx context.Context, authorization string) error {
 	req.Header.Set("User-Agent", c.userAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", authorization)
-	req = req.WithContext(ctx)
-	resp, err := c.deps.HTTPClientDo(req)
+	resp, err := c.deps.HTTPClientDo(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -558,7 +558,7 @@ func TestOpenReportFailure(t *testing.T) {
 	}
 	exp := builder.NewExperiment()
 	exp.session.availableCollectors = []model.Service{
-		model.Service{
+		{
 			Address: server.URL,
 			Type:    "https",
 		},
@@ -599,7 +599,7 @@ func TestOpenReportNonHTTPS(t *testing.T) {
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	sess.availableCollectors = []model.Service{
-		model.Service{
+		{
 			Address: "antani",
 			Type:    "mascetti",
 		},

--- a/netx/httptransport/system_compat.go
+++ b/netx/httptransport/system_compat.go
@@ -1,8 +1,10 @@
-// +build go1.14
+// +build !go1.14
 
 package httptransport
 
 import (
+	"context"
+	"net"
 	"net/http"
 )
 
@@ -12,7 +14,10 @@ func NewSystemTransport(dialer Dialer, tlsDialer TLSDialer, proxy ProxyFunc) *ht
 	txp := http.DefaultTransport.(*http.Transport).Clone()
 	txp.Proxy = proxy
 	txp.DialContext = dialer.DialContext
-	txp.DialTLSContext = tlsDialer.DialTLSContext
+	txp.DialTLS = func(network, address string) (net.Conn, error) {
+		// Go < 1.14 does not have http.Transport.DialTLSContext
+		return tlsDialer.DialTLSContext(context.Background(), network, address)
+	}
 	// Better for Cloudflare DNS and also better because we have less
 	// noisy events and we can better understand what happened.
 	txp.MaxConnsPerHost = 1


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/501

It should be noted that this solution is such that byte counting
does not work when using HTTP for Go < 1.14.