### PR TITLE
dash: remove unused/unimportant code

### DIFF
--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -2,7 +2,6 @@ package dash
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
@@ -46,24 +45,7 @@ func TestUnitRunnerLoopClientStartDownloadError(t *testing.T) {
 	expect := errors.New("mocked error")
 	c := &mockableClient{StartDownloadError: expect}
 	runner := newRunner(
-		log.Log, c, handler.NewPrinterCallbacks(log.Log), json.Marshal,
-	)
-	err := runner.loop(context.Background())
-	if !errors.Is(err, expect) {
-		t.Fatal("not the expected error")
-	}
-}
-
-func TestUnitRunnerLoopClientJSONMarshalErrorInLoop(t *testing.T) {
-	expect := errors.New("mocked error")
-	c := &mockableClient{
-		ClientResults: make([]clientResults, 10),
-	}
-	runner := newRunner(
 		log.Log, c, handler.NewPrinterCallbacks(log.Log),
-		func(v interface{}) ([]byte, error) {
-			return nil, expect
-		},
 	)
 	err := runner.loop(context.Background())
 	if !errors.Is(err, expect) {
@@ -75,22 +57,7 @@ func TestUnitRunnerLoopClientError(t *testing.T) {
 	expect := errors.New("mocked error")
 	c := &mockableClient{ErrorResult: expect}
 	runner := newRunner(
-		log.Log, c, handler.NewPrinterCallbacks(log.Log), json.Marshal,
-	)
-	err := runner.loop(context.Background())
-	if !errors.Is(err, expect) {
-		t.Fatal("not the expected error")
-	}
-}
-
-func TestUnitRunnerLoopJSONMarshalErrorAfterLoop(t *testing.T) {
-	expect := errors.New("mocked error")
-	c := &mockableClient{}
-	runner := newRunner(
 		log.Log, c, handler.NewPrinterCallbacks(log.Log),
-		func(v interface{}) ([]byte, error) {
-			return nil, expect
-		},
 	)
 	err := runner.loop(context.Background())
 	if !errors.Is(err, expect) {
@@ -103,7 +70,7 @@ func TestUnitRunnerLoopGood(t *testing.T) {
 		ClientResults: make([]clientResults, 10),
 	}
 	runner := newRunner(
-		log.Log, c, handler.NewPrinterCallbacks(log.Log), json.Marshal,
+		log.Log, c, handler.NewPrinterCallbacks(log.Log),
 	)
 	err := runner.loop(context.Background())
 	if err != nil {
@@ -195,19 +162,12 @@ func TestUnitTestKeysAnalyzeMinPlayoutDelay(t *testing.T) {
 	}
 }
 
-func TestUnitTestKeysPrintSummaryWithNoData(t *testing.T) {
-	// The main concern here is that we don't crash when we're
-	// provided empty input from the caller
-	tk := &TestKeys{}
-	tk.printSummary(log.Log)
-}
-
 func TestUnitRunnerDoWithLoopSuccess(t *testing.T) {
 	c := &mockableClient{
 		ClientResults: make([]clientResults, 10),
 	}
 	runner := newRunner(
-		log.Log, c, handler.NewPrinterCallbacks(log.Log), json.Marshal,
+		log.Log, c, handler.NewPrinterCallbacks(log.Log),
 	)
 	err := runner.do(context.Background())
 	if err != nil {
@@ -218,7 +178,7 @@ func TestUnitRunnerDoWithLoopSuccess(t *testing.T) {
 func TestUnitRunnerDoWithNoData(t *testing.T) {
 	c := &mockableClient{}
 	runner := newRunner(
-		log.Log, c, handler.NewPrinterCallbacks(log.Log), json.Marshal,
+		log.Log, c, handler.NewPrinterCallbacks(log.Log),
 	)
 	err := runner.do(context.Background())
 	if !errors.Is(err, stats.EmptyInputErr) {

--- a/experiment/dash/model.go
+++ b/experiment/dash/model.go
@@ -33,15 +33,6 @@ type serverResults struct {
 	Timestamp int64   `json:"timestamp"`
 }
 
-// serverSchema is the data format traditionally used by the
-// original Neubot server for DASH experiments.
-type serverSchema struct {
-	Client              []clientResults `json:"client"`
-	ServerSchemaVersion int             `json:"srvr_schema_version"`
-	ServerTimestamp     int64           `json:"srvr_timestamp"`
-	Server              []serverResults `json:"server"`
-}
-
 // negotiateRequest contains the request of negotiation
 type negotiateRequest struct {
 	DASHRates []int64 `json:"dash_rates"`
@@ -55,12 +46,8 @@ type negotiateResponse struct {
 	Unchoked      int    `json:"unchoked"`
 }
 
-// dashLogger defines the common interface that a logger should have. It is
-// out of the box compatible with `log.Log` in `apex/log`.
+// dashLogger is the interface we expect from a logger
 type dashLogger interface {
-	// Debug emits a debug message.
 	Debug(msg string)
-
-	// Debugf formats and emits a debug message.
 	Debugf(format string, v ...interface{})
 }

--- a/experiment/dash/nologger.go
+++ b/experiment/dash/nologger.go
@@ -1,10 +1,7 @@
 package dash
 
-// NoLogger is a fake logger.
 type noLogger struct{}
 
-// Debug emits a debug message.
 func (noLogger) Debug(msg string) {}
 
-// Debugf formats and emits a debug message.
 func (noLogger) Debugf(format string, v ...interface{}) {}

--- a/experiment/dash/spec.go
+++ b/experiment/dash/spec.go
@@ -10,15 +10,10 @@ const (
 	// negotiatePath is the URL path used to negotiate
 	negotiatePath = "/negotiate/dash"
 
-	// downloadPathNoTrailingSlash is like DownloadPath but has no
-	// trailing slash. For historical reasons we also need to handle
-	// this path in addition to DownloadPath.
-	downloadPathNoTrailingSlash = "/dash/download"
-
 	// downloadPath is the URL path used to request DASH segments. You can
 	// append to this path an integer indicating how many bytes you would like
 	// the server to send you as part of the next chunk.
-	downloadPath = downloadPathNoTrailingSlash + "/"
+	downloadPath = "/dash/download/"
 
 	// collectPath is the URL path used to collect
 	collectPath = "/collect/dash"
@@ -26,24 +21,6 @@ const (
 
 // defaultRates contains the default DASH rates in kbit/s.
 var defaultRates = []int64{
-	100,
-	150,
-	200,
-	250,
-	300,
-	400,
-	500,
-	700,
-	900,
-	1200,
-	1500,
-	2000,
-	2500,
-	3000,
-	4000,
-	5000,
-	6000,
-	7000,
-	10000,
-	20000,
+	100, 150, 200, 250, 300, 400, 500, 700, 900, 1200, 1500, 2000,
+	2500, 3000, 4000, 5000, 6000, 7000, 10000, 20000,
 }


### PR DESCRIPTION
As part of merging the existing codebase with the neubot/dash client, let's
also dispose of the code that does not matter much.

For example, remove server-side code only that slipped through when we
merged neubot/dash client into this codebase.

Also, there was code whose only purpose was printing serialized JSONs in
debug mode, which we actually don't need.

Part of https://github.com/ooni/probe-engine/issues/501