### PR TITLE
dash: don't report error after download started

### DIFF
--- a/experiment/dash/client.go
+++ b/experiment/dash/client.go
@@ -352,17 +352,3 @@ func (c *client) StartDownload(ctx context.Context) (<-chan clientResults, error
 	go c.deps.Loop(ctx, ch)
 	return ch, nil
 }
-
-// Error returns the error that occurred during the test, if any. A nil
-// return value means that all was good. A returned error does not however
-// necessarily mean that all was bad; you may have _some_ data.
-func (c *client) Error() error {
-	return c.err
-}
-
-// ServerResults returns the results of the experiment collected by the
-// server. In case Error() returns non nil, this function will typically
-// return an empty slice to the caller.
-func (c *client) ServerResults() []serverResults {
-	return c.serverResults
-}

--- a/experiment/dash/dash.go
+++ b/experiment/dash/dash.go
@@ -45,8 +45,6 @@ type TestKeys struct {
 
 type dashClient interface {
 	StartDownload(ctx context.Context) (<-chan clientResults, error)
-	Error() error
-	ServerResults() []serverResults
 }
 
 type runner struct {
@@ -89,9 +87,6 @@ func (r *runner) loop(ctx context.Context) error {
 		)
 		r.callbacks.OnProgress(percentage, message)
 		r.tk.ReceiverData = append(r.tk.ReceiverData, results)
-	}
-	if r.clnt.Error() != nil {
-		return r.clnt.Error()
 	}
 	// TODO(bassosimone): it seems we're not saving the server data?
 	return nil

--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -53,18 +53,6 @@ func TestUnitRunnerLoopClientStartDownloadError(t *testing.T) {
 	}
 }
 
-func TestUnitRunnerLoopClientError(t *testing.T) {
-	expect := errors.New("mocked error")
-	c := &mockableClient{ErrorResult: expect}
-	runner := newRunner(
-		log.Log, c, handler.NewPrinterCallbacks(log.Log),
-	)
-	err := runner.loop(context.Background())
-	if !errors.Is(err, expect) {
-		t.Fatal("not the expected error")
-	}
-}
-
 func TestUnitRunnerLoopGood(t *testing.T) {
 	c := &mockableClient{
 		ClientResults: make([]clientResults, 10),
@@ -80,7 +68,6 @@ func TestUnitRunnerLoopGood(t *testing.T) {
 
 type mockableClient struct {
 	StartDownloadError error
-	ErrorResult        error
 	ClientResults      []clientResults
 }
 
@@ -95,14 +82,6 @@ func (c *mockableClient) StartDownload(
 		}
 	}()
 	return ch, c.StartDownloadError
-}
-
-func (c *mockableClient) Error() error {
-	return c.ErrorResult
-}
-
-func (c *mockableClient) ServerResults() []serverResults {
-	return nil
 }
 
 func TestUnitTestKeysAnalyzeWithNoData(t *testing.T) {


### PR DESCRIPTION
This is similar to ndt7. Treat this kind of errors more
liberally and do not fail the whole experiment.

Zap code to obtain the server measurements since we aren't
currently using them.

Part of https://github.com/ooni/probe-engine/issues/501