### PR TITLE
dash: bump the version number

### DIFF
--- a/experiment/dash/dash.go
+++ b/experiment/dash/dash.go
@@ -28,7 +28,7 @@ const (
 	defaultTimeout = 55 * time.Second
 	magicVersion   = "0.008000000"
 	testName       = "dash"
-	testVersion    = "0.8.0"
+	testVersion    = "0.9.0"
 	totalStep      = 15.0
 )
 

--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -261,7 +261,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "dash" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.8.0" {
+	if measurer.ExperimentVersion() != "0.9.0" {
 		t.Fatal("unexpected version")
 	}
 }


### PR DESCRIPTION
The implementation has changed significantly.

Part of https://github.com/ooni/probe-engine/issues/501