### PR TITLE
Rework code that manages proxying

### DIFF
--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -45,14 +45,14 @@ func TestUnitRunnerLoopNegotiateFailure(t *testing.T) {
 		httpClient: &http.Client{
 			Transport: &FakeHTTPTransportStack{
 				all: []FakeHTTPTransport{
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body: ioutil.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{err: expected},
+					{err: expected},
 				},
 			},
 		},
@@ -75,21 +75,21 @@ func TestUnitRunnerLoopMeasureFailure(t *testing.T) {
 		httpClient: &http.Client{
 			Transport: &FakeHTTPTransportStack{
 				all: []FakeHTTPTransport{
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body: ioutil.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body: ioutil.NopCloser(strings.NewReader(
 								`{"authorization": "xx", "unchoked": 1}`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{err: expected},
+					{err: expected},
 				},
 			},
 		},
@@ -114,27 +114,27 @@ func TestUnitRunnerLoopCollectFailure(t *testing.T) {
 		httpClient: &http.Client{
 			Transport: &FakeHTTPTransportStack{
 				all: []FakeHTTPTransport{
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body: ioutil.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body: ioutil.NopCloser(strings.NewReader(
 								`{"authorization": "xx", "unchoked": 1}`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body:       ioutil.NopCloser(strings.NewReader(`1234567`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{err: expected},
+					{err: expected},
 				},
 			},
 		},
@@ -158,27 +158,27 @@ func TestUnitRunnerLoopSuccess(t *testing.T) {
 		httpClient: &http.Client{
 			Transport: &FakeHTTPTransportStack{
 				all: []FakeHTTPTransport{
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body: ioutil.NopCloser(strings.NewReader(
 								`{"fqdn": "ams01.measurementlab.net"}`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body: ioutil.NopCloser(strings.NewReader(
 								`{"authorization": "xx", "unchoked": 1}`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body:       ioutil.NopCloser(strings.NewReader(`1234567`)),
 							StatusCode: 200,
 						},
 					},
-					FakeHTTPTransport{
+					{
 						resp: &http.Response{
 							Body:       ioutil.NopCloser(strings.NewReader(`[]`)),
 							StatusCode: 200,

--- a/experiment/handler/handler.go
+++ b/experiment/handler/handler.go
@@ -26,5 +26,5 @@ func (d PrinterCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
 
 // OnProgress provides information about an experiment progress.
 func (d PrinterCallbacks) OnProgress(percentage float64, message string) {
-	d.Logger.Infof("[%4.1f%%] %s", percentage*100, message)
+	d.Logger.Infof("[%5.1f%%] %s", percentage*100, message)
 }

--- a/experiment/ndt7/dial_test.go
+++ b/experiment/ndt7/dial_test.go
@@ -9,7 +9,7 @@ import (
 func TestDialDownloadWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately halt
-	mgr := newDialManager("hostname.fake")
+	mgr := newDialManager("hostname.fake", nil)
 	conn, err := mgr.dialDownload(ctx)
 	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
 		t.Fatal("not the error we expected")
@@ -22,7 +22,7 @@ func TestDialDownloadWithCancelledContext(t *testing.T) {
 func TestDialUploadWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately halt
-	mgr := newDialManager("hostname.fake")
+	mgr := newDialManager("hostname.fake", nil)
 	conn, err := mgr.dialUpload(ctx)
 	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
 		t.Fatal("not the error we expected")

--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -68,9 +68,6 @@ type measurer struct {
 
 func (m *measurer) discover(ctx context.Context, sess model.ExperimentSession) (string, error) {
 	client := mlablocate.NewClient(sess.DefaultHTTPClient(), sess.Logger(), sess.UserAgent())
-	if sess.ExplicitProxy() {
-		client.NewRequest = mlablocate.NewRequestWithProxy(sess.ProbeIP())
-	}
 	return client.Query(ctx, "ndt7")
 }
 
@@ -87,7 +84,7 @@ func (m *measurer) doDownload(
 	callbacks model.ExperimentCallbacks, tk *TestKeys,
 	hostname string,
 ) error {
-	conn, err := newDialManager(hostname).dialDownload(ctx)
+	conn, err := newDialManager(hostname, sess.ProxyURL()).dialDownload(ctx)
 	if err != nil {
 		return err
 	}
@@ -153,7 +150,7 @@ func (m *measurer) doUpload(
 	callbacks model.ExperimentCallbacks, tk *TestKeys,
 	hostname string,
 ) error {
-	conn, err := newDialManager(hostname).dialUpload(ctx)
+	conn, err := newDialManager(hostname, sess.ProxyURL()).dialUpload(ctx)
 	if err != nil {
 		return err
 	}

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -41,31 +41,6 @@ func TestUnitDiscoverCancelledContext(t *testing.T) {
 	}
 }
 
-func TestUnitDiscoverWithExplicitProxy(t *testing.T) {
-	m := new(measurer)
-	expected := errors.New("expected error")
-	sess := &mockable.ExperimentSession{
-		MockableExplicitProxy: true,
-		MockableHTTPClient: &http.Client{
-			Transport: &verifyRequestTransport{
-				ExpectedError: expected,
-			},
-		},
-		MockableLogger:    log.Log,
-		MockableProbeIP:   "1.2.3.4",
-		MockableUserAgent: "miniooni/0.1.0-dev",
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // immediately cancel
-	fqdn, err := m.discover(ctx, sess)
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-	if fqdn != "" {
-		t.Fatal("not the fqdn we expected")
-	}
-}
-
 type verifyRequestTransport struct {
 	ExpectedError error
 }

--- a/internal/mlablocate/mlablocate_test.go
+++ b/internal/mlablocate/mlablocate_test.go
@@ -28,23 +28,6 @@ func TestIntegrationWithoutProxy(t *testing.T) {
 	t.Log(fqdn)
 }
 
-func TestIntegrationWithProxy(t *testing.T) {
-	client := mlablocate.NewClient(
-		http.DefaultClient,
-		log.Log,
-		"miniooni/0.1.0-dev",
-	)
-	client.NewRequest = mlablocate.NewRequestWithProxy("8.8.8.8")
-	fqdn, err := client.Query(context.Background(), "ndt7")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if fqdn == "" {
-		t.Fatal("unexpected empty fqdn")
-	}
-	t.Log(fqdn)
-}
-
 func TestIntegration404Response(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,

--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -4,6 +4,7 @@ package mockable
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-engine/internal/kvstore"
@@ -17,7 +18,6 @@ import (
 type ExperimentSession struct {
 	MockableASNDatabasePath      string
 	MockableCABundlePath         string
-	MockableExplicitProxy        bool
 	MockableTestHelpers          map[string][]model.Service
 	MockableHTTPClient           *http.Client
 	MockableLogger               model.Logger
@@ -27,6 +27,7 @@ type ExperimentSession struct {
 	MockableProbeCC              string
 	MockableProbeIP              string
 	MockableProbeNetworkName     string
+	MockableProxyURL             *url.URL
 	MockableSoftwareName         string
 	MockableSoftwareVersion      string
 	MockableTempDir              string
@@ -41,11 +42,6 @@ func (sess *ExperimentSession) ASNDatabasePath() string {
 // CABundlePath implements ExperimentSession.CABundlePath
 func (sess *ExperimentSession) CABundlePath() string {
 	return sess.MockableCABundlePath
-}
-
-// ExplicitProxy implements ExperimentSession.ExplicitProxy
-func (sess *ExperimentSession) ExplicitProxy() bool {
-	return sess.MockableExplicitProxy
 }
 
 // GetTestHelpersByName implements ExperimentSession.GetTestHelpersByName
@@ -108,6 +104,11 @@ func (sess *ExperimentSession) ProbeIP() string {
 // ProbeNetworkName implements ExperimentSession.ProbeNetworkName
 func (sess *ExperimentSession) ProbeNetworkName() string {
 	return sess.MockableProbeNetworkName
+}
+
+// ProxyURL implements ExperimentSession.ProxyURL
+func (sess *ExperimentSession) ProxyURL() *url.URL {
+	return sess.MockableProxyURL
 }
 
 // SoftwareName implements ExperimentSession.SoftwareName

--- a/model/model.go
+++ b/model/model.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -353,7 +354,6 @@ type ExperimentOrchestraClient interface {
 type ExperimentSession interface {
 	ASNDatabasePath() string
 	CABundlePath() string
-	ExplicitProxy() bool
 	GetTestHelpersByName(name string) ([]Service, bool)
 	DefaultHTTPClient() *http.Client
 	Logger() Logger
@@ -362,6 +362,7 @@ type ExperimentSession interface {
 	ProbeCC() string
 	ProbeIP() string
 	ProbeNetworkName() string
+	ProxyURL() *url.URL
 	SoftwareName() string
 	SoftwareVersion() string
 	TempDir() string

--- a/netx/dialer/logging.go
+++ b/netx/dialer/logging.go
@@ -41,7 +41,7 @@ type LoggingTLSHandshaker struct {
 func (h LoggingTLSHandshaker) Handshake(
 	ctx context.Context, conn net.Conn, config *tls.Config,
 ) (net.Conn, tls.ConnectionState, error) {
-	h.Logger.Debugf("tls {sni=%s netx=%+v}...", config.ServerName, config.NextProtos)
+	h.Logger.Debugf("tls {sni=%s next=%+v}...", config.ServerName, config.NextProtos)
 	start := time.Now()
 	tlsconn, state, err := h.TLSHandshaker.Handshake(ctx, conn, config)
 	stop := time.Now()

--- a/netx/dialer/proxy.go
+++ b/netx/dialer/proxy.go
@@ -9,7 +9,9 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-// ProxyDialer is a dialer that uses a proxy
+// ProxyDialer is a dialer that uses a proxy. If the ProxyURL is not configured, this
+// dialer is a passthrough for the next Dialer in chain. Otherwise, it will internally
+// create a SOCKS5 dialer that will connect to the proxy using the underlying Dialer.
 type ProxyDialer struct {
 	Dialer
 	ProxyURL *url.URL

--- a/netx/dialer/proxy.go
+++ b/netx/dialer/proxy.go
@@ -1,0 +1,64 @@
+package dialer
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+
+	"golang.org/x/net/proxy"
+)
+
+// ProxyDialer is a dialer that uses a proxy
+type ProxyDialer struct {
+	Dialer
+	ProxyURL *url.URL
+}
+
+// DialContext implements Dialer.DialContext
+func (d ProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if d.ProxyURL == nil {
+		return d.Dialer.DialContext(ctx, network, address)
+	}
+	if d.ProxyURL.Scheme != "socks5" {
+		return nil, errors.New("Scheme is not socks5")
+	}
+	// the code at proxy/socks5.go never fails
+	child, _ := proxy.SOCKS5(
+		network, d.ProxyURL.Host, nil, proxyDialerWrapper{Dialer: d.Dialer})
+	return d.dial(ctx, child, network, address)
+}
+
+func (d ProxyDialer) dial(
+	ctx context.Context, child proxy.Dialer, network, address string) (net.Conn, error) {
+	connch := make(chan net.Conn)
+	errch := make(chan error, 1)
+	go func() {
+		conn, err := child.Dial(network, address)
+		if err != nil {
+			errch <- err
+			return
+		}
+		select {
+		case connch <- conn:
+		default:
+			conn.Close()
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errch:
+		return nil, err
+	case conn := <-connch:
+		return conn, nil
+	}
+}
+
+type proxyDialerWrapper struct {
+	Dialer
+}
+
+func (d proxyDialerWrapper) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}

--- a/netx/dialer/proxy.go
+++ b/netx/dialer/proxy.go
@@ -25,7 +25,7 @@ func (d ProxyDialer) DialContext(ctx context.Context, network, address string) (
 	if d.ProxyURL.Scheme != "socks5" {
 		return nil, errors.New("Scheme is not socks5")
 	}
-	// the code at proxy/socks5.go never fails
+	// the code at proxy/socks5.go never fails; see https://git.io/JfJ4g
 	child, _ := proxy.SOCKS5(
 		network, d.ProxyURL.Host, nil, proxyDialerWrapper{Dialer: d.Dialer})
 	return d.dial(ctx, child, network, address)
@@ -57,6 +57,11 @@ func (d ProxyDialer) dial(
 	}
 }
 
+// proxyDialerWrapper is required because SOCKS5 expects a Dialer.Dial type but internally
+// it checks whether DialContext is available and prefers that. So, we need to use this
+// structure to cast our inner Dialer the way in which SOCKS5 likes it.
+//
+// See https://git.io/JfJ4g.
 type proxyDialerWrapper struct {
 	Dialer
 }

--- a/netx/dialer/proxy_internal_test.go
+++ b/netx/dialer/proxy_internal_test.go
@@ -1,0 +1,15 @@
+package dialer
+
+import (
+	"context"
+	"net"
+
+	"golang.org/x/net/proxy"
+)
+
+type ProxyDialerWrapper = proxyDialerWrapper
+
+func (d ProxyDialer) DialContextWithDialer(
+	ctx context.Context, child proxy.Dialer, network, address string) (net.Conn, error) {
+	return d.dial(ctx, child, network, address)
+}

--- a/netx/dialer/proxy_test.go
+++ b/netx/dialer/proxy_test.go
@@ -1,0 +1,135 @@
+package dialer_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"testing"
+
+	"github.com/ooni/probe-engine/netx/dialer"
+)
+
+func TestUnitProxyDialerDialContextNoProxyURL(t *testing.T) {
+	expected := errors.New("mocked error")
+	d := dialer.ProxyDialer{
+		Dialer: dialer.FakeDialer{Err: expected},
+	}
+	conn, err := d.DialContext(context.Background(), "tcp", "www.google.com:443")
+	if !errors.Is(err, expected) {
+		t.Fatal(err)
+	}
+	if conn != nil {
+		t.Fatal("conn is not nil")
+	}
+}
+
+func TestUnitProxyDialerDialContextInvalidScheme(t *testing.T) {
+	d := dialer.ProxyDialer{
+		Dialer:   dialer.FakeDialer{},
+		ProxyURL: &url.URL{Scheme: "antani"},
+	}
+	conn, err := d.DialContext(context.Background(), "tcp", "www.google.com:443")
+	if err.Error() != "Scheme is not socks5" {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("conn is not nil")
+	}
+}
+
+func TestUnitProxyDialerDialContextWithEOF(t *testing.T) {
+	d := dialer.ProxyDialer{
+		Dialer: dialer.FakeDialer{
+			Err: io.EOF,
+		},
+		ProxyURL: &url.URL{Scheme: "socks5"},
+	}
+	conn, err := d.DialContext(context.Background(), "tcp", "www.google.com:443")
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("conn is not nil")
+	}
+}
+
+func TestUnitProxyDialerDialContextWithContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately fail
+	d := dialer.ProxyDialer{
+		Dialer: dialer.FakeDialer{
+			Err: io.EOF,
+		},
+		ProxyURL: &url.URL{Scheme: "socks5"},
+	}
+	conn, err := d.DialContext(ctx, "tcp", "www.google.com:443")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("conn is not nil")
+	}
+}
+
+func TestUnitProxyDialerDialContextWithDialerSuccess(t *testing.T) {
+	d := dialer.ProxyDialer{
+		Dialer: dialer.FakeDialer{
+			Conn: &dialer.FakeConn{
+				ReadError:  io.EOF,
+				WriteError: io.EOF,
+			},
+		},
+		ProxyURL: &url.URL{Scheme: "socks5"},
+	}
+	conn, err := d.DialContextWithDialer(
+		context.Background(), dialer.ProxyDialerWrapper{
+			Dialer: d.Dialer,
+		}, "tcp", "www.google.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}
+
+func TestUnitProxyDialerDialContextWithDialerCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	// Stop immediately. The FakeDialer sleeps for some microseconds so
+	// it is much more likely we immediately exit with done context. The
+	// arm where we receive the conn is much less likely.
+	cancel()
+	d := dialer.ProxyDialer{
+		Dialer: dialer.FakeDialer{
+			Conn: &dialer.FakeConn{
+				ReadError:  io.EOF,
+				WriteError: io.EOF,
+			},
+		},
+		ProxyURL: &url.URL{Scheme: "socks5"},
+	}
+	conn, err := d.DialContextWithDialer(
+		ctx, dialer.ProxyDialerWrapper{
+			Dialer: d.Dialer,
+		}, "tcp", "www.google.com:443")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("expected nil conn here")
+	}
+}
+
+func TestUnitProxyDialerWrapper(t *testing.T) {
+	d := dialer.ProxyDialerWrapper{
+		Dialer: dialer.FakeDialer{
+			Err: io.EOF,
+		},
+	}
+	conn, err := d.Dial("tcp", "www.google.com:443")
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("conn is not nil")
+	}
+}

--- a/netx/httptransport/system.go
+++ b/netx/httptransport/system.go
@@ -8,9 +8,8 @@ import (
 
 // NewSystemTransport creates a new "system" HTTP transport. That is a transport
 // using the Go standard library with custom dialer and TLS dialer.
-func NewSystemTransport(dialer Dialer, tlsDialer TLSDialer, proxy ProxyFunc) *http.Transport {
+func NewSystemTransport(dialer Dialer, tlsDialer TLSDialer) *http.Transport {
 	txp := http.DefaultTransport.(*http.Transport).Clone()
-	txp.Proxy = proxy
 	txp.DialContext = dialer.DialContext
 	txp.DialTLSContext = tlsDialer.DialTLSContext
 	// Better for Cloudflare DNS and also better because we have less

--- a/netx/httptransport/system_compat.go
+++ b/netx/httptransport/system_compat.go
@@ -10,9 +10,8 @@ import (
 
 // NewSystemTransport creates a new "system" HTTP transport. That is a transport
 // using the Go standard library with custom dialer and TLS dialer.
-func NewSystemTransport(dialer Dialer, tlsDialer TLSDialer, proxy ProxyFunc) *http.Transport {
+func NewSystemTransport(dialer Dialer, tlsDialer TLSDialer) *http.Transport {
 	txp := http.DefaultTransport.(*http.Transport).Clone()
-	txp.Proxy = proxy
 	txp.DialContext = dialer.DialContext
 	txp.DialTLS = func(network, address string) (net.Conn, error) {
 		// Go < 1.14 does not have http.Transport.DialTLSContext

--- a/session_test.go
+++ b/session_test.go
@@ -185,7 +185,7 @@ func TestBouncerError(t *testing.T) {
 	}
 	sess := newSessionForTestingNoLookupsWithProxyURL(t, URL)
 	defer sess.Close()
-	if sess.ExplicitProxy() == false {
+	if sess.ProxyURL() == nil {
 		t.Fatal("expected to see explicit proxy here")
 	}
 	if err := sess.MaybeLookupBackends(); err == nil {


### PR DESCRIPTION
The rationale of this change is the following:

1. honouring `HTTP_PROX`Y is increasingly weird when we have HTTP and non-HTTP pieces of code

2. so, let's instead introduce a concept of explicit proxy at SOCKS5 level

3. if we have a concept of explicit proxy, then use it for everything, to honour the user wishes

4. then we don't need a transport without proxy anymore

Part of https://github.com/ooni/probe-engine/issues/506