### PR TITLE
ndt7 and dash can run over psiphon

### DIFF
--- a/cmd/miniooni/main.go
+++ b/cmd/miniooni/main.go
@@ -229,13 +229,13 @@ func main() {
 	}
 
 	if !globalOptions.noBouncer {
-		log.Info("Looking up OONI backends")
+		log.Info("Looking up OONI backends; please be patient...")
 		if err := sess.MaybeLookupBackends(); err != nil {
 			log.WithError(err).Fatal("cannot lookup OONI backends")
 		}
 	}
 	if !globalOptions.noGeoIP {
-		log.Info("Looking up your location")
+		log.Info("Looking up your location; please be patient...")
 		if err := sess.MaybeLookupLocation(); err != nil {
 			log.WithError(err).Warn("cannot lookup your location")
 		} else {
@@ -292,10 +292,12 @@ func main() {
 	}()
 
 	if !globalOptions.noCollector {
+		log.Info("Opening report; please be patient...")
 		if err := experiment.OpenReport(); err != nil {
 			log.WithError(err).Fatal("cannot open report")
 		}
 		defer experiment.CloseReport()
+		log.Infof("Report ID: %s", experiment.ReportID())
 	}
 
 	inputCount := len(globalOptions.inputs)
@@ -313,7 +315,7 @@ func main() {
 		}
 		measurement.AddAnnotations(annotations)
 		if !globalOptions.noCollector {
-			log.Infof("submitting measurement to OONI collector")
+			log.Infof("submitting measurement to OONI collector; please be patient...")
 			if err := experiment.SubmitAndUpdateMeasurement(measurement); err != nil {
 				log.WithError(err).Warn("submitting measurement failed")
 				// fallthrough and save to disk what we have. Not saving is

--- a/experiment/ndt7/dial_test.go
+++ b/experiment/ndt7/dial_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/apex/log"
 )
 
 func TestDialDownloadWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately halt
-	mgr := newDialManager("hostname.fake", nil)
+	mgr := newDialManager("hostname.fake", nil, log.Log)
 	conn, err := mgr.dialDownload(ctx)
 	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
 		t.Fatal("not the error we expected")
@@ -22,7 +24,7 @@ func TestDialDownloadWithCancelledContext(t *testing.T) {
 func TestDialUploadWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately halt
-	mgr := newDialManager("hostname.fake", nil)
+	mgr := newDialManager("hostname.fake", nil, log.Log)
 	conn, err := mgr.dialUpload(ctx)
 	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
 		t.Fatal("not the error we expected")

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "ndt" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.4.0" {
+	if measurer.ExperimentVersion() != "0.5.0" {
 		t.Fatal("unexpected version")
 	}
 }
@@ -94,6 +95,42 @@ func TestUnitRunWithCancelledContext(t *testing.T) {
 	err := m.Run(ctx, sess, new(model.Measurement), handler.NewPrinterCallbacks(log.Log))
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
+	}
+}
+
+func TestUnitRunWithMaybeStartTunnelFailure(t *testing.T) {
+	m := new(measurer)
+	expected := errors.New("mocked error")
+	sess := &mockable.ExperimentSession{
+		MockableHTTPClient:          http.DefaultClient,
+		MockableMaybeStartTunnelErr: expected,
+		MockableLogger:              log.Log,
+		MockableUserAgent:           "miniooni/0.1.0-dev",
+	}
+	measurement := new(model.Measurement)
+	err := m.Run(context.TODO(), sess, measurement, handler.NewPrinterCallbacks(log.Log))
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestUnitRunWithProxyURL(t *testing.T) {
+	m := new(measurer)
+	sess := &mockable.ExperimentSession{
+		MockableHTTPClient: http.DefaultClient,
+		MockableLogger:     log.Log,
+		MockableProxyURL:   &url.URL{Host: "1.1.1.1:22"},
+		MockableUserAgent:  "miniooni/0.1.0-dev",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+	measurement := new(model.Measurement)
+	err := m.Run(ctx, sess, measurement, handler.NewPrinterCallbacks(log.Log))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if measurement.TestKeys.(*TestKeys).SOCKSProxy != "1.1.1.1:22" {
+		t.Fatal("not the SOCKSProxy we expected")
 	}
 }
 

--- a/experiment/psiphon/psiphon.go
+++ b/experiment/psiphon/psiphon.go
@@ -4,6 +4,8 @@
 // See https://github.com/ooni/spec/blob/master/nettests/ts-015-psiphon.md
 package psiphon
 
+// TODO(bassosimone): rewrite in terms of internal/psiphonx.
+
 import (
 	"context"
 	"errors"

--- a/internal/psiphonx/psiphonx.go
+++ b/internal/psiphonx/psiphonx.go
@@ -1,0 +1,125 @@
+// Package psiphonx is a wrapper around the psiphon-tunnel-core.
+package psiphonx
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Psiphon-Labs/psiphon-tunnel-core/ClientLibrary/clientlib"
+	"github.com/ooni/probe-engine/model"
+)
+
+// Dependencies contains dependencies for Start
+type Dependencies interface {
+	MkdirAll(path string, perm os.FileMode) error
+	RemoveAll(path string) error
+	Start(ctx context.Context, config []byte,
+		workdir string) (*clientlib.PsiphonTunnel, error)
+}
+
+type defaultDependencies struct{}
+
+func (defaultDependencies) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (defaultDependencies) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (defaultDependencies) Start(
+	ctx context.Context, config []byte, workdir string) (*clientlib.PsiphonTunnel, error) {
+	return clientlib.StartTunnel(ctx, config, "", clientlib.Parameters{
+		DataRootDirectory: &workdir}, nil, nil)
+}
+
+// Config contains the settings for Start. The empty config object implies
+// that we will be using default settings for starting the tunnel.
+type Config struct {
+	// Dependencies contains dependencies for Start.
+	Dependencies Dependencies
+
+	// WorkDir is the directory where Psiphon should store
+	// its configuration database.
+	WorkDir string
+}
+
+// Tunnel is a psiphon tunnel
+type Tunnel struct {
+	tunnel   *clientlib.PsiphonTunnel
+	duration time.Duration
+}
+
+func makeworkingdir(config Config) (string, error) {
+	const testdirname = "oonipsiphon"
+	workdir := filepath.Join(config.WorkDir, testdirname)
+	if err := config.Dependencies.RemoveAll(workdir); err != nil {
+		return "", err
+	}
+	if err := config.Dependencies.MkdirAll(workdir, 0700); err != nil {
+		return "", err
+	}
+	return workdir, nil
+}
+
+// Start starts the psiphon tunnel.
+func Start(
+	ctx context.Context, sess model.ExperimentSession, config Config) (*Tunnel, error) {
+	if config.Dependencies == nil {
+		config.Dependencies = defaultDependencies{}
+	}
+	if config.WorkDir == "" {
+		config.WorkDir = sess.TempDir()
+	}
+	clnt, err := sess.NewOrchestraClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	configJSON, err := clnt.FetchPsiphonConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	workdir, err := makeworkingdir(config)
+	if err != nil {
+		return nil, err
+	}
+	start := time.Now()
+	tunnel, err := config.Dependencies.Start(ctx, configJSON, workdir)
+	if err != nil {
+		return nil, err
+	}
+	stop := time.Now()
+	return &Tunnel{tunnel: tunnel, duration: stop.Sub(start)}, nil
+}
+
+// Stop is an idempotent method that shuts down the tunnel
+func (t *Tunnel) Stop() {
+	if t != nil {
+		t.tunnel.Stop()
+	}
+}
+
+// SOCKS5ProxyURL returns the SOCKS5 proxy URL.
+func (t *Tunnel) SOCKS5ProxyURL() (proxyURL *url.URL) {
+	if t != nil {
+		proxyURL = &url.URL{
+			Scheme: "socks5",
+			Host: net.JoinHostPort(
+				"127.0.0.1", fmt.Sprintf("%d", t.tunnel.SOCKSProxyPort)),
+		}
+	}
+	return
+}
+
+// BootstrapTime returns the bootstrap time
+func (t *Tunnel) BootstrapTime() (duration time.Duration) {
+	if t != nil {
+		duration = t.duration
+	}
+	return
+}

--- a/model/model.go
+++ b/model/model.go
@@ -357,6 +357,7 @@ type ExperimentSession interface {
 	GetTestHelpersByName(name string) ([]Service, bool)
 	DefaultHTTPClient() *http.Client
 	Logger() Logger
+	MaybeStartTunnel(ctx context.Context, name string) error
 	NewOrchestraClient(ctx context.Context) (ExperimentOrchestraClient, error)
 	ProbeASNString() string
 	ProbeCC() string
@@ -366,6 +367,7 @@ type ExperimentSession interface {
 	SoftwareName() string
 	SoftwareVersion() string
 	TempDir() string
+	TunnelBootstrapTime() time.Duration
 	UserAgent() string
 }
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
+func TestUnitMeasurementTargetMarshalJSON(t *testing.T) {
+	var mt model.MeasurementTarget
+	data, err := json.Marshal(mt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "null" {
+		t.Fatal("unexpected serialization")
+	}
+	mt = "xx"
+	data, err = json.Marshal(mt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `"xx"` {
+		t.Fatal("unexpected serialization")
+	}
+}
+
 type fakeTestKeys struct {
 	ClientResolver string `json:"client_resolver"`
 	Body           string `json:"body"`

--- a/netx/httptransport/httptransport.go
+++ b/netx/httptransport/httptransport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ooni/probe-engine/netx/bytecounter"
 	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/resolver"
+	"github.com/ooni/probe-engine/netx/trace"
 )
 
 // Dialer is the definition of dialer assumed by this package.
@@ -38,13 +39,16 @@ type Resolver interface {
 // Config contains configuration for creating a new transport. When any
 // field of Config is nil/empty, we will use a suitable default.
 type Config struct {
-	ByteCounter *bytecounter.Counter // default: no byte counting
-	Dialer      Dialer               // default: dialer.DNSDialer
-	Logger      Logger               // default: no logging
-	ProxyURL    *url.URL             // default: no proxy
-	Resolver    Resolver             // default: system resolver
-	TLSConfig   *tls.Config          // default: attempt using h2
-	TLSDialer   TLSDialer            // default: dialer.TLSDialer
+	BogonIsError        bool                 // default: bogon is not error
+	ByteCounter         *bytecounter.Counter // default: no byte counting
+	ContextByteCounting bool                 // default: no context byte counting
+	Dialer              Dialer               // default: dialer.DNSDialer
+	Logger              Logger               // default: no logging
+	ProxyURL            *url.URL             // default: no proxy
+	Resolver            Resolver             // default: system resolver
+	Saver               *trace.Saver         // default: no saver
+	TLSConfig           *tls.Config          // default: attempt using h2
+	TLSDialer           TLSDialer            // default: dialer.TLSDialer
 }
 
 type tlsHandshaker interface {
@@ -56,46 +60,51 @@ type tlsHandshaker interface {
 // RoundTripper before wrapping it into an http.Client.
 func New(config Config) RoundTripper {
 	if config.Resolver == nil {
-		var r Resolver = resolver.ErrorWrapperResolver{
-			Resolver: resolver.BogonResolver{
-				Resolver: resolver.SystemResolver{},
-			},
+		var r Resolver = resolver.SystemResolver{}
+		if config.BogonIsError {
+			r = resolver.BogonResolver{Resolver: r}
 		}
+		r = resolver.ErrorWrapperResolver{Resolver: r}
 		if config.Logger != nil {
 			r = resolver.LoggingResolver{Logger: config.Logger, Resolver: r}
+		}
+		if config.Saver != nil {
+			r = resolver.SaverResolver{Resolver: r, Saver: config.Saver}
 		}
 		config.Resolver = r
 	}
 	if config.Dialer == nil {
-		var d Dialer = dialer.ErrorWrapperDialer{
-			Dialer: dialer.TimeoutDialer{
-				Dialer: new(net.Dialer),
-			},
-		}
+		var d Dialer = new(net.Dialer)
+		d = dialer.TimeoutDialer{Dialer: d}
+		d = dialer.ErrorWrapperDialer{Dialer: d}
 		if config.Logger != nil {
 			d = dialer.LoggingDialer{Dialer: d, Logger: config.Logger}
 		}
-		d = dialer.DNSDialer{
-			Resolver: config.Resolver,
-			Dialer:   d,
+		if config.Saver != nil {
+			d = dialer.SaverDialer{Dialer: d, Saver: config.Saver}
 		}
-		config.Dialer = dialer.ProxyDialer{
-			ProxyURL: config.ProxyURL,
-			Dialer:   d,
+		d = dialer.DNSDialer{Resolver: config.Resolver, Dialer: d}
+		d = dialer.ProxyDialer{ProxyURL: config.ProxyURL, Dialer: d}
+		if config.ContextByteCounting {
+			d = dialer.ByteCounterDialer{Dialer: d}
 		}
+		config.Dialer = d
 	}
 	if config.TLSDialer == nil {
-		var h tlsHandshaker
-		h = dialer.ErrorWrapperTLSHandshaker{
-			TLSHandshaker: dialer.TimeoutTLSHandshaker{
-				TLSHandshaker: dialer.SystemTLSHandshaker{},
-			},
-		}
+		var h tlsHandshaker = dialer.SystemTLSHandshaker{}
+		h = dialer.TimeoutTLSHandshaker{TLSHandshaker: h}
+		h = dialer.ErrorWrapperTLSHandshaker{TLSHandshaker: h}
 		if config.Logger != nil {
 			h = dialer.LoggingTLSHandshaker{Logger: config.Logger, TLSHandshaker: h}
 		}
+		if config.Saver != nil {
+			h = dialer.SaverTLSHandshaker{TLSHandshaker: h, Saver: config.Saver}
+		}
+		if config.TLSConfig == nil {
+			config.TLSConfig = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+		}
 		config.TLSDialer = dialer.TLSDialer{
-			Config:        &tls.Config{NextProtos: []string{"h2", "http/1.1"}},
+			Config:        config.TLSConfig,
 			Dialer:        config.Dialer,
 			TLSHandshaker: h,
 		}
@@ -107,6 +116,9 @@ func New(config Config) RoundTripper {
 	}
 	if config.Logger != nil {
 		txp = LoggingTransport{Logger: config.Logger, RoundTripper: txp}
+	}
+	if config.Saver != nil {
+		txp = SaverHTTPTransport{RoundTripper: txp, Saver: config.Saver}
 	}
 	txp = UserAgentTransport{RoundTripper: txp}
 	return txp

--- a/netx/httptransport/integration_test.go
+++ b/netx/httptransport/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apex/log"
 	"github.com/ooni/probe-engine/netx/bytecounter"
 	"github.com/ooni/probe-engine/netx/httptransport"
+	"github.com/ooni/probe-engine/netx/trace"
 )
 
 func TestIntegrationSuccess(t *testing.T) {
@@ -16,9 +17,13 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 	log.SetLevel(log.DebugLevel)
 	counter := bytecounter.New()
+	saver := new(trace.Saver)
 	txp := httptransport.New(httptransport.Config{
-		ByteCounter: counter,
-		Logger:      log.Log,
+		BogonIsError:        true,
+		ByteCounter:         counter,
+		ContextByteCounting: true,
+		Logger:              log.Log,
+		Saver:               saver,
 	})
 	client := &http.Client{Transport: txp}
 	resp, err := client.Get("https://www.google.com")


### PR DESCRIPTION
The design is that we have a tunnel managed by the session. We may ask the
session to possibly start a tunnel, provided that one is configured.

If no tunnel is configured, nothing actually happens. Otherwise, we get
a proxy (similar to when `--proxy` is used) that we use.

The psiphon experiment now needs refactoring to use this tunnel.

Part of https://github.com/ooni/probe-engine/issues/506.