### PR TITLE
Measurement += ProbeNetworkName non standard field

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -340,6 +340,7 @@ func (e *Experiment) newMeasurement(input string) *model.Measurement {
 		ProbeIP:                   e.session.ProbeIP(),
 		ProbeASN:                  e.session.ProbeASNString(),
 		ProbeCC:                   e.session.ProbeCC(),
+		ProbeNetworkName:          e.session.ProbeNetworkName(),
 		ReportID:                  e.ReportID(),
 		ResolverASN:               e.session.ResolverASNString(),
 		ResolverIP:                e.session.ResolverIP(),

--- a/model/model.go
+++ b/model/model.go
@@ -74,6 +74,9 @@ type Measurement struct {
 	// ProbeIP contains the probe IP
 	ProbeIP string `json:"probe_ip,omitempty"`
 
+	// ProbeNetworkName contains the probe network name
+	ProbeNetworkName string `json:"probe_network_name,omitempty"`
+
 	// ReportID contains the report ID
 	ReportID string `json:"report_id"`
 


### PR DESCRIPTION
This is non standard. We don't need to add it to the spec. It is just
useful when you are vetting measurements manually.

Cherry-picked from work related to https://github.com/ooni/probe-engine/issues/509