### PR TITLE
resolver: collect transport's Network and Address

### DIFF
--- a/experiment/ndt7/dial.go
+++ b/experiment/ndt7/dial.go
@@ -37,7 +37,7 @@ func newDialManager(hostname string, proxyURL *url.URL, logger model.Logger) dia
 }
 
 func (mgr dialManager) dialWithTestName(ctx context.Context, testName string) (*websocket.Conn, error) {
-	var reso resolver.Resolver = new(net.Resolver)
+	var reso resolver.Resolver = resolver.SystemResolver{}
 	reso = resolver.LoggingResolver{Resolver: reso, Logger: mgr.logger}
 	var dlr dialer.Dialer = new(net.Dialer)
 	dlr = dialer.TimeoutDialer{Dialer: dlr}

--- a/netx/httptransport/httptransport.go
+++ b/netx/httptransport/httptransport.go
@@ -34,6 +34,8 @@ type RoundTripper interface {
 // Resolver is the interface we expect from a resolver
 type Resolver interface {
 	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+	Network() string
+	Address() string
 }
 
 // Config contains configuration for creating a new transport. When any

--- a/netx/resolver.go
+++ b/netx/resolver.go
@@ -127,10 +127,25 @@ func NewResolver(network, address string) (modelx.DNSResolver, error) {
 	return newResolver(time.Now(), handlers.NoHandler, network, address)
 }
 
+type chainWrapperResolver struct {
+	modelx.DNSResolver
+}
+
+func (r chainWrapperResolver) Network() string {
+	return "chain"
+}
+
+func (r chainWrapperResolver) Address() string {
+	return ""
+}
+
 // ChainResolvers chains a primary and a secondary resolver such that
 // we can fallback to the secondary if primary is broken.
 func ChainResolvers(primary, secondary modelx.DNSResolver) modelx.DNSResolver {
-	return resolver.ChainResolver{Primary: primary, Secondary: secondary}
+	return resolver.ChainResolver{
+		Primary:   chainWrapperResolver{DNSResolver: primary},
+		Secondary: chainWrapperResolver{DNSResolver: secondary},
+	}
 }
 
 func resolverWrapResolver(r resolver.Resolver) resolver.EmitterResolver {

--- a/netx/resolver/chain.go
+++ b/netx/resolver/chain.go
@@ -20,4 +20,14 @@ func (c ChainResolver) LookupHost(ctx context.Context, hostname string) ([]strin
 	return addrs, err
 }
 
+// Network implements Resolver.Network
+func (c ChainResolver) Network() string {
+	return "chain"
+}
+
+// Address implements Resolver.Address
+func (c ChainResolver) Address() string {
+	return ""
+}
+
 var _ Resolver = ChainResolver{}

--- a/netx/resolver/chain_test.go
+++ b/netx/resolver/chain_test.go
@@ -2,18 +2,23 @@ package resolver_test
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
 func TestChainLookupHost(t *testing.T) {
-	client := resolver.ChainResolver{
+	r := resolver.ChainResolver{
 		Primary:   resolver.NewFakeResolverThatFails(),
-		Secondary: new(net.Resolver),
+		Secondary: resolver.SystemResolver{},
 	}
-	addrs, err := client.LookupHost(context.Background(), "www.google.com")
+	if r.Address() != "" {
+		t.Fatal("invalid address")
+	}
+	if r.Network() != "chain" {
+		t.Fatal("invalid network")
+	}
+	addrs, err := r.LookupHost(context.Background(), "www.google.com")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/netx/resolver/fake_test.go
+++ b/netx/resolver/fake_test.go
@@ -131,4 +131,12 @@ func (c FakeResolver) LookupHost(ctx context.Context, hostname string) ([]string
 	return c.Result, nil
 }
 
+func (c FakeResolver) Network() string {
+	return "fake"
+}
+
+func (c FakeResolver) Address() string {
+	return ""
+}
+
 var _ Resolver = FakeResolver{}

--- a/netx/resolver/resolver.go
+++ b/netx/resolver/resolver.go
@@ -9,4 +9,10 @@ import (
 type Resolver interface {
 	// LookupHost resolves a hostname to a list of IP addresses.
 	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+
+	// Network returns the network being used by the resolver
+	Network() string
+
+	// Address returns the address being used by the resolver
+	Address() string
 }

--- a/netx/resolver/saver.go
+++ b/netx/resolver/saver.go
@@ -17,18 +17,22 @@ type SaverResolver struct {
 func (r SaverResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	start := time.Now()
 	r.Saver.Write(trace.Event{
+		Address:  r.Resolver.Address(),
 		Hostname: hostname,
 		Name:     "resolve_start",
+		Proto:    r.Resolver.Network(),
 		Time:     start,
 	})
 	addrs, err := r.Resolver.LookupHost(ctx, hostname)
 	stop := time.Now()
 	r.Saver.Write(trace.Event{
 		Addresses: addrs,
+		Address:   r.Resolver.Address(),
 		Duration:  stop.Sub(start),
 		Err:       err,
 		Hostname:  hostname,
 		Name:      "resolve_done",
+		Proto:     r.Resolver.Network(),
 		Time:      stop,
 	})
 	return addrs, err
@@ -44,18 +48,22 @@ type SaverDNSTransport struct {
 func (txp SaverDNSTransport) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	start := time.Now()
 	txp.Saver.Write(trace.Event{
+		Address:  txp.Address(),
 		DNSQuery: query,
 		Name:     "dns_round_trip_start",
+		Proto:    txp.Network(),
 		Time:     start,
 	})
 	reply, err := txp.RoundTripper.RoundTrip(ctx, query)
 	stop := time.Now()
 	txp.Saver.Write(trace.Event{
+		Address:  txp.Address(),
 		DNSQuery: query,
 		DNSReply: reply,
 		Duration: stop.Sub(start),
 		Err:      err,
 		Name:     "dns_round_trip_done",
+		Proto:    txp.Network(),
 		Time:     stop,
 	})
 	return reply, err

--- a/netx/resolver/serial.go
+++ b/netx/resolver/serial.go
@@ -48,6 +48,16 @@ func (r SerialResolver) Transport() RoundTripper {
 	return r.Txp
 }
 
+// Network implements Resolver.Network
+func (r SerialResolver) Network() string {
+	return r.Txp.Network()
+}
+
+// Address implements Resolver.Address
+func (r SerialResolver) Address() string {
+	return r.Txp.Address()
+}
+
 // LookupHost implements Resolver.LookupHost.
 func (r SerialResolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	var addrs []string

--- a/netx/resolver/serial_test.go
+++ b/netx/resolver/serial_test.go
@@ -19,6 +19,12 @@ func TestUnitOONIGettingTransport(t *testing.T) {
 	if rtx.Network() != "dot" || rtx.Address() != "8.8.8.8:853" {
 		t.Fatal("not the transport we expected")
 	}
+	if r.Network() != rtx.Network() {
+		t.Fatal("invalid network seen from the resolver")
+	}
+	if r.Address() != rtx.Address() {
+		t.Fatal("invalid address seen from the resolver")
+	}
 }
 
 func TestUnitOONIEncodeError(t *testing.T) {

--- a/netx/resolver/system.go
+++ b/netx/resolver/system.go
@@ -13,4 +13,14 @@ func (r SystemResolver) LookupHost(ctx context.Context, hostname string) ([]stri
 	return net.DefaultResolver.LookupHost(ctx, hostname)
 }
 
+// Network implements Resolver.Network
+func (r SystemResolver) Network() string {
+	return "system"
+}
+
+// Address implements Resolver.Address
+func (r SystemResolver) Address() string {
+	return ""
+}
+
 var _ Resolver = SystemResolver{}

--- a/netx/resolver/system_test.go
+++ b/netx/resolver/system_test.go
@@ -9,6 +9,12 @@ import (
 
 func TestIntegrationSystemResolverLookupHost(t *testing.T) {
 	r := resolver.SystemResolver{}
+	if r.Network() != "system" {
+		t.Fatal("invalid Network")
+	}
+	if r.Address() != "" {
+		t.Fatal("invalid Address")
+	}
 	addrs, err := r.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
 		t.Fatal(err)

--- a/netx/resolver_internal_test.go
+++ b/netx/resolver_internal_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// NewHTTPClientForDoH exposes the factory function we use internally for
-// creating DoH optimised clients to unit tests.
 func NewHTTPClientForDoH(beginning time.Time, handler modelx.Handler) *http.Client {
 	return newHTTPClientForDoH(beginning, handler)
 }
+
+type ChainWrapperResolver = chainWrapperResolver

--- a/netx/resolver_test.go
+++ b/netx/resolver_test.go
@@ -142,3 +142,13 @@ func TestUnitNewHTTPClientForDoH(t *testing.T) {
 		t.Fatal("expected to see different client here")
 	}
 }
+
+func TestUnitChainWrapperResolver(t *testing.T) {
+	r := netx.ChainWrapperResolver{}
+	if r.Address() != "" {
+		t.Fatal("invalid Address")
+	}
+	if r.Network() != "chain" {
+		t.Fatal("invalid Network")
+	}
+}


### PR DESCRIPTION
These are useful bits of information when filling a measurement
because they allow us to understand what transport is used.

Part of https://github.com/ooni/probe-engine/issues/509