### PR TITLE
netx: decouple TLS from saving R/W events

### DIFF
--- a/netx/dialer/saver.go
+++ b/netx/dialer/saver.go
@@ -44,8 +44,6 @@ type SaverTLSHandshaker struct {
 func (h SaverTLSHandshaker) Handshake(
 	ctx context.Context, conn net.Conn, config *tls.Config,
 ) (net.Conn, tls.ConnectionState, error) {
-	measuringconn := tlsMeasuringConn{Conn: conn, saver: h.Saver}
-	proxyconn := tlsProxyConn{Conn: measuringconn}
 	start := time.Now()
 	h.Saver.Write(trace.Event{
 		Name:          "tls_handshake_start",
@@ -53,7 +51,7 @@ func (h SaverTLSHandshaker) Handshake(
 		TLSServerName: config.ServerName,
 		Time:          start,
 	})
-	tlsconn, state, err := h.TLSHandshaker.Handshake(ctx, proxyconn, config)
+	tlsconn, state, err := h.TLSHandshaker.Handshake(ctx, conn, config)
 	stop := time.Now()
 	h.Saver.Write(trace.Event{
 		Duration:           stop.Sub(start),
@@ -67,20 +65,31 @@ func (h SaverTLSHandshaker) Handshake(
 		TLSVersion:         tlsx.VersionString(state.Version),
 		Time:               stop,
 	})
-	proxyconn.Conn = conn // stop measuring
 	return tlsconn, state, err
 }
 
-type tlsProxyConn struct {
-	net.Conn
+// SaverConnDialer wraps the returned connection such that we
+// collect all the read/write events that occur.
+type SaverConnDialer struct {
+	Dialer
+	Saver *trace.Saver
 }
 
-type tlsMeasuringConn struct {
+// DialContext implements Dialer.DialContext
+func (d SaverConnDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := d.Dialer.DialContext(ctx, network, address)
+	if conn == nil {
+		return nil, err
+	}
+	return saverConn{saver: d.Saver, Conn: conn}, nil
+}
+
+type saverConn struct {
 	net.Conn
 	saver *trace.Saver
 }
 
-func (c tlsMeasuringConn) Read(p []byte) (int, error) {
+func (c saverConn) Read(p []byte) (int, error) {
 	start := time.Now()
 	count, err := c.Conn.Read(p)
 	stop := time.Now()
@@ -95,7 +104,7 @@ func (c tlsMeasuringConn) Read(p []byte) (int, error) {
 	return count, err
 }
 
-func (c tlsMeasuringConn) Write(p []byte) (int, error) {
+func (c saverConn) Write(p []byte) (int, error) {
 	start := time.Now()
 	count, err := c.Conn.Write(p)
 	stop := time.Now()
@@ -134,5 +143,4 @@ func peerCerts(state tls.ConnectionState, err error) []*x509.Certificate {
 
 var _ Dialer = SaverDialer{}
 var _ TLSHandshaker = SaverTLSHandshaker{}
-var _ net.Conn = tlsMeasuringConn{}
-var _ net.Conn = tlsProxyConn{}
+var _ net.Conn = saverConn{}

--- a/netx/dialer/saver.go
+++ b/netx/dialer/saver.go
@@ -78,7 +78,7 @@ type SaverConnDialer struct {
 // DialContext implements Dialer.DialContext
 func (d SaverConnDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	conn, err := d.Dialer.DialContext(ctx, network, address)
-	if conn == nil {
+	if err != nil {
 		return nil, err
 	}
 	return saverConn{saver: d.Saver, Conn: conn}, nil

--- a/netx/dialer/saver_test.go
+++ b/netx/dialer/saver_test.go
@@ -177,7 +177,7 @@ func TestIntegrationSaverTLSHandshakerSuccess(t *testing.T) {
 	tlsdlr := dialer.TLSDialer{
 		Config: &tls.Config{NextProtos: nextprotos},
 		Dialer: new(net.Dialer),
-		TLSHandshaker: &dialer.SaverTLSHandshaker{
+		TLSHandshaker: dialer.SaverTLSHandshaker{
 			TLSHandshaker: dialer.SystemTLSHandshaker{},
 			Saver:         saver,
 		},
@@ -242,7 +242,7 @@ func TestIntegrationSaverTLSHandshakerHostnameError(t *testing.T) {
 	saver := &trace.Saver{}
 	tlsdlr := dialer.TLSDialer{
 		Dialer: new(net.Dialer),
-		TLSHandshaker: &dialer.SaverTLSHandshaker{
+		TLSHandshaker: dialer.SaverTLSHandshaker{
 			TLSHandshaker: dialer.SystemTLSHandshaker{},
 			Saver:         saver,
 		},
@@ -272,7 +272,7 @@ func TestIntegrationSaverTLSHandshakerInvalidCertError(t *testing.T) {
 	saver := &trace.Saver{}
 	tlsdlr := dialer.TLSDialer{
 		Dialer: new(net.Dialer),
-		TLSHandshaker: &dialer.SaverTLSHandshaker{
+		TLSHandshaker: dialer.SaverTLSHandshaker{
 			TLSHandshaker: dialer.SystemTLSHandshaker{},
 			Saver:         saver,
 		},
@@ -302,7 +302,7 @@ func TestIntegrationSaverTLSHandshakerAuthorityError(t *testing.T) {
 	saver := &trace.Saver{}
 	tlsdlr := dialer.TLSDialer{
 		Dialer: new(net.Dialer),
-		TLSHandshaker: &dialer.SaverTLSHandshaker{
+		TLSHandshaker: dialer.SaverTLSHandshaker{
 			TLSHandshaker: dialer.SystemTLSHandshaker{},
 			Saver:         saver,
 		},

--- a/netx/httptransport/httptransport.go
+++ b/netx/httptransport/httptransport.go
@@ -49,6 +49,7 @@ type Config struct {
 	Logger              Logger               // default: no logging
 	ProxyURL            *url.URL             // default: no proxy
 	Resolver            Resolver             // default: system resolver
+	SaveReadWrite       bool                 // default: don't save read/write
 	Saver               *trace.Saver         // default: no saver
 	TLSConfig           *tls.Config          // default: attempt using h2
 	TLSDialer           TLSDialer            // default: dialer.TLSDialer
@@ -88,6 +89,9 @@ func New(config Config) RoundTripper {
 		}
 		if config.Saver != nil {
 			d = dialer.SaverDialer{Dialer: d, Saver: config.Saver}
+			if config.SaveReadWrite {
+				d = dialer.SaverConnDialer{Dialer: d, Saver: config.Saver}
+			}
 		}
 		d = dialer.DNSDialer{Resolver: config.Resolver, Dialer: d}
 		d = dialer.ProxyDialer{ProxyURL: config.ProxyURL, Dialer: d}

--- a/netx/httptransport/integration_test.go
+++ b/netx/httptransport/integration_test.go
@@ -24,6 +24,7 @@ func TestIntegrationSuccess(t *testing.T) {
 		CacheResolutions:    true,
 		ContextByteCounting: true,
 		Logger:              log.Log,
+		SaveReadWrite:       true,
 		Saver:               saver,
 	})
 	client := &http.Client{Transport: txp}
@@ -37,6 +38,13 @@ func TestIntegrationSuccess(t *testing.T) {
 	if err = resp.Body.Close(); err != nil {
 		t.Fatal(err)
 	}
-	t.Log(counter.Sent.Load())
-	t.Log(counter.Received.Load())
+	if counter.Sent.Load() <= 0 {
+		t.Fatal("no bytes sent?!")
+	}
+	if counter.Received.Load() <= 0 {
+		t.Fatal("no bytes received?!")
+	}
+	if ev := saver.Read(); len(ev) <= 0 {
+		t.Fatal("no low level events?!")
+	}
 }


### PR DESCRIPTION
We may want to perform TLS measurements without saving R/W events and we may
want to save R/W events without performing TLS.

We also may want to perform dial measurements without saving R/W events and we
may want to save R/W events without dial measurements.

So, create a new dialer that also does R/W measurements.

Also, add option to httptransport.New factory to enable this functionality.

Part of https://github.com/ooni/probe-engine/issues/543