### PR TITLE
netx/httptransport: stop using http/httptrace

### DIFF
--- a/netx/httptransport/saver.go
+++ b/netx/httptransport/saver.go
@@ -2,7 +2,6 @@ package httptransport
 
 import (
 	"net/http"
-	"net/http/httptrace"
 	"time"
 
 	"github.com/ooni/probe-engine/netx/trace"
@@ -16,22 +15,6 @@ type SaverHTTPTransport struct {
 
 // RoundTrip implements RoundTripper.RoundTrip
 func (txp SaverHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	tracep := httptrace.ContextClientTrace(req.Context())
-	if tracep == nil {
-		tracep = &httptrace.ClientTrace{
-			WroteHeaders: func() {
-				txp.Saver.Write(trace.Event{Name: "http_wrote_headers", Time: time.Now()})
-			},
-			WroteRequest: func(httptrace.WroteRequestInfo) {
-				txp.Saver.Write(trace.Event{Name: "http_wrote_request", Time: time.Now()})
-			},
-			GotFirstResponseByte: func() {
-				txp.Saver.Write(trace.Event{
-					Name: "http_first_response_byte", Time: time.Now()})
-			},
-		}
-		req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracep))
-	}
 	start := time.Now()
 	txp.Saver.Write(trace.Event{
 		HTTPRequest: req,


### PR DESCRIPTION
Using http/httptrace leads to tricky code because of the context and the
fact we may mistakenly register more than once.

If we want, we have network level data. So we are going to use network
level data to evaluate performance instead.

Part of https://github.com/ooni/probe-engine/issues/543