### PR TITLE
netx/httptransport: reintroduce http/httptrace

### DIFF
--- a/netx/httptransport/httptransport.go
+++ b/netx/httptransport/httptransport.go
@@ -129,6 +129,7 @@ func New(config Config) RoundTripper {
 	}
 	if config.Saver != nil {
 		txp = SaverHTTPTransport{RoundTripper: txp, Saver: config.Saver}
+		txp = SaverPerformanceHTTPTransport{RoundTripper: txp, Saver: config.Saver}
 	}
 	txp = UserAgentTransport{RoundTripper: txp}
 	return txp

--- a/netx/httptransport/saver.go
+++ b/netx/httptransport/saver.go
@@ -1,11 +1,89 @@
 package httptransport
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptrace"
 	"time"
 
+	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/trace"
 )
+
+// SaverPerformanceHTTPTransport is a RoundTripper that saves
+// performance events during the round trip
+type SaverPerformanceHTTPTransport struct {
+	RoundTripper
+	Saver *trace.Saver
+}
+
+// RoundTrip implements RoundTripper.RoundTrip
+func (txp SaverPerformanceHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Implementation description: create a new context independent from
+	// the original one but still honour the original one. This guarantees
+	// that we will always have a single tracer.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	origCtx := req.Context()
+	// Make sure we honour the parent's byte counters. This is horrible
+	// and if we could avoid using context for doing that...
+	if bc := dialer.ContextSessionByteCounter(origCtx); bc != nil {
+		ctx = dialer.WithSessionByteCounter(ctx, bc)
+	}
+	if bc := dialer.ContextExperimentByteCounter(origCtx); bc != nil {
+		ctx = dialer.WithExperimentByteCounter(ctx, bc)
+	}
+	req = req.WithContext(ctx)
+	respch := make(chan *http.Response)
+	errch := make(chan error)
+	go txp.roundTrip(req, respch, errch)
+	select {
+	case <-origCtx.Done():
+		return nil, origCtx.Err()
+	case resp := <-respch:
+		return resp, nil
+	case err := <-errch:
+		return nil, err
+	}
+}
+
+func (txp SaverPerformanceHTTPTransport) roundTrip(
+	req *http.Request, respch chan *http.Response, errch chan error) {
+	// Implementation description: if we cannot write, it means
+	// that the parent has already cancelled the context
+	resp, err := txp.doRoundTrip(req)
+	if err != nil {
+		select {
+		case errch <- err:
+		default:
+		}
+		return
+	}
+	select {
+	case respch <- resp:
+	default:
+		resp.Body.Close() // honour round tripper protocol
+	}
+}
+
+func (txp SaverPerformanceHTTPTransport) doRoundTrip(req *http.Request) (*http.Response, error) {
+	// Unconditionally attach tracer. We know there's only this one because
+	// above we created a pristine context for this request.
+	tracep := &httptrace.ClientTrace{
+		WroteHeaders: func() {
+			txp.Saver.Write(trace.Event{Name: "http_wrote_headers", Time: time.Now()})
+		},
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			txp.Saver.Write(trace.Event{Name: "http_wrote_request", Time: time.Now()})
+		},
+		GotFirstResponseByte: func() {
+			txp.Saver.Write(trace.Event{
+				Name: "http_first_response_byte", Time: time.Now()})
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracep))
+	return txp.RoundTripper.RoundTrip(req)
+}
 
 // SaverHTTPTransport is a RoundTripper that saves events
 type SaverHTTPTransport struct {
@@ -34,4 +112,5 @@ func (txp SaverHTTPTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	return resp, err
 }
 
+var _ RoundTripper = SaverPerformanceHTTPTransport{}
 var _ RoundTripper = SaverHTTPTransport{}

--- a/netx/httptransport/saver.go
+++ b/netx/httptransport/saver.go
@@ -1,12 +1,10 @@
 package httptransport
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptrace"
 	"time"
 
-	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -19,69 +17,22 @@ type SaverPerformanceHTTPTransport struct {
 
 // RoundTrip implements RoundTripper.RoundTrip
 func (txp SaverPerformanceHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Implementation description: create a new context independent from
-	// the original one but still honour the original one. This guarantees
-	// that we will always have a single tracer.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	origCtx := req.Context()
-	// Make sure we honour the parent's byte counters. This is horrible
-	// and if we could avoid using context for doing that...
-	if bc := dialer.ContextSessionByteCounter(origCtx); bc != nil {
-		ctx = dialer.WithSessionByteCounter(ctx, bc)
-	}
-	if bc := dialer.ContextExperimentByteCounter(origCtx); bc != nil {
-		ctx = dialer.WithExperimentByteCounter(ctx, bc)
-	}
-	req = req.WithContext(ctx)
-	respch := make(chan *http.Response)
-	errch := make(chan error)
-	go txp.roundTrip(req, respch, errch)
-	select {
-	case <-origCtx.Done():
-		return nil, origCtx.Err()
-	case resp := <-respch:
-		return resp, nil
-	case err := <-errch:
-		return nil, err
-	}
-}
-
-func (txp SaverPerformanceHTTPTransport) roundTrip(
-	req *http.Request, respch chan *http.Response, errch chan error) {
-	// Implementation description: if we cannot write, it means
-	// that the parent has already cancelled the context
-	resp, err := txp.doRoundTrip(req)
-	if err != nil {
-		select {
-		case errch <- err:
-		default:
+	tracep := httptrace.ContextClientTrace(req.Context())
+	if tracep == nil {
+		tracep = &httptrace.ClientTrace{
+			WroteHeaders: func() {
+				txp.Saver.Write(trace.Event{Name: "http_wrote_headers", Time: time.Now()})
+			},
+			WroteRequest: func(httptrace.WroteRequestInfo) {
+				txp.Saver.Write(trace.Event{Name: "http_wrote_request", Time: time.Now()})
+			},
+			GotFirstResponseByte: func() {
+				txp.Saver.Write(trace.Event{
+					Name: "http_first_response_byte", Time: time.Now()})
+			},
 		}
-		return
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracep))
 	}
-	select {
-	case respch <- resp:
-	default:
-		resp.Body.Close() // honour round tripper protocol
-	}
-}
-
-func (txp SaverPerformanceHTTPTransport) doRoundTrip(req *http.Request) (*http.Response, error) {
-	// Unconditionally attach tracer. We know there's only this one because
-	// above we created a pristine context for this request.
-	tracep := &httptrace.ClientTrace{
-		WroteHeaders: func() {
-			txp.Saver.Write(trace.Event{Name: "http_wrote_headers", Time: time.Now()})
-		},
-		WroteRequest: func(httptrace.WroteRequestInfo) {
-			txp.Saver.Write(trace.Event{Name: "http_wrote_request", Time: time.Now()})
-		},
-		GotFirstResponseByte: func() {
-			txp.Saver.Write(trace.Event{
-				Name: "http_first_response_byte", Time: time.Now()})
-		},
-	}
-	req = req.WithContext(httptrace.WithClientTrace(req.Context(), tracep))
 	return txp.RoundTripper.RoundTrip(req)
 }
 

--- a/netx/httptransport/saver_test.go
+++ b/netx/httptransport/saver_test.go
@@ -1,185 +1,14 @@
 package httptransport_test
 
 import (
-	"bytes"
-	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/ooni/probe-engine/netx/bytecounter"
-	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/httptransport"
 	"github.com/ooni/probe-engine/netx/trace"
 )
-
-func TestUnitSaverPerformanceHTTPTransportSuccessContext(t *testing.T) {
-	saver := &trace.Saver{}
-	txp := httptransport.SaverPerformanceHTTPTransport{
-		RoundTripper: httptransport.FakeTransport{
-			Resp: &http.Response{
-				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
-				StatusCode: 200,
-			},
-		},
-		Saver: saver,
-	}
-	req, err := http.NewRequest("GET", "https://www.google.com", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // immediately fail
-	resp, err := txp.RoundTrip(req.WithContext(ctx))
-	if !errors.Is(err, context.Canceled) {
-		t.Fatal("not the error we expected")
-	}
-	if resp != nil {
-		t.Fatal("expected nil response here")
-	}
-	ev := saver.Read()
-	if len(ev) != 0 {
-		t.Fatal("expected zero events")
-	}
-}
-
-func TestIntegrationSaverPerformanceHTTPTransportSuccess(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-	saver := &trace.Saver{}
-	txp := httptransport.SaverPerformanceHTTPTransport{
-		RoundTripper: http.DefaultTransport.(*http.Transport),
-		Saver:        saver,
-	}
-	req, err := http.NewRequest("GET", "https://www.google.com", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := txp.RoundTrip(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non nil response here")
-	}
-	ev := saver.Read()
-	if len(ev) != 3 {
-		t.Fatal("expected two events")
-	}
-	//
-	if ev[0].Name != "http_wrote_headers" {
-		t.Fatal("unexpected Name")
-	}
-	if !ev[0].Time.Before(time.Now()) {
-		t.Fatal("unexpected Time")
-	}
-	//
-	if ev[1].Name != "http_wrote_request" {
-		t.Fatal("unexpected Name")
-	}
-	if !ev[1].Time.After(ev[0].Time) {
-		t.Fatal("unexpected Time")
-	}
-	//
-	if ev[2].Name != "http_first_response_byte" {
-		t.Fatal("unexpected Name")
-	}
-	if !ev[2].Time.After(ev[1].Time) {
-		t.Fatal("unexpected Time")
-	}
-}
-
-func TestIntegrationSaverPerformanceHTTPTransportSuccessByteCounting(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-	expCounter := bytecounter.New()
-	sessCounter := bytecounter.New()
-	ctx := context.Background()
-	ctx = dialer.WithExperimentByteCounter(ctx, expCounter)
-	ctx = dialer.WithSessionByteCounter(ctx, sessCounter)
-	saver := &trace.Saver{}
-	txp := httptransport.SaverPerformanceHTTPTransport{
-		RoundTripper: httptransport.New(httptransport.Config{
-			ContextByteCounting: true,
-		}),
-		Saver: saver,
-	}
-	req, err := http.NewRequest("GET", "https://www.google.com", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := txp.RoundTrip(req.WithContext(ctx))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp == nil {
-		t.Fatal("expected non nil response here")
-	}
-	if expCounter.Received.Load() <= 0 || expCounter.Sent.Load() <= 0 {
-		t.Fatal("broken experiment counter")
-	}
-	if sessCounter.Received.Load() <= 0 || sessCounter.Received.Load() <= 0 {
-		t.Fatal("broken session counter")
-	}
-}
-
-func TestUnitSaverPerformanceHTTPTransportFailure(t *testing.T) {
-	expected := errors.New("mocked error")
-	saver := &trace.Saver{}
-	txp := httptransport.SaverPerformanceHTTPTransport{
-		RoundTripper: httptransport.FakeTransport{
-			Err: expected,
-		},
-		Saver: saver,
-	}
-	req, err := http.NewRequest("GET", "https://www.google.com", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := txp.RoundTrip(req)
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-	if resp != nil {
-		t.Fatal("expected nil response here")
-	}
-	ev := saver.Read()
-	if len(ev) != 0 {
-		t.Fatal("expected zero events")
-	}
-}
-
-func TestUnitSaverPerformanceHTTPTransportFailureContext(t *testing.T) {
-	expected := errors.New("mocked error")
-	saver := &trace.Saver{}
-	txp := httptransport.SaverPerformanceHTTPTransport{
-		RoundTripper: httptransport.FakeTransport{
-			Err: expected,
-		},
-		Saver: saver,
-	}
-	req, err := http.NewRequest("GET", "https://www.google.com", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cause immediate failure
-	resp, err := txp.RoundTrip(req.WithContext(ctx))
-	if !errors.Is(err, context.Canceled) {
-		t.Fatal("not the error we expected")
-	}
-	if resp != nil {
-		t.Fatal("expected nil response here")
-	}
-	ev := saver.Read()
-	if len(ev) != 0 {
-		t.Fatal("expected zero events")
-	}
-}
 
 func TestUnitSaverHTTPTransportFailure(t *testing.T) {
 	expected := errors.New("mocked error")
@@ -298,5 +127,51 @@ func TestIntegrationSaverHTTPTransportSuccess(t *testing.T) {
 	}
 	if !ev[1].Time.After(ev[0].Time) {
 		t.Fatal("unexpected Time")
+	}
+}
+
+func TestIntegrationSaverPerformanceNoMultipleEvents(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	saver := &trace.Saver{}
+	// register twice - do we see events twice?
+	txp := httptransport.SaverPerformanceHTTPTransport{
+		RoundTripper: http.DefaultTransport.(*http.Transport),
+		Saver:        saver,
+	}
+	txp = httptransport.SaverPerformanceHTTPTransport{
+		RoundTripper: txp,
+		Saver:        saver,
+	}
+	req, err := http.NewRequest("GET", "https://www.google.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := txp.RoundTrip(req)
+	if err != nil {
+		t.Fatal("not the error we expected")
+	}
+	if resp == nil {
+		t.Fatal("expected non nil response here")
+	}
+	ev := saver.Read()
+	// we should specifically see the events not attached to any
+	// context being submitted twice. This is fine because they are
+	// explicit, while the context is implicit and hence leads to
+	// more subtle bugs. For example, this happens when you measure
+	// every event and combine HTTP with DoH.
+	if len(ev) != 3 {
+		t.Fatal("expected three events")
+	}
+	expected := []string{
+		"http_wrote_headers",       // measured with context
+		"http_wrote_request",       // measured with context
+		"http_first_response_byte", // measured with context
+	}
+	for i := 0; i < len(expected); i++ {
+		if ev[i].Name != expected[i] {
+			t.Fatal("unexpected event name")
+		}
 	}
 }

--- a/netx/httptransport/saver_test.go
+++ b/netx/httptransport/saver_test.go
@@ -60,7 +60,7 @@ func TestIntegrationSaverPerformanceHTTPTransportSuccess(t *testing.T) {
 	}
 	resp, err := txp.RoundTrip(req)
 	if err != nil {
-		t.Fatal("not the error we expected")
+		t.Fatal(err)
 	}
 	if resp == nil {
 		t.Fatal("expected non nil response here")
@@ -114,7 +114,7 @@ func TestIntegrationSaverPerformanceHTTPTransportSuccessByteCounting(t *testing.
 	}
 	resp, err := txp.RoundTrip(req.WithContext(ctx))
 	if err != nil {
-		t.Fatal("not the error we expected")
+		t.Fatal(err)
 	}
 	if resp == nil {
 		t.Fatal("expected non nil response here")

--- a/netx/httptransport/saver_test.go
+++ b/netx/httptransport/saver_test.go
@@ -1,14 +1,185 @@
 package httptransport_test
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/ooni/probe-engine/netx/bytecounter"
+	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/httptransport"
 	"github.com/ooni/probe-engine/netx/trace"
 )
+
+func TestUnitSaverPerformanceHTTPTransportSuccessContext(t *testing.T) {
+	saver := &trace.Saver{}
+	txp := httptransport.SaverPerformanceHTTPTransport{
+		RoundTripper: httptransport.FakeTransport{
+			Resp: &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+				StatusCode: 200,
+			},
+		},
+		Saver: saver,
+	}
+	req, err := http.NewRequest("GET", "https://www.google.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately fail
+	resp, err := txp.RoundTrip(req.WithContext(ctx))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+	ev := saver.Read()
+	if len(ev) != 0 {
+		t.Fatal("expected zero events")
+	}
+}
+
+func TestIntegrationSaverPerformanceHTTPTransportSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	saver := &trace.Saver{}
+	txp := httptransport.SaverPerformanceHTTPTransport{
+		RoundTripper: http.DefaultTransport.(*http.Transport),
+		Saver:        saver,
+	}
+	req, err := http.NewRequest("GET", "https://www.google.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := txp.RoundTrip(req)
+	if err != nil {
+		t.Fatal("not the error we expected")
+	}
+	if resp == nil {
+		t.Fatal("expected non nil response here")
+	}
+	ev := saver.Read()
+	if len(ev) != 3 {
+		t.Fatal("expected two events")
+	}
+	//
+	if ev[0].Name != "http_wrote_headers" {
+		t.Fatal("unexpected Name")
+	}
+	if !ev[0].Time.Before(time.Now()) {
+		t.Fatal("unexpected Time")
+	}
+	//
+	if ev[1].Name != "http_wrote_request" {
+		t.Fatal("unexpected Name")
+	}
+	if !ev[1].Time.After(ev[0].Time) {
+		t.Fatal("unexpected Time")
+	}
+	//
+	if ev[2].Name != "http_first_response_byte" {
+		t.Fatal("unexpected Name")
+	}
+	if !ev[2].Time.After(ev[1].Time) {
+		t.Fatal("unexpected Time")
+	}
+}
+
+func TestIntegrationSaverPerformanceHTTPTransportSuccessByteCounting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	expCounter := bytecounter.New()
+	sessCounter := bytecounter.New()
+	ctx := context.Background()
+	ctx = dialer.WithExperimentByteCounter(ctx, expCounter)
+	ctx = dialer.WithSessionByteCounter(ctx, sessCounter)
+	saver := &trace.Saver{}
+	txp := httptransport.SaverPerformanceHTTPTransport{
+		RoundTripper: httptransport.New(httptransport.Config{
+			ContextByteCounting: true,
+		}),
+		Saver: saver,
+	}
+	req, err := http.NewRequest("GET", "https://www.google.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := txp.RoundTrip(req.WithContext(ctx))
+	if err != nil {
+		t.Fatal("not the error we expected")
+	}
+	if resp == nil {
+		t.Fatal("expected non nil response here")
+	}
+	if expCounter.Received.Load() <= 0 || expCounter.Sent.Load() <= 0 {
+		t.Fatal("broken experiment counter")
+	}
+	if sessCounter.Received.Load() <= 0 || sessCounter.Received.Load() <= 0 {
+		t.Fatal("broken session counter")
+	}
+}
+
+func TestUnitSaverPerformanceHTTPTransportFailure(t *testing.T) {
+	expected := errors.New("mocked error")
+	saver := &trace.Saver{}
+	txp := httptransport.SaverPerformanceHTTPTransport{
+		RoundTripper: httptransport.FakeTransport{
+			Err: expected,
+		},
+		Saver: saver,
+	}
+	req, err := http.NewRequest("GET", "https://www.google.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := txp.RoundTrip(req)
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+	ev := saver.Read()
+	if len(ev) != 0 {
+		t.Fatal("expected zero events")
+	}
+}
+
+func TestUnitSaverPerformanceHTTPTransportFailureContext(t *testing.T) {
+	expected := errors.New("mocked error")
+	saver := &trace.Saver{}
+	txp := httptransport.SaverPerformanceHTTPTransport{
+		RoundTripper: httptransport.FakeTransport{
+			Err: expected,
+		},
+		Saver: saver,
+	}
+	req, err := http.NewRequest("GET", "https://www.google.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cause immediate failure
+	resp, err := txp.RoundTrip(req.WithContext(ctx))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response here")
+	}
+	ev := saver.Read()
+	if len(ev) != 0 {
+		t.Fatal("expected zero events")
+	}
+}
 
 func TestUnitSaverHTTPTransportFailure(t *testing.T) {
 	expected := errors.New("mocked error")


### PR DESCRIPTION
In https://github.com/ooni/probe-engine/pull/556 I was optimistic. It seems
it's difficult to generate a HAR w/o using http/httptrace.

Thus, reimplement measuring using http/httptrace. This time, however, do that
in a separate round tripper, to be more tidy.

Part of https://github.com/ooni/probe-engine/issues/543