### PR TITLE
netx/httptransport: allow to configure different savers

### DIFF
--- a/experiment/dash/dash.go
+++ b/experiment/dash/dash.go
@@ -271,9 +271,9 @@ func (m measurer) Run(
 	httpClient := &http.Client{
 		Transport: httptransport.New(httptransport.Config{
 			ContextByteCounting: true,
+			DialSaver:           saver,
 			Logger:              sess.Logger(),
 			ProxyURL:            sess.ProxyURL(),
-			Saver:               saver,
 		}),
 	}
 	defer httpClient.CloseIdleConnections()


### PR DESCRIPTION
Specifically for DASH, we're only interested in saving dials.

Part of https://github.com/ooni/probe-engine/issues/543