### PR TITLE
experiment: add the new urlgetter experiment

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ooni/probe-engine/experiment/sniblocking"
 	"github.com/ooni/probe-engine/experiment/telegram"
 	"github.com/ooni/probe-engine/experiment/tor"
+	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/experiment/web_connectivity"
 	"github.com/ooni/probe-engine/experiment/whatsapp"
 	"github.com/ooni/probe-engine/internal/platform"
@@ -603,6 +604,18 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 			},
 			config:     &tor.Config{},
 			needsInput: false,
+		}
+	},
+
+	"urlgetter": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *Experiment {
+				return NewExperiment(session, urlgetter.NewExperimentMeasurer(
+					*config.(*urlgetter.Config),
+				))
+			},
+			config:     &urlgetter.Config{},
+			needsInput: true,
 		}
 	},
 

--- a/experiment/urlgetter/configurer.go
+++ b/experiment/urlgetter/configurer.go
@@ -1,0 +1,102 @@
+package urlgetter
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/httptransport"
+	"github.com/ooni/probe-engine/netx/resolver"
+	"github.com/ooni/probe-engine/netx/trace"
+)
+
+// The Configurer job is to construct a Configuration that can
+// later be used by the measurer to perform measurements.
+type Configurer struct {
+	Config   Config
+	Logger   model.Logger
+	ProxyURL *url.URL
+	Saver    *trace.Saver
+}
+
+// The Configuration is the configuration for running a measurement.
+type Configuration struct {
+	HTTPConfig        httptransport.Config
+	DNSOverHTTPClient *http.Client
+}
+
+// CloseIdleConnections will close idle connections, if needed.
+func (c Configuration) CloseIdleConnections() {
+	if c.DNSOverHTTPClient != nil {
+		c.DNSOverHTTPClient.CloseIdleConnections()
+	}
+}
+
+// NewConfiguration builds a new measurement configuration.
+func (c Configurer) NewConfiguration() (Configuration, error) {
+	// set up defaults
+	configuration := Configuration{
+		HTTPConfig: httptransport.Config{
+			BogonIsError:        c.Config.RejectDNSBogons,
+			ContextByteCounting: true,
+			DialSaver:           c.Saver,
+			HTTPSaver:           c.Saver,
+			Logger:              c.Logger,
+			ReadWriteSaver:      c.Saver,
+			ResolveSaver:        c.Saver,
+			TLSSaver:            c.Saver,
+		},
+	}
+	// configure the resolver
+	switch c.Config.ResolverURL {
+	case "doh://google":
+		c.Config.ResolverURL = "https://dns.google/dns-query"
+	case "doh://cloudflare":
+		c.Config.ResolverURL = "https://cloudflare-dns.com/dns-query"
+	case "":
+		c.Config.ResolverURL = "system:///"
+	}
+	resolverURL, err := url.Parse(c.Config.ResolverURL)
+	if err != nil {
+		return configuration, err
+	}
+	switch resolverURL.Scheme {
+	case "system":
+	case "https":
+		configuration.DNSOverHTTPClient = &http.Client{
+			Transport: httptransport.New(configuration.HTTPConfig),
+		}
+		configuration.HTTPConfig.BaseResolver = resolver.NewSerialResolver(
+			resolver.SaverDNSTransport{
+				RoundTripper: resolver.NewDNSOverHTTPS(
+					configuration.DNSOverHTTPClient, c.Config.ResolverURL,
+				),
+				Saver: c.Saver,
+			},
+		)
+	case "udp":
+		dialer := httptransport.NewDialer(configuration.HTTPConfig)
+		configuration.HTTPConfig.BaseResolver = resolver.NewSerialResolver(
+			resolver.SaverDNSTransport{
+				RoundTripper: resolver.NewDNSOverUDP(
+					dialer, resolverURL.Host,
+				),
+				Saver: c.Saver,
+			},
+		)
+	default:
+		return configuration, errors.New("unsupported resolver scheme")
+	}
+	// configure TLS
+	if c.Config.TLSServerName != "" {
+		configuration.HTTPConfig.TLSConfig = &tls.Config{
+			NextProtos: []string{"h2", "http/1.1"},
+			ServerName: c.Config.TLSServerName,
+		}
+	}
+	// configure proxy
+	configuration.HTTPConfig.ProxyURL = c.ProxyURL
+	return configuration, nil
+}

--- a/experiment/urlgetter/configurer_test.go
+++ b/experiment/urlgetter/configurer_test.go
@@ -1,0 +1,336 @@
+package urlgetter_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/netx/resolver"
+	"github.com/ooni/probe-engine/netx/trace"
+)
+
+func TestConfigurerNewConfigurationVanilla(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer configuration.CloseIdleConnections()
+	if configuration.DNSOverHTTPClient != nil {
+		t.Fatal("not the DNSOverHTTPClient we expected")
+	}
+	if configuration.HTTPConfig.BogonIsError != false {
+		t.Fatal("not the BogonIsError we expected")
+	}
+	if configuration.HTTPConfig.ContextByteCounting != true {
+		t.Fatal("not the ContextByteCounting we expected")
+	}
+	if configuration.HTTPConfig.DialSaver != saver {
+		t.Fatal("not the DialSaver we expected")
+	}
+	if configuration.HTTPConfig.HTTPSaver != saver {
+		t.Fatal("not the HTTPSaver we expected")
+	}
+	if configuration.HTTPConfig.Logger != log.Log {
+		t.Fatal("not the Logger we expected")
+	}
+	if configuration.HTTPConfig.ReadWriteSaver != saver {
+		t.Fatal("not the ReadWriteSaver we expected")
+	}
+	if configuration.HTTPConfig.ResolveSaver != saver {
+		t.Fatal("not the ResolveSaver we expected")
+	}
+	if configuration.HTTPConfig.TLSSaver != saver {
+		t.Fatal("not the TLSSaver we expected")
+	}
+	if configuration.HTTPConfig.BaseResolver != nil {
+		t.Fatal("not the BaseResolver we expected")
+	}
+	if configuration.HTTPConfig.TLSConfig != nil {
+		t.Fatal("not the TLSConfig we expected")
+	}
+	if configuration.HTTPConfig.ProxyURL != nil {
+		t.Fatal("not the ProxyURL we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationResolverDNSOverHTTPSGoogle(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			ResolverURL: "doh://google",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer configuration.CloseIdleConnections()
+	if configuration.DNSOverHTTPClient == nil {
+		t.Fatal("not the DNSOverHTTPClient we expected")
+	}
+	if configuration.HTTPConfig.BogonIsError != false {
+		t.Fatal("not the BogonIsError we expected")
+	}
+	if configuration.HTTPConfig.ContextByteCounting != true {
+		t.Fatal("not the ContextByteCounting we expected")
+	}
+	if configuration.HTTPConfig.DialSaver != saver {
+		t.Fatal("not the DialSaver we expected")
+	}
+	if configuration.HTTPConfig.HTTPSaver != saver {
+		t.Fatal("not the HTTPSaver we expected")
+	}
+	if configuration.HTTPConfig.Logger != log.Log {
+		t.Fatal("not the Logger we expected")
+	}
+	if configuration.HTTPConfig.ReadWriteSaver != saver {
+		t.Fatal("not the ReadWriteSaver we expected")
+	}
+	if configuration.HTTPConfig.ResolveSaver != saver {
+		t.Fatal("not the ResolveSaver we expected")
+	}
+	if configuration.HTTPConfig.TLSSaver != saver {
+		t.Fatal("not the TLSSaver we expected")
+	}
+	if configuration.HTTPConfig.BaseResolver == nil {
+		t.Fatal("not the BaseResolver we expected")
+	}
+	sr, ok := configuration.HTTPConfig.BaseResolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	stxp, ok := sr.Txp.(resolver.SaverDNSTransport)
+	if !ok {
+		t.Fatal("not the DNS transport we expected")
+	}
+	dohtxp, ok := stxp.RoundTripper.(resolver.DNSOverHTTPS)
+	if !ok {
+		t.Fatal("not the DNS transport we expected")
+	}
+	if dohtxp.URL != "https://dns.google/dns-query" {
+		t.Fatal("not the DoH URL we expected")
+	}
+	if configuration.HTTPConfig.TLSConfig != nil {
+		t.Fatal("not the TLSConfig we expected")
+	}
+	if configuration.HTTPConfig.ProxyURL != nil {
+		t.Fatal("not the ProxyURL we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationResolverDNSOverHTTPSCloudflare(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			ResolverURL: "doh://cloudflare",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer configuration.CloseIdleConnections()
+	if configuration.DNSOverHTTPClient == nil {
+		t.Fatal("not the DNSOverHTTPClient we expected")
+	}
+	if configuration.HTTPConfig.BogonIsError != false {
+		t.Fatal("not the BogonIsError we expected")
+	}
+	if configuration.HTTPConfig.ContextByteCounting != true {
+		t.Fatal("not the ContextByteCounting we expected")
+	}
+	if configuration.HTTPConfig.DialSaver != saver {
+		t.Fatal("not the DialSaver we expected")
+	}
+	if configuration.HTTPConfig.HTTPSaver != saver {
+		t.Fatal("not the HTTPSaver we expected")
+	}
+	if configuration.HTTPConfig.Logger != log.Log {
+		t.Fatal("not the Logger we expected")
+	}
+	if configuration.HTTPConfig.ReadWriteSaver != saver {
+		t.Fatal("not the ReadWriteSaver we expected")
+	}
+	if configuration.HTTPConfig.ResolveSaver != saver {
+		t.Fatal("not the ResolveSaver we expected")
+	}
+	if configuration.HTTPConfig.TLSSaver != saver {
+		t.Fatal("not the TLSSaver we expected")
+	}
+	if configuration.HTTPConfig.BaseResolver == nil {
+		t.Fatal("not the BaseResolver we expected")
+	}
+	sr, ok := configuration.HTTPConfig.BaseResolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	stxp, ok := sr.Txp.(resolver.SaverDNSTransport)
+	if !ok {
+		t.Fatal("not the DNS transport we expected")
+	}
+	dohtxp, ok := stxp.RoundTripper.(resolver.DNSOverHTTPS)
+	if !ok {
+		t.Fatal("not the DNS transport we expected")
+	}
+	if dohtxp.URL != "https://cloudflare-dns.com/dns-query" {
+		t.Fatal("not the DoH URL we expected")
+	}
+	if configuration.HTTPConfig.TLSConfig != nil {
+		t.Fatal("not the TLSConfig we expected")
+	}
+	if configuration.HTTPConfig.ProxyURL != nil {
+		t.Fatal("not the ProxyURL we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationResolverUDP(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			ResolverURL: "udp://8.8.8.8:53",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer configuration.CloseIdleConnections()
+	if configuration.DNSOverHTTPClient != nil {
+		t.Fatal("not the DNSOverHTTPClient we expected")
+	}
+	if configuration.HTTPConfig.BogonIsError != false {
+		t.Fatal("not the BogonIsError we expected")
+	}
+	if configuration.HTTPConfig.ContextByteCounting != true {
+		t.Fatal("not the ContextByteCounting we expected")
+	}
+	if configuration.HTTPConfig.DialSaver != saver {
+		t.Fatal("not the DialSaver we expected")
+	}
+	if configuration.HTTPConfig.HTTPSaver != saver {
+		t.Fatal("not the HTTPSaver we expected")
+	}
+	if configuration.HTTPConfig.Logger != log.Log {
+		t.Fatal("not the Logger we expected")
+	}
+	if configuration.HTTPConfig.ReadWriteSaver != saver {
+		t.Fatal("not the ReadWriteSaver we expected")
+	}
+	if configuration.HTTPConfig.ResolveSaver != saver {
+		t.Fatal("not the ResolveSaver we expected")
+	}
+	if configuration.HTTPConfig.TLSSaver != saver {
+		t.Fatal("not the TLSSaver we expected")
+	}
+	if configuration.HTTPConfig.BaseResolver == nil {
+		t.Fatal("not the BaseResolver we expected")
+	}
+	sr, ok := configuration.HTTPConfig.BaseResolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	stxp, ok := sr.Txp.(resolver.SaverDNSTransport)
+	if !ok {
+		t.Fatal("not the DNS transport we expected")
+	}
+	udptxp, ok := stxp.RoundTripper.(resolver.DNSOverUDP)
+	if !ok {
+		t.Fatal("not the DNS transport we expected")
+	}
+	if udptxp.Address() != "8.8.8.8:53" {
+		t.Fatal("not the DoH URL we expected")
+	}
+	if configuration.HTTPConfig.TLSConfig != nil {
+		t.Fatal("not the TLSConfig we expected")
+	}
+	if configuration.HTTPConfig.ProxyURL != nil {
+		t.Fatal("not the ProxyURL we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationResolverInvalidURL(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			ResolverURL: "\t",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	_, err := configurer.NewConfiguration()
+	if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationResolverInvalidURLScheme(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			ResolverURL: "antani://8.8.8.8:53",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	_, err := configurer.NewConfiguration()
+	if err == nil || !strings.HasSuffix(err.Error(), "unsupported resolver scheme") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationTLSServerName(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			TLSServerName: "www.x.org",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configuration.HTTPConfig.TLSConfig.ServerName != "www.x.org" {
+		t.Fatal("invalid ServerName")
+	}
+	if len(configuration.HTTPConfig.TLSConfig.NextProtos) != 2 {
+		t.Fatal("invalid len(NextProtos)")
+	}
+	if configuration.HTTPConfig.TLSConfig.NextProtos[0] != "h2" {
+		t.Fatal("invalid NextProtos[0]")
+	}
+	if configuration.HTTPConfig.TLSConfig.NextProtos[1] != "http/1.1" {
+		t.Fatal("invalid NextProtos[1]")
+	}
+}
+
+func TestConfigurerNewConfigurationProxyURL(t *testing.T) {
+	URL, _ := url.Parse("socks5://127.0.0.1:9050")
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Logger:   log.Log,
+		Saver:    saver,
+		ProxyURL: URL,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configuration.HTTPConfig.ProxyURL != URL {
+		t.Fatal("invalid ProxyURL")
+	}
+}

--- a/experiment/urlgetter/getter.go
+++ b/experiment/urlgetter/getter.go
@@ -1,0 +1,80 @@
+package urlgetter
+
+import (
+	"context"
+	"time"
+
+	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/archival"
+	"github.com/ooni/probe-engine/netx/trace"
+)
+
+// The Getter gets the specified target in the context of the
+// given session and with the specified config.
+//
+// Other OONI experiment should use the Getter to factor code when
+// the Getter implements the operations they wanna perform.
+type Getter struct {
+	Config  Config
+	Session model.ExperimentSession
+	Target  string
+}
+
+// Get performs the action described by g using the given context
+// and returning the test keys and eventually an error
+func (g Getter) Get(ctx context.Context) (TestKeys, error) {
+	begin := time.Now()
+	saver := new(trace.Saver)
+	tk, err := g.get(ctx, saver)
+	if err != nil {
+		tk.Failure = archival.NewFailure(err)
+	}
+	events := saver.Read()
+	tk.Queries = append(
+		tk.Queries, archival.NewDNSQueriesList(begin, events)...,
+	)
+	tk.NetworkEvents = append(
+		tk.NetworkEvents, archival.NewNetworkEventsList(begin, events)...,
+	)
+	tk.Requests = append(
+		tk.Requests, archival.NewRequestList(begin, events)...,
+	)
+	tk.TLSHandshakes = append(
+		tk.TLSHandshakes, archival.NewTLSHandshakesList(begin, events)...,
+	)
+	return tk, err
+}
+
+func (g Getter) get(ctx context.Context, saver *trace.Saver) (TestKeys, error) {
+	tk := TestKeys{Agent: "redirect", Tunnel: g.Config.Tunnel}
+	if g.Config.NoFollowRedirects {
+		tk.Agent = "agent"
+	}
+	// start tunnel
+	if err := g.Session.MaybeStartTunnel(ctx, g.Config.Tunnel); err != nil {
+		return tk, err
+	}
+	tk.BootstrapTime = g.Session.TunnelBootstrapTime().Seconds()
+	if url := g.Session.ProxyURL(); url != nil {
+		tk.SOCKSProxy = url.Host
+	}
+	// create configuration
+	configurer := Configurer{
+		Config:   g.Config,
+		Logger:   g.Session.Logger(),
+		ProxyURL: g.Session.ProxyURL(),
+		Saver:    saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		return tk, err
+	}
+	defer configuration.CloseIdleConnections()
+	// run the measurement
+	runner := Runner{
+		Config:     g.Config,
+		HTTPConfig: configuration.HTTPConfig,
+		Target:     g.Target,
+	}
+	return tk, runner.Run(ctx)
+}

--- a/experiment/urlgetter/getter_test.go
+++ b/experiment/urlgetter/getter_test.go
@@ -1,0 +1,274 @@
+package urlgetter_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/internal/mockable"
+)
+
+func TestGetterWithCancelledContextVanilla(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := urlgetter.Getter{
+		Session: &mockable.ExperimentSession{},
+		Target:  "https://www.google.com",
+	}
+	tk, err := g.Get(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if tk.Agent != "redirect" {
+		t.Fatal("not the Agent we expected")
+	}
+	if tk.BootstrapTime != 0 {
+		t.Fatal("not the BootstrapTime we expected")
+	}
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+		t.Fatal("not the Failure we expected")
+	}
+	if len(tk.NetworkEvents) != 3 {
+		t.Fatal("not the NetworkEvents we expected")
+	}
+	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
+		t.Fatal("not the NetworkEvents[0].Operation we expected")
+	}
+	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+		t.Fatal("not the NetworkEvents[1].Operation we expected")
+	}
+	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
+		t.Fatal("not the NetworkEvents[2].Operation we expected")
+	}
+	if len(tk.Queries) != 0 {
+		t.Fatal("not the Queries we expected")
+	}
+	if len(tk.Requests) != 1 {
+		t.Fatal("not the Requests we expected")
+	}
+	if tk.Requests[0].Request.Method != "GET" {
+		t.Fatal("not the Method we expected")
+	}
+	if tk.Requests[0].Request.URL != "https://www.google.com" {
+		t.Fatal("not the URL we expected")
+	}
+	if tk.SOCKSProxy != "" {
+		t.Fatal("not the SOCKSProxy we expected")
+	}
+	if len(tk.TLSHandshakes) != 0 {
+		t.Fatal("not the TLSHandshakes we expected")
+	}
+	if tk.Tunnel != "" {
+		t.Fatal("not the Tunnel we expected")
+	}
+}
+
+func TestGetterWithCancelledContextNoFollowRedirects(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := urlgetter.Getter{
+		Config: urlgetter.Config{
+			NoFollowRedirects: true,
+		},
+		Session: &mockable.ExperimentSession{},
+		Target:  "https://www.google.com",
+	}
+	tk, err := g.Get(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if tk.Agent != "agent" {
+		t.Fatal("not the Agent we expected")
+	}
+	if tk.BootstrapTime != 0 {
+		t.Fatal("not the BootstrapTime we expected")
+	}
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+		t.Fatal("not the Failure we expected")
+	}
+	if len(tk.NetworkEvents) != 3 {
+		t.Fatal("not the NetworkEvents we expected")
+	}
+	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
+		t.Fatal("not the NetworkEvents[0].Operation we expected")
+	}
+	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+		t.Fatal("not the NetworkEvents[1].Operation we expected")
+	}
+	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
+		t.Fatal("not the NetworkEvents[2].Operation we expected")
+	}
+	if len(tk.Queries) != 0 {
+		t.Fatal("not the Queries we expected")
+	}
+	if len(tk.Requests) != 1 {
+		t.Fatal("not the Requests we expected")
+	}
+	if tk.Requests[0].Request.Method != "GET" {
+		t.Fatal("not the Method we expected")
+	}
+	if tk.Requests[0].Request.URL != "https://www.google.com" {
+		t.Fatal("not the URL we expected")
+	}
+	if tk.SOCKSProxy != "" {
+		t.Fatal("not the SOCKSProxy we expected")
+	}
+	if len(tk.TLSHandshakes) != 0 {
+		t.Fatal("not the TLSHandshakes we expected")
+	}
+	if tk.Tunnel != "" {
+		t.Fatal("not the Tunnel we expected")
+	}
+}
+
+func TestGetterWithCancelledContextCannotStartTunnel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := urlgetter.Getter{
+		Session: &mockable.ExperimentSession{
+			MockableMaybeStartTunnelErr: io.EOF,
+		},
+		Target: "https://www.google.com",
+	}
+	tk, err := g.Get(ctx)
+	if !errors.Is(err, io.EOF) {
+		t.Fatal("not the error we expected")
+	}
+	if tk.Agent != "redirect" {
+		t.Fatal("not the Agent we expected")
+	}
+	if tk.BootstrapTime != 0 {
+		t.Fatal("not the BootstrapTime we expected")
+	}
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "EOF") {
+		t.Fatal("not the Failure we expected")
+	}
+	if len(tk.NetworkEvents) != 0 {
+		t.Fatal("not the NetworkEvents we expected")
+	}
+	if len(tk.Queries) != 0 {
+		t.Fatal("not the Queries we expected")
+	}
+	if len(tk.Requests) != 0 {
+		t.Fatal("not the Requests we expected")
+	}
+	if tk.SOCKSProxy != "" {
+		t.Fatal("not the SOCKSProxy we expected")
+	}
+	if len(tk.TLSHandshakes) != 0 {
+		t.Fatal("not the TLSHandshakes we expected")
+	}
+	if tk.Tunnel != "" {
+		t.Fatal("not the Tunnel we expected")
+	}
+}
+
+func TestGetterWithCancelledContextWithTunnel(t *testing.T) {
+	tunnelURL, _ := url.Parse("socks5://127.0.0.1:9050")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := urlgetter.Getter{
+		Config: urlgetter.Config{
+			Tunnel: "psiphon",
+		},
+		Session: &mockable.ExperimentSession{
+			MockableProxyURL:            tunnelURL,
+			MockableTunnelBootstrapTime: 10 * time.Second,
+		},
+		Target: "https://www.google.com",
+	}
+	tk, err := g.Get(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if tk.Agent != "redirect" {
+		t.Fatal("not the Agent we expected")
+	}
+	if tk.BootstrapTime != 10.0 {
+		t.Fatal("not the BootstrapTime we expected")
+	}
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+		t.Fatal("not the Failure we expected")
+	}
+	if len(tk.NetworkEvents) != 3 {
+		t.Fatal("not the NetworkEvents we expected")
+	}
+	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
+		t.Fatal("not the NetworkEvents[0].Operation we expected")
+	}
+	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+		t.Fatal("not the NetworkEvents[1].Operation we expected")
+	}
+	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
+		t.Fatal("not the NetworkEvents[2].Operation we expected")
+	}
+	if len(tk.Queries) != 0 {
+		t.Fatal("not the Queries we expected")
+	}
+	if len(tk.Requests) != 1 {
+		t.Fatal("not the Requests we expected")
+	}
+	if tk.Requests[0].Request.Method != "GET" {
+		t.Fatal("not the Method we expected")
+	}
+	if tk.Requests[0].Request.URL != "https://www.google.com" {
+		t.Fatal("not the URL we expected")
+	}
+	if tk.SOCKSProxy != "127.0.0.1:9050" {
+		t.Fatal("not the SOCKSProxy we expected")
+	}
+	if len(tk.TLSHandshakes) != 0 {
+		t.Fatal("not the TLSHandshakes we expected")
+	}
+	if tk.Tunnel != "psiphon" {
+		t.Fatal("not the Tunnel we expected")
+	}
+}
+
+func TestGetterWithCancelledContextUnknownResolverURL(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := urlgetter.Getter{
+		Config: urlgetter.Config{
+			ResolverURL: "antani://8.8.8.8:53",
+		},
+		Session: &mockable.ExperimentSession{},
+		Target:  "https://www.google.com",
+	}
+	tk, err := g.Get(ctx)
+	if err == nil || err.Error() != "unsupported resolver scheme" {
+		t.Fatal("not the error we expected")
+	}
+	if tk.Agent != "redirect" {
+		t.Fatal("not the Agent we expected")
+	}
+	if tk.BootstrapTime != 0 {
+		t.Fatal("not the BootstrapTime we expected")
+	}
+	if tk.Failure == nil || *tk.Failure != "unsupported resolver scheme" {
+		t.Fatal("not the Failure we expected")
+	}
+	if len(tk.NetworkEvents) != 0 {
+		t.Fatal("not the NetworkEvents we expected")
+	}
+	if len(tk.Queries) != 0 {
+		t.Fatal("not the Queries we expected")
+	}
+	if len(tk.Requests) != 0 {
+		t.Fatal("not the Requests we expected")
+	}
+	if tk.SOCKSProxy != "" {
+		t.Fatal("not the SOCKSProxy we expected")
+	}
+	if len(tk.TLSHandshakes) != 0 {
+		t.Fatal("not the TLSHandshakes we expected")
+	}
+	if tk.Tunnel != "" {
+		t.Fatal("not the Tunnel we expected")
+	}
+}

--- a/experiment/urlgetter/runner.go
+++ b/experiment/urlgetter/runner.go
@@ -1,0 +1,92 @@
+package urlgetter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/ooni/probe-engine/experiment/httpheader"
+	"github.com/ooni/probe-engine/internal/runtimex"
+	"github.com/ooni/probe-engine/netx/httptransport"
+)
+
+// The Runner job is to run a single measurement
+type Runner struct {
+	Config     Config
+	HTTPConfig httptransport.Config
+	Target     string
+}
+
+// Run runs a measurement and returns the measurement result
+func (r Runner) Run(ctx context.Context) error {
+	targetURL, err := url.Parse(r.Target)
+	if err != nil {
+		return fmt.Errorf("urlgetter: invalid target URL: %w", err)
+	}
+	switch targetURL.Scheme {
+	case "http", "https":
+		return r.httpGet(ctx, r.Target)
+	case "dnslookup":
+		return r.dnsLookup(ctx, targetURL.Hostname())
+	case "tlshandshake":
+		return r.tlsHandshake(ctx, targetURL.Host)
+	case "tcpconnect":
+		return r.tcpConnect(ctx, targetURL.Host)
+	default:
+		return errors.New("unknown targetURL scheme")
+	}
+}
+
+func (r Runner) httpGet(ctx context.Context, url string) error {
+	req, err := http.NewRequest("GET", url, nil)
+	runtimex.PanicOnError(err, "http.NewRequest failed")
+	req = req.WithContext(ctx)
+	req.Header.Set("Accept", httpheader.RandomAccept())
+	req.Header.Set("Accept-Language", httpheader.RandomAcceptLanguage())
+	req.Header.Set("User-Agent", httpheader.RandomUserAgent())
+	if r.Config.HTTPHost != "" {
+		req.Host = r.Config.HTTPHost
+	}
+	httpClient := &http.Client{Transport: httptransport.New(r.HTTPConfig)}
+	if r.Config.NoFollowRedirects {
+		httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+	defer httpClient.CloseIdleConnections()
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, err = io.Copy(ioutil.Discard, resp.Body)
+	return err
+}
+
+func (r Runner) dnsLookup(ctx context.Context, hostname string) error {
+	resolver := httptransport.NewResolver(r.HTTPConfig)
+	_, err := resolver.LookupHost(ctx, hostname)
+	return err
+}
+
+func (r Runner) tlsHandshake(ctx context.Context, address string) error {
+	tlsDialer := httptransport.NewTLSDialer(r.HTTPConfig)
+	conn, err := tlsDialer.DialTLSContext(ctx, "tcp", address)
+	if conn != nil {
+		conn.Close()
+	}
+	return err
+}
+
+func (r Runner) tcpConnect(ctx context.Context, address string) error {
+	dialer := httptransport.NewDialer(r.HTTPConfig)
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if conn != nil {
+		conn.Close()
+	}
+	return err
+}

--- a/experiment/urlgetter/runner_test.go
+++ b/experiment/urlgetter/runner_test.go
@@ -1,0 +1,160 @@
+package urlgetter_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+)
+
+func TestRunnerWithInvalidURLScheme(t *testing.T) {
+	r := urlgetter.Runner{Target: "antani://www.google.com"}
+	err := r.Run(context.Background())
+	if err == nil || err.Error() != "unknown targetURL scheme" {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestRunnerHTTPWithContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := urlgetter.Runner{Target: "https://www.google.com"}
+	err := r.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestRunnerDNSLookupWithContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := urlgetter.Runner{Target: "dnslookup://www.google.com"}
+	err := r.Run(ctx)
+	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestRunnerTLSHandshakeWithContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := urlgetter.Runner{Target: "tlshandshake://www.google.com:443"}
+	err := r.Run(ctx)
+	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestRunnerTCPConnectWithContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := urlgetter.Runner{Target: "tcpconnect://www.google.com:443"}
+	err := r.Run(ctx)
+	if err == nil || !strings.HasSuffix(err.Error(), "operation was canceled") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestRunnerWithInvalidURL(t *testing.T) {
+	r := urlgetter.Runner{Target: "\t"}
+	err := r.Run(context.Background())
+	if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestRunnerWithEmptyHostname(t *testing.T) {
+	r := urlgetter.Runner{Target: "http:///foo.txt"}
+	err := r.Run(context.Background())
+	if err == nil || !strings.HasSuffix(err.Error(), "no Host in request URL") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestIntegrationRunnerTLSHandshakeSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	r := urlgetter.Runner{Target: "tlshandshake://www.google.com:443"}
+	err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntegrationRunnerTCPConnectSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	r := urlgetter.Runner{Target: "tcpconnect://www.google.com:443"}
+	err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntegrationRunnerDNSLookupSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	r := urlgetter.Runner{Target: "dnslookup://www.google.com"}
+	err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntegrationRunnerHTTPSSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	r := urlgetter.Runner{Target: "https://www.google.com"}
+	err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunnerHTTPSetHostHeader(t *testing.T) {
+	var host string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host = r.Host
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+	r := urlgetter.Runner{
+		Config: urlgetter.Config{
+			HTTPHost: "x.org",
+		},
+		Target: server.URL,
+	}
+	err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host != "x.org" {
+		t.Fatal("not the host we expected")
+	}
+}
+
+func TestRunnerHTTPNoRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Location", "http:///") // cause failure if we redirect
+		w.WriteHeader(302)
+	}))
+	defer server.Close()
+	r := urlgetter.Runner{
+		Config: urlgetter.Config{
+			NoFollowRedirects: true,
+		},
+		Target: server.URL,
+	}
+	err := r.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -1,0 +1,78 @@
+// Package urlgetter implements a nettest that fetches a URL. This is not
+// an official OONI nettest, but rather is a probe-engine specific internal
+// experimental nettest that can be useful to do research.
+package urlgetter
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/archival"
+)
+
+const (
+	testName    = "urlgetter"
+	testVersion = "0.0.3"
+)
+
+// Config contains the experiment's configuration.
+type Config struct {
+	HTTPHost          string `ooni:"Force using specific HTTP Host header"`
+	NoFollowRedirects bool   `ooni:"Disable following redirects"`
+	RejectDNSBogons   bool   `ooni:"Fail DNS lookup if response contains bogons"`
+	ResolverURL       string `ooni:"URL describing the resolver to use"`
+	TLSServerName     string `ooni:"Force TLS to using a specific SNI in Client Hello"`
+	Tunnel            string `ooni:"Run experiment over a tunnel, e.g. psiphon"`
+}
+
+// TestKeys contains the experiment's result.
+type TestKeys struct {
+	Agent         string                   `json:"agent"`
+	BootstrapTime float64                  `json:"bootstrap_time,omitempty"`
+	Failure       *string                  `json:"failure"`
+	NetworkEvents []archival.NetworkEvent  `json:"network_events"`
+	Queries       []archival.DNSQueryEntry `json:"queries"`
+	Requests      []archival.RequestEntry  `json:"requests"`
+	SOCKSProxy    string                   `json:"socksproxy,omitempty"`
+	TLSHandshakes []archival.TLSHandshake  `json:"tls_handshakes"`
+	Tunnel        string                   `json:"tunnel,omitempty"`
+}
+
+func registerExtensions(m *model.Measurement) {
+	archival.ExtHTTP.AddTo(m)
+	archival.ExtDNS.AddTo(m)
+	archival.ExtNetevents.AddTo(m)
+	archival.ExtTLSHandshake.AddTo(m)
+}
+
+type measurer struct {
+	Config
+}
+
+func (m measurer) ExperimentName() string {
+	return testName
+}
+
+func (m measurer) ExperimentVersion() string {
+	return testVersion
+}
+
+func (m measurer) Run(
+	ctx context.Context, sess model.ExperimentSession,
+	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
+) error {
+	registerExtensions(measurement)
+	g := Getter{
+		Config:  m.Config,
+		Session: sess,
+		Target:  string(measurement.Input),
+	}
+	tk, err := g.Get(ctx)
+	measurement.TestKeys = tk
+	return err
+}
+
+// NewExperimentMeasurer creates a new ExperimentMeasurer.
+func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
+	return measurer{Config: config}
+}

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -1,0 +1,37 @@
+package urlgetter_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/experiment/handler"
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/internal/mockable"
+	"github.com/ooni/probe-engine/model"
+)
+
+func TestMeasurer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := urlgetter.NewExperimentMeasurer(urlgetter.Config{})
+	if m.ExperimentName() != "urlgetter" {
+		t.Fatal("invalid experiment name")
+	}
+	if m.ExperimentVersion() != "0.0.3" {
+		t.Fatal("invalid experiment version")
+	}
+	measurement := new(model.Measurement)
+	measurement.Input = "https://www.google.com"
+	err := m.Run(
+		ctx, &mockable.ExperimentSession{},
+		measurement, handler.NewPrinterCallbacks(log.Log),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if len(measurement.Extensions) != 4 {
+		t.Fatal("not the expected number of extensions")
+	}
+}


### PR DESCRIPTION
This is the basic building block on which to rewrite most other OONI
experiments. It handles different kind of URLs, leading to performing
HTTP requests, TCP connects, TLS handshakes, etc.

Part of https://github.com/ooni/probe-engine/issues/543