### PR TITLE
netx: reduce toplevel HTTP errors to OONI failures

### DIFF
--- a/experiment/urlgetter/getter_test.go
+++ b/experiment/urlgetter/getter_test.go
@@ -250,7 +250,7 @@ func TestGetterWithCancelledContextUnknownResolverURL(t *testing.T) {
 	if tk.BootstrapTime != 0 {
 		t.Fatal("not the BootstrapTime we expected")
 	}
-	if tk.Failure == nil || *tk.Failure != "unsupported resolver scheme" {
+	if tk.Failure == nil || *tk.Failure != "unknown_failure: unsupported resolver scheme" {
 		t.Fatal("not the Failure we expected")
 	}
 	if len(tk.NetworkEvents) != 0 {

--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -16,6 +17,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/internal/errwrapper"
+	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -92,12 +95,20 @@ func NewTCPConnectList(begin time.Time, events []trace.Event) []TCPConnectEntry 
 }
 
 // NewFailure creates a failure nullable string from the given error
-func NewFailure(err error) (s *string) {
-	if err != nil {
-		serio := err.Error()
-		s = &serio
+func NewFailure(err error) *string {
+	if err == nil {
+		return nil
 	}
-	return
+	var errWrapper *modelx.ErrWrapper
+	if errors.As(err, &errWrapper) {
+		s := errWrapper.Failure
+		if s == "" {
+			s = "unknown_failure: errWrapper.Failure is empty"
+		}
+		return &s
+	}
+	s := fmt.Sprintf("unknown_failure: %s", errwrapper.Scrub(err.Error()))
+	return &s
 }
 
 // HTTPTor contains Tor information

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -3,6 +3,7 @@ package archival_test
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"io"
 	"net/http"
 	"reflect"
@@ -13,6 +14,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
+	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -768,6 +770,72 @@ func TestHTTPHeader_UnmarshalJSON(t *testing.T) {
 			}
 			if d := cmp.Diff(hh, expect); d != "" {
 				t.Error(d)
+			}
+		})
+	}
+}
+
+func TestNewFailure(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want *string
+	}{{
+		name: "when error is nil",
+		args: args{
+			err: nil,
+		},
+		want: nil,
+	}, {
+		name: "when error is wrapped and failure meaningful",
+		args: args{
+			err: &modelx.ErrWrapper{
+				Failure: modelx.FailureConnectionRefused,
+			},
+		},
+		want: func() *string {
+			s := modelx.FailureConnectionRefused
+			return &s
+		}(),
+	}, {
+		name: "when error is wrapped and failure is notmeaningful",
+		args: args{
+			err: &modelx.ErrWrapper{},
+		},
+		want: func() *string {
+			s := "unknown_failure: errWrapper.Failure is empty"
+			return &s
+		}(),
+	}, {
+		name: "otherwise",
+		args: args{
+			err: errors.New("use of closed socket 127.0.0.1:8080->10.0.0.1:22"),
+		},
+		want: func() *string {
+			s := "unknown_failure: use of closed socket [scrubbed]->[scrubbed]"
+			return &s
+		}(),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := archival.NewFailure(tt.args.err)
+			if tt.want == nil && got == nil {
+				return
+			}
+			if tt.want == nil && got != nil {
+				t.Errorf("NewFailure:  want %+v, got %s", tt.want, *got)
+				return
+			}
+			if tt.want != nil && got == nil {
+				t.Errorf("NewFailure:  want %s, got %+v", *tt.want, got)
+				return
+			}
+			if *tt.want != *got {
+				t.Errorf("NewFailure:  want %s, got %s", *tt.want, *got)
+				return
 			}
 		})
 	}

--- a/netx/internal/errwrapper/errwrapper.go
+++ b/netx/internal/errwrapper/errwrapper.go
@@ -102,7 +102,7 @@ func toFailureString(err error) string {
 	}
 
 	formatted := fmt.Sprintf("unknown_failure: %s", s)
-	return scrubs(formatted) // scrub IP addresses in the error
+	return Scrub(formatted) // scrub IP addresses in the error
 }
 
 func toOperationString(err error, operation string) string {

--- a/netx/internal/errwrapper/sanitizer.go
+++ b/netx/internal/errwrapper/sanitizer.go
@@ -63,6 +63,8 @@ func scrub(b []byte) []byte {
 	return scrubbedBytes
 }
 
-func scrubs(s string) string {
+// Scrub sanitizes a string containing an error such that
+// any occurrence of IP endpoints is scrubbed
+func Scrub(s string) string {
 	return string(scrub([]byte(s)))
 }

--- a/netx/internal/errwrapper/sanitizer_test.go
+++ b/netx/internal/errwrapper/sanitizer_test.go
@@ -68,7 +68,7 @@ func TestLogScrubberMessages(t *testing.T) {
 			"2019/05/08 15:37:31 starting",
 		},
 	} {
-		if scrubs(test.input) != test.expected {
+		if Scrub(test.input) != test.expected {
 			t.Error(cmp.Diff(test.input, test.expected))
 		}
 	}
@@ -122,7 +122,7 @@ func TestLogScrubberGoodFormats(t *testing.T) {
 		"[::ffff:0:255.255.255.255]",
 		"[2001:db8:3:4::192.0.2.33]",
 	} {
-		if scrubs(addr) != "[scrubbed]" {
+		if Scrub(addr) != "[scrubbed]" {
 			t.Error(cmp.Diff(addr, "[scrubbed]"))
 		}
 	}


### PR DESCRIPTION
This is related to https://github.com/ooni/probe-engine/issues/290, which is
not done, because we're still using old netx in some places.

Part of https://github.com/ooni/probe-engine/issues/543