### PR TITLE
netx, experiment/urlgetter: allow to disable TLS verify

### DIFF
--- a/experiment/urlgetter/configurer.go
+++ b/experiment/urlgetter/configurer.go
@@ -96,6 +96,7 @@ func (c Configurer) NewConfiguration() (Configuration, error) {
 			ServerName: c.Config.TLSServerName,
 		}
 	}
+	configuration.HTTPConfig.NoTLSVerify = c.Config.NoTLSVerify
 	// configure proxy
 	configuration.HTTPConfig.ProxyURL = c.ProxyURL
 	return configuration, nil

--- a/experiment/urlgetter/configurer_test.go
+++ b/experiment/urlgetter/configurer_test.go
@@ -55,6 +55,9 @@ func TestConfigurerNewConfigurationVanilla(t *testing.T) {
 	if configuration.HTTPConfig.TLSConfig != nil {
 		t.Fatal("not the TLSConfig we expected")
 	}
+	if configuration.HTTPConfig.NoTLSVerify == true {
+		t.Fatal("not the NoTLSVerify we expected")
+	}
 	if configuration.HTTPConfig.ProxyURL != nil {
 		t.Fatal("not the ProxyURL we expected")
 	}
@@ -121,6 +124,9 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSGoogle(t *testing.T) {
 	}
 	if configuration.HTTPConfig.TLSConfig != nil {
 		t.Fatal("not the TLSConfig we expected")
+	}
+	if configuration.HTTPConfig.NoTLSVerify == true {
+		t.Fatal("not the NoTLSVerify we expected")
 	}
 	if configuration.HTTPConfig.ProxyURL != nil {
 		t.Fatal("not the ProxyURL we expected")
@@ -189,6 +195,9 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSCloudflare(t *testing.T) 
 	if configuration.HTTPConfig.TLSConfig != nil {
 		t.Fatal("not the TLSConfig we expected")
 	}
+	if configuration.HTTPConfig.NoTLSVerify == true {
+		t.Fatal("not the NoTLSVerify we expected")
+	}
 	if configuration.HTTPConfig.ProxyURL != nil {
 		t.Fatal("not the ProxyURL we expected")
 	}
@@ -256,6 +265,9 @@ func TestConfigurerNewConfigurationResolverUDP(t *testing.T) {
 	if configuration.HTTPConfig.TLSConfig != nil {
 		t.Fatal("not the TLSConfig we expected")
 	}
+	if configuration.HTTPConfig.NoTLSVerify == true {
+		t.Fatal("not the NoTLSVerify we expected")
+	}
 	if configuration.HTTPConfig.ProxyURL != nil {
 		t.Fatal("not the ProxyURL we expected")
 	}
@@ -315,6 +327,24 @@ func TestConfigurerNewConfigurationTLSServerName(t *testing.T) {
 	}
 	if configuration.HTTPConfig.TLSConfig.NextProtos[1] != "http/1.1" {
 		t.Fatal("invalid NextProtos[1]")
+	}
+}
+
+func TestConfigurerNewConfigurationNoTLSVerify(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			NoTLSVerify: true,
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configuration.HTTPConfig.NoTLSVerify != true {
+		t.Fatal("not the NoTLSVerify we expected")
 	}
 }
 

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -19,6 +19,7 @@ const (
 type Config struct {
 	HTTPHost          string `ooni:"Force using specific HTTP Host header"`
 	NoFollowRedirects bool   `ooni:"Disable following redirects"`
+	NoTLSVerify       bool   `ooni:"Disable TLS verification"`
 	RejectDNSBogons   bool   `ooni:"Fail DNS lookup if response contains bogons"`
 	ResolverURL       string `ooni:"URL describing the resolver to use"`
 	TLSServerName     string `ooni:"Force TLS to using a specific SNI in Client Hello"`

--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -471,6 +471,7 @@ type TLSHandshake struct {
 	ConnID             int64              `json:"conn_id,omitempty"`
 	Failure            *string            `json:"failure"`
 	NegotiatedProtocol string             `json:"negotiated_protocol"`
+	NoTLSVerify        bool               `json:"no_tls_verify"`
 	PeerCertificates   []MaybeBinaryValue `json:"peer_certificates"`
 	T                  float64            `json:"t"`
 	TLSVersion         string             `json:"tls_version"`
@@ -488,6 +489,7 @@ func NewTLSHandshakesList(begin time.Time, events []trace.Event) []TLSHandshake 
 			CipherSuite:        ev.TLSCipherSuite,
 			Failure:            NewFailure(ev.Err),
 			NegotiatedProtocol: ev.TLSNegotiatedProto,
+			NoTLSVerify:        ev.NoTLSVerify,
 			PeerCertificates:   makePeerCerts(ev.TLSPeerCerts),
 			T:                  ev.Time.Sub(begin).Seconds(),
 			TLSVersion:         ev.TLSVersion,

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -396,6 +396,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 			}, {
 				Name:               "tls_handshake_done",
 				Err:                io.EOF,
+				NoTLSVerify:        false,
 				TLSCipherSuite:     "SUITE",
 				TLSNegotiatedProto: "h2",
 				TLSPeerCerts: []*x509.Certificate{{
@@ -411,6 +412,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 			CipherSuite:        "SUITE",
 			Failure:            archival.NewFailure(io.EOF),
 			NegotiatedProtocol: "h2",
+			NoTLSVerify:        false,
 			PeerCertificates: []archival.MaybeBinaryValue{{
 				Value: "deadbeef",
 			}, {

--- a/netx/dialer/saver.go
+++ b/netx/dialer/saver.go
@@ -47,6 +47,7 @@ func (h SaverTLSHandshaker) Handshake(
 	start := time.Now()
 	h.Saver.Write(trace.Event{
 		Name:          "tls_handshake_start",
+		NoTLSVerify:   config.InsecureSkipVerify,
 		TLSNextProtos: config.NextProtos,
 		TLSServerName: config.ServerName,
 		Time:          start,
@@ -57,6 +58,7 @@ func (h SaverTLSHandshaker) Handshake(
 		Duration:           stop.Sub(start),
 		Err:                err,
 		Name:               "tls_handshake_done",
+		NoTLSVerify:        config.InsecureSkipVerify,
 		TLSCipherSuite:     tlsx.CipherSuiteString(state.CipherSuite),
 		TLSNegotiatedProto: state.NegotiatedProtocol,
 		TLSNextProtos:      config.NextProtos,

--- a/netx/httptransport/httptransport.go
+++ b/netx/httptransport/httptransport.go
@@ -51,6 +51,7 @@ type Config struct {
 	FullResolver        Resolver             // default: base resolver + goodies
 	HTTPSaver           *trace.Saver         // default: not saving HTTP
 	Logger              Logger               // default: no logging
+	NoTLSVerify         bool                 // default: perform TLS verify
 	ProxyURL            *url.URL             // default: no proxy
 	ReadWriteSaver      *trace.Saver         // default: not saving read/write
 	ResolveSaver        *trace.Saver         // default: not saving resolves
@@ -128,6 +129,7 @@ func NewTLSDialer(config Config) TLSDialer {
 	if config.TLSConfig == nil {
 		config.TLSConfig = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
 	}
+	config.TLSConfig.InsecureSkipVerify = config.NoTLSVerify
 	return dialer.TLSDialer{
 		Config:        config.TLSConfig,
 		Dialer:        config.Dialer,

--- a/netx/httptransport/httptransport_test.go
+++ b/netx/httptransport/httptransport_test.go
@@ -507,6 +507,82 @@ func TestNewTLSDialerWithSaver(t *testing.T) {
 	}
 }
 
+func TestNewTLSDialerWithNoTLSVerifyAndConfig(t *testing.T) {
+	td := httptransport.NewTLSDialer(httptransport.Config{
+		TLSConfig:   new(tls.Config),
+		NoTLSVerify: true,
+	})
+	rtd, ok := td.(dialer.TLSDialer)
+	if !ok {
+		t.Fatal("not the TLSDialer we expected")
+	}
+	if len(rtd.Config.NextProtos) != 0 {
+		t.Fatal("invalid len(config.NextProtos)")
+	}
+	if rtd.Config.InsecureSkipVerify != true {
+		t.Fatal("expected true InsecureSkipVerify")
+	}
+	if rtd.Dialer == nil {
+		t.Fatal("invalid Dialer")
+	}
+	if _, ok := rtd.Dialer.(dialer.ProxyDialer); !ok {
+		t.Fatal("not the Dialer we expected")
+	}
+	if rtd.TLSHandshaker == nil {
+		t.Fatal("invalid TLSHandshaker")
+	}
+	ewth, ok := rtd.TLSHandshaker.(dialer.ErrorWrapperTLSHandshaker)
+	if !ok {
+		t.Fatal("not the TLSHandshaker we expected")
+	}
+	tth, ok := ewth.TLSHandshaker.(dialer.TimeoutTLSHandshaker)
+	if !ok {
+		t.Fatal("not the TLSHandshaker we expected")
+	}
+	if _, ok := tth.TLSHandshaker.(dialer.SystemTLSHandshaker); !ok {
+		t.Fatal("not the TLSHandshaker we expected")
+	}
+}
+
+func TestNewTLSDialerWithNoTLSVerifyAndNoConfig(t *testing.T) {
+	td := httptransport.NewTLSDialer(httptransport.Config{
+		NoTLSVerify: true,
+	})
+	rtd, ok := td.(dialer.TLSDialer)
+	if !ok {
+		t.Fatal("not the TLSDialer we expected")
+	}
+	if len(rtd.Config.NextProtos) != 2 {
+		t.Fatal("invalid len(config.NextProtos)")
+	}
+	if rtd.Config.NextProtos[0] != "h2" || rtd.Config.NextProtos[1] != "http/1.1" {
+		t.Fatal("invalid Config.NextProtos")
+	}
+	if rtd.Config.InsecureSkipVerify != true {
+		t.Fatal("expected true InsecureSkipVerify")
+	}
+	if rtd.Dialer == nil {
+		t.Fatal("invalid Dialer")
+	}
+	if _, ok := rtd.Dialer.(dialer.ProxyDialer); !ok {
+		t.Fatal("not the Dialer we expected")
+	}
+	if rtd.TLSHandshaker == nil {
+		t.Fatal("invalid TLSHandshaker")
+	}
+	ewth, ok := rtd.TLSHandshaker.(dialer.ErrorWrapperTLSHandshaker)
+	if !ok {
+		t.Fatal("not the TLSHandshaker we expected")
+	}
+	tth, ok := ewth.TLSHandshaker.(dialer.TimeoutTLSHandshaker)
+	if !ok {
+		t.Fatal("not the TLSHandshaker we expected")
+	}
+	if _, ok := tth.TLSHandshaker.(dialer.SystemTLSHandshaker); !ok {
+		t.Fatal("not the TLSHandshaker we expected")
+	}
+}
+
 func TestNewVanilla(t *testing.T) {
 	txp := httptransport.New(httptransport.Config{})
 	uatxp, ok := txp.(httptransport.UserAgentTransport)

--- a/netx/trace/event.go
+++ b/netx/trace/event.go
@@ -22,6 +22,7 @@ type Event struct {
 	HTTPURL            string              `json:",omitempty"`
 	Hostname           string              `json:",omitempty"`
 	Name               string              `json:",omitempty"`
+	NoTLSVerify        bool                `json:",omitempty"`
 	NumBytes           int                 `json:",omitempty"`
 	Proto              string              `json:",omitempty"`
 	TLSServerName      string              `json:",omitempty"`


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/543