### PR TITLE
netx, experiment: implement prefilled DNS cache

### DIFF
--- a/experiment/urlgetter/configurer_test.go
+++ b/experiment/urlgetter/configurer_test.go
@@ -28,6 +28,9 @@ func TestConfigurerNewConfigurationVanilla(t *testing.T) {
 	if configuration.HTTPConfig.BogonIsError != false {
 		t.Fatal("not the BogonIsError we expected")
 	}
+	if configuration.HTTPConfig.CacheResolutions != true {
+		t.Fatal("not the CacheResolutions we expected")
+	}
 	if configuration.HTTPConfig.ContextByteCounting != true {
 		t.Fatal("not the ContextByteCounting we expected")
 	}
@@ -79,6 +82,9 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSGoogle(t *testing.T) {
 	}
 	if configuration.HTTPConfig.BogonIsError != false {
 		t.Fatal("not the BogonIsError we expected")
+	}
+	if configuration.HTTPConfig.CacheResolutions != true {
+		t.Fatal("not the CacheResolutions we expected")
 	}
 	if configuration.HTTPConfig.ContextByteCounting != true {
 		t.Fatal("not the ContextByteCounting we expected")
@@ -147,6 +153,9 @@ func TestConfigurerNewConfigurationResolverDNSOverHTTPSCloudflare(t *testing.T) 
 	if configuration.HTTPConfig.BogonIsError != false {
 		t.Fatal("not the BogonIsError we expected")
 	}
+	if configuration.HTTPConfig.CacheResolutions != true {
+		t.Fatal("not the CacheResolutions we expected")
+	}
 	if configuration.HTTPConfig.ContextByteCounting != true {
 		t.Fatal("not the ContextByteCounting we expected")
 	}
@@ -214,6 +223,9 @@ func TestConfigurerNewConfigurationResolverUDP(t *testing.T) {
 	if configuration.HTTPConfig.BogonIsError != false {
 		t.Fatal("not the BogonIsError we expected")
 	}
+	if configuration.HTTPConfig.CacheResolutions != true {
+		t.Fatal("not the CacheResolutions we expected")
+	}
 	if configuration.HTTPConfig.ContextByteCounting != true {
 		t.Fatal("not the ContextByteCounting we expected")
 	}
@@ -258,6 +270,75 @@ func TestConfigurerNewConfigurationResolverUDP(t *testing.T) {
 	}
 	if configuration.HTTPConfig.ProxyURL != nil {
 		t.Fatal("not the ProxyURL we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationDNSCacheInvalidString(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			DNSCache: "a b c",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	_, err := configurer.NewConfiguration()
+	if err == nil || !strings.HasSuffix(err.Error(), "invalid DNSCache string") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationDNSCacheNotIP(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			DNSCache: "a b",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	_, err := configurer.NewConfiguration()
+	if err == nil || !strings.HasSuffix(err.Error(), "invalid IP in DNSCache") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationDNSCacheNotDomain(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			DNSCache: "127.0.0.1 b",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	_, err := configurer.NewConfiguration()
+	if err == nil || !strings.HasSuffix(err.Error(), "invalid domain in DNSCache") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestConfigurerNewConfigurationDNSCacheGood(t *testing.T) {
+	saver := new(trace.Saver)
+	configurer := urlgetter.Configurer{
+		Config: urlgetter.Config{
+			DNSCache: "127.0.0.1 google.com",
+		},
+		Logger: log.Log,
+		Saver:  saver,
+	}
+	configuration, err := configurer.NewConfiguration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configuration.HTTPConfig.DNSCache) != 1 {
+		t.Fatal("invalid number of entries in DNSCache")
+	}
+	if len(configuration.HTTPConfig.DNSCache["google.com"]) != 1 {
+		t.Fatal("invalid number of IPs saved in DNSCache")
+	}
+	if configuration.HTTPConfig.DNSCache["google.com"][0] != "127.0.0.1" {
+		t.Fatal("invalid IPs saved in DNSCache")
 	}
 }
 

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -17,6 +17,7 @@ const (
 
 // Config contains the experiment's configuration.
 type Config struct {
+	DNSCache          string `ooni:"Add 'IP DOMAIN' to cache"`
 	HTTPHost          string `ooni:"Force using specific HTTP Host header"`
 	NoFollowRedirects bool   `ooni:"Disable following redirects"`
 	RejectDNSBogons   bool   `ooni:"Fail DNS lookup if response contains bogons"`

--- a/netx/httptransport/httptransport_test.go
+++ b/netx/httptransport/httptransport_test.go
@@ -104,13 +104,42 @@ func TestNewResolverWithSaver(t *testing.T) {
 	}
 }
 
-func TestNewResolverWithCache(t *testing.T) {
+func TestNewResolverWithReadWriteCache(t *testing.T) {
 	r := httptransport.NewResolver(httptransport.Config{
 		CacheResolutions: true,
 	})
 	cr, ok := r.(*resolver.CacheResolver)
 	if !ok {
 		t.Fatal("not the resolver we expected")
+	}
+	if cr.ReadOnly != false {
+		t.Fatal("expected readwrite cache here")
+	}
+	ewr, ok := cr.Resolver.(resolver.ErrorWrapperResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	_, ok = ewr.Resolver.(resolver.SystemResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+}
+
+func TestNewResolverWithPrefilledReadonlyCache(t *testing.T) {
+	r := httptransport.NewResolver(httptransport.Config{
+		DNSCache: map[string][]string{
+			"dns.google.com": {"8.8.8.8"},
+		},
+	})
+	cr, ok := r.(*resolver.CacheResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	if cr.ReadOnly != true {
+		t.Fatal("expected readonly cache here")
+	}
+	if cr.Get("dns.google.com")[0] != "8.8.8.8" {
+		t.Fatal("cache not correctly prefilled")
 	}
 	ewr, ok := cr.Resolver.(resolver.ErrorWrapperResolver)
 	if !ok {

--- a/netx/resolver/cache.go
+++ b/netx/resolver/cache.go
@@ -7,6 +7,7 @@ import (
 
 // CacheResolver is a resolver that caches successful replies.
 type CacheResolver struct {
+	ReadOnly bool
 	Resolver
 	mu    sync.Mutex
 	cache map[string][]string
@@ -22,7 +23,9 @@ func (r *CacheResolver) LookupHost(
 	if err != nil {
 		return nil, err
 	}
-	r.Set(hostname, entry)
+	if r.ReadOnly == false {
+		r.Set(hostname, entry)
+	}
 	return entry, nil
 }
 

--- a/netx/resolver/cache_test.go
+++ b/netx/resolver/cache_test.go
@@ -13,13 +13,16 @@ func TestUnitCacheFailure(t *testing.T) {
 	var r resolver.Resolver = resolver.FakeResolver{
 		Err: expected,
 	}
-	r = &resolver.CacheResolver{Resolver: r}
-	addrs, err := r.LookupHost(context.Background(), "www.google.com")
+	cache := &resolver.CacheResolver{Resolver: r}
+	addrs, err := cache.LookupHost(context.Background(), "www.google.com")
 	if !errors.Is(err, expected) {
 		t.Fatal("not the error we expected")
 	}
 	if addrs != nil {
 		t.Fatal("expected nil addrs here")
+	}
+	if cache.Get("www.google.com") != nil {
+		t.Fatal("expected empty cache here")
 	}
 }
 
@@ -42,12 +45,32 @@ func TestUnitCacheMissSuccess(t *testing.T) {
 	var r resolver.Resolver = resolver.FakeResolver{
 		Result: []string{"8.8.8.8"},
 	}
-	r = &resolver.CacheResolver{Resolver: r}
-	addrs, err := r.LookupHost(context.Background(), "dns.google.com")
+	cache := &resolver.CacheResolver{Resolver: r}
+	addrs, err := cache.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(addrs) != 1 || addrs[0] != "8.8.8.8" {
 		t.Fatal("not the result we expected")
+	}
+	if cache.Get("dns.google.com")[0] != "8.8.8.8" {
+		t.Fatal("expected full cache here")
+	}
+}
+
+func TestUnitCacheReadonlySuccess(t *testing.T) {
+	var r resolver.Resolver = resolver.FakeResolver{
+		Result: []string{"8.8.8.8"},
+	}
+	cache := &resolver.CacheResolver{Resolver: r, ReadOnly: true}
+	addrs, err := cache.LookupHost(context.Background(), "dns.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 1 || addrs[0] != "8.8.8.8" {
+		t.Fatal("not the result we expected")
+	}
+	if cache.Get("dns.google.com") != nil {
+		t.Fatal("expected empty cache here")
 	}
 }


### PR DESCRIPTION
Seems to be required when running HTTP experiments where we have
previously already resolved the domain(s) we need.

Part of https://github.com/ooni/probe-engine/issues/543