### PR TITLE
experiment/urlgetter: include DNSCache in TestKeys

### DIFF
--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -31,6 +31,7 @@ type Config struct {
 type TestKeys struct {
 	Agent         string                   `json:"agent"`
 	BootstrapTime float64                  `json:"bootstrap_time,omitempty"`
+	DNSCache      []string                 `json:"dns_cache,omitempty"`
 	Failure       *string                  `json:"failure"`
 	NetworkEvents []archival.NetworkEvent  `json:"network_events"`
 	Queries       []archival.DNSQueryEntry `json:"queries"`
@@ -70,6 +71,7 @@ func (m measurer) Run(
 		Target:  string(measurement.Input),
 	}
 	tk, err := g.Get(ctx)
+	tk.DNSCache = []string{m.Config.DNSCache}
 	measurement.TestKeys = tk
 	return err
 }

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -35,3 +35,33 @@ func TestMeasurer(t *testing.T) {
 		t.Fatal("not the expected number of extensions")
 	}
 }
+
+func TestMeasurerDNSCache(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := urlgetter.NewExperimentMeasurer(urlgetter.Config{
+		DNSCache: "dns.google 8.8.8.8 8.8.4.4",
+	})
+	if m.ExperimentName() != "urlgetter" {
+		t.Fatal("invalid experiment name")
+	}
+	if m.ExperimentVersion() != "0.0.3" {
+		t.Fatal("invalid experiment version")
+	}
+	measurement := new(model.Measurement)
+	measurement.Input = "https://www.google.com"
+	err := m.Run(
+		ctx, &mockable.ExperimentSession{},
+		measurement, handler.NewPrinterCallbacks(log.Log),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if len(measurement.Extensions) != 4 {
+		t.Fatal("not the expected number of extensions")
+	}
+	tk := measurement.TestKeys.(urlgetter.TestKeys)
+	if len(tk.DNSCache) != 1 || tk.DNSCache[0] != "dns.google 8.8.8.8 8.8.4.4" {
+		t.Fatal("invalid tk.DNSCache")
+	}
+}


### PR DESCRIPTION
This simplifies analysing the measurement JSON.

Part of https://github.com/ooni/probe-engine/issues/543