### PR TITLE
fix(netx/archival): include TLS server name

### DIFF
--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -473,6 +473,7 @@ type TLSHandshake struct {
 	NegotiatedProtocol string             `json:"negotiated_protocol"`
 	NoTLSVerify        bool               `json:"no_tls_verify"`
 	PeerCertificates   []MaybeBinaryValue `json:"peer_certificates"`
+	ServerName         string             `json:"server_name"`
 	T                  float64            `json:"t"`
 	TLSVersion         string             `json:"tls_version"`
 	TransactionID      int64              `json:"transaction_id,omitempty"`
@@ -491,6 +492,7 @@ func NewTLSHandshakesList(begin time.Time, events []trace.Event) []TLSHandshake 
 			NegotiatedProtocol: ev.TLSNegotiatedProto,
 			NoTLSVerify:        ev.NoTLSVerify,
 			PeerCertificates:   makePeerCerts(ev.TLSPeerCerts),
+			ServerName:         ev.TLSServerName,
 			T:                  ev.Time.Sub(begin).Seconds(),
 			TLSVersion:         ev.TLSVersion,
 		})

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -404,8 +404,9 @@ func TestNewTLSHandshakesList(t *testing.T) {
 				}, {
 					Raw: []byte("abad1dea"),
 				}},
-				TLSVersion: "TLSv1.3",
-				Time:       begin.Add(55 * time.Millisecond),
+				TLSServerName: "x.org",
+				TLSVersion:    "TLSv1.3",
+				Time:          begin.Add(55 * time.Millisecond),
 			}},
 		},
 		want: []archival.TLSHandshake{{
@@ -418,6 +419,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 			}, {
 				Value: "abad1dea",
 			}},
+			ServerName: "x.org",
 			T:          0.055,
 			TLSVersion: "TLSv1.3",
 		}},


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/547