### PR TITLE
psiphon: collect performance metrics from arbitrary URLs

### DIFF
--- a/experiment/psiphon/psiphon.go
+++ b/experiment/psiphon/psiphon.go
@@ -4,191 +4,48 @@
 // See https://github.com/ooni/spec/blob/master/nettests/ts-015-psiphon.md
 package psiphon
 
-// TODO(bassosimone): rewrite in terms of internal/psiphonx.
-
 import (
 	"context"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
-	"github.com/Psiphon-Labs/psiphon-tunnel-core/ClientLibrary/clientlib"
-	"github.com/ooni/probe-engine/internal/httpheader"
-	"github.com/ooni/probe-engine/internal/netxlogger"
-	"github.com/ooni/probe-engine/internal/oonidatamodel"
-	"github.com/ooni/probe-engine/internal/oonitemplates"
+	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/model"
 )
 
 const (
 	testName    = "psiphon"
-	testVersion = "0.3.2"
+	testVersion = "0.4.0"
 )
 
 // Config contains the experiment's configuration.
 type Config struct {
-	// WorkDir is the directory where Psiphon should store
-	// its configuration database.
-	WorkDir string `ooni:"experiment working directory"`
+	urlgetter.Config
 }
 
 // TestKeys contains the experiment's result.
-//
-// This is what will end up into the Measurement.TestKeys field
-// when you run this experiment.
 type TestKeys struct {
-	Agent         string                          `json:"agent"`
-	BootstrapTime float64                         `json:"bootstrap_time"`
-	Failure       *string                         `json:"failure"`
-	MaxRuntime    float64                         `json:"max_runtime"`
-	Queries       oonidatamodel.DNSQueriesList    `json:"queries"`
-	Requests      oonidatamodel.RequestList       `json:"requests"`
-	SOCKSProxy    string                          `json:"socksproxy"`
-	TLSHandshakes oonidatamodel.TLSHandshakesList `json:"tls_handshakes"`
+	urlgetter.TestKeys
+	MaxRuntime float64 `json:"max_runtime"`
 }
 
-func registerExtensions(m *model.Measurement) {
-	oonidatamodel.ExtHTTP.AddTo(m)
-	oonidatamodel.ExtDNS.AddTo(m)
-	oonidatamodel.ExtTLSHandshake.AddTo(m)
+// Measurer is the psiphon measurer.
+type Measurer struct {
+	BeforeGetHook func(g urlgetter.Getter)
+	Config        Config
 }
 
-type runner struct {
-	beginning      time.Time
-	callbacks      model.ExperimentCallbacks
-	config         Config
-	ioutilReadFile func(filename string) ([]byte, error)
-	osMkdirAll     func(path string, perm os.FileMode) error
-	osRemoveAll    func(path string) error
-	testkeys       *TestKeys
-}
-
-func newRunner(
-	config Config, callbacks model.ExperimentCallbacks,
-	beginning time.Time,
-) *runner {
-	return &runner{
-		beginning:      beginning,
-		callbacks:      callbacks,
-		config:         config,
-		ioutilReadFile: ioutil.ReadFile,
-		osMkdirAll:     os.MkdirAll,
-		osRemoveAll:    os.RemoveAll,
-		testkeys:       new(TestKeys),
-	}
-}
-
-func (r *runner) makeworkingdir() (string, error) {
-	if r.config.WorkDir == "" {
-		return "", errors.New("WorkDir is empty")
-	}
-	const testdirname = "oonipsiphon"
-	workdir := filepath.Join(r.config.WorkDir, testdirname)
-	if err := r.osRemoveAll(workdir); err != nil {
-		return "", err
-	}
-	if err := r.osMkdirAll(workdir, 0700); err != nil {
-		return "", err
-	}
-	return workdir, nil
-}
-
-func (r *runner) starttunnel(
-	ctx context.Context, configJSON []byte,
-	params clientlib.Parameters,
-) (*clientlib.PsiphonTunnel, error) {
-	return clientlib.StartTunnel(ctx, configJSON, "", params, nil, nil)
-}
-
-func (r *runner) usetunnel(
-	ctx context.Context, port int, logger model.Logger,
-) error {
-	r.testkeys.Agent = "redirect"
-	r.testkeys.SOCKSProxy = fmt.Sprintf("127.0.0.1:%d", port)
-	results := oonitemplates.HTTPDo(ctx, oonitemplates.HTTPDoConfig{
-		Accept:         httpheader.RandomAccept(),
-		AcceptLanguage: httpheader.RandomAcceptLanguage(),
-		Beginning:      r.beginning,
-		Handler:        netxlogger.NewHandler(logger),
-		Method:         "GET",
-		ProxyFunc: func(req *http.Request) (*url.URL, error) {
-			return &url.URL{
-				Scheme: "socks5",
-				Host:   r.testkeys.SOCKSProxy,
-			}, nil
-		},
-		URL:       "https://www.google.com/humans.txt",
-		UserAgent: httpheader.RandomUserAgent(),
-	})
-	r.testkeys.Queries = append(
-		r.testkeys.Queries, oonidatamodel.NewDNSQueriesList(results.TestKeys)...,
-	)
-	r.testkeys.Requests = append(
-		r.testkeys.Requests, oonidatamodel.NewRequestList(results.TestKeys)...,
-	)
-	r.testkeys.TLSHandshakes = append(
-		r.testkeys.TLSHandshakes, oonidatamodel.NewTLSHandshakesList(results.TestKeys)...,
-	)
-	// TODO(bassosimone): understand if there is a way to ask
-	// the tunnel the number of bytes sent and received
-	if results.Error != nil {
-		s := results.Error.Error()
-		r.testkeys.Failure = &s
-		return results.Error
-	}
-	return nil
-}
-
-func (r *runner) run(
-	ctx context.Context,
-	logger model.Logger,
-	fetchPsiphonConfig func(ctx context.Context) ([]byte, error),
-) error {
-	configJSON, err := fetchPsiphonConfig(ctx)
-	if err != nil {
-		s := err.Error()
-		r.testkeys.Failure = &s
-		return err
-	}
-	workdir, err := r.makeworkingdir()
-	if err != nil {
-		s := err.Error()
-		r.testkeys.Failure = &s
-		return err
-	}
-	start := time.Now()
-	tunnel, err := r.starttunnel(ctx, configJSON, clientlib.Parameters{
-		DataRootDirectory: &workdir,
-	})
-	if err != nil {
-		s := err.Error()
-		r.testkeys.Failure = &s
-		return err
-	}
-	r.testkeys.BootstrapTime = time.Since(start).Seconds()
-	defer tunnel.Stop()
-	return r.usetunnel(ctx, tunnel.SOCKSProxyPort, logger)
-}
-
-type measurer struct {
-	config Config
-}
-
-func (m *measurer) ExperimentName() string {
+// ExperimentName returns the experiment name
+func (m *Measurer) ExperimentName() string {
 	return testName
 }
 
-func (m *measurer) ExperimentVersion() string {
+// ExperimentVersion returns the experiment version
+func (m *Measurer) ExperimentVersion() string {
 	return testVersion
 }
 
-func (m *measurer) printprogress(
+func (m *Measurer) printprogress(
 	ctx context.Context, wg *sync.WaitGroup,
 	maxruntime int, callbacks model.ExperimentCallbacks,
 ) {
@@ -209,30 +66,41 @@ func (m *measurer) printprogress(
 	}
 }
 
-func (m *measurer) Run(
+// Run runs the measurement
+func (m *Measurer) Run(
 	ctx context.Context, sess model.ExperimentSession,
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
 ) error {
-	clnt, err := sess.NewOrchestraClient(ctx)
-	if err != nil {
-		return err
-	}
 	const maxruntime = 60
 	ctx, cancel := context.WithTimeout(ctx, maxruntime*time.Second)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go m.printprogress(ctx, &wg, maxruntime, callbacks)
-	r := newRunner(m.config, callbacks, measurement.MeasurementStartTimeSaved)
-	registerExtensions(measurement)
-	measurement.TestKeys = r.testkeys
-	r.testkeys.MaxRuntime = maxruntime
-	err = r.run(ctx, sess.Logger(), clnt.FetchPsiphonConfig)
+	m.Config.Tunnel = "psiphon" // force to use psiphon tunnel
+	urlgetter.RegisterExtensions(measurement)
+	target := "https://www.google.com/humans.txt"
+	if measurement.Input != "" {
+		target = string(measurement.Input)
+	}
+	g := urlgetter.Getter{
+		Config:  m.Config.Config,
+		Session: sess,
+		Target:  target,
+	}
+	if m.BeforeGetHook != nil {
+		m.BeforeGetHook(g)
+	}
+	tk, err := g.Get(ctx)
 	cancel()
 	wg.Wait()
+	measurement.TestKeys = TestKeys{
+		TestKeys:   tk,
+		MaxRuntime: maxruntime,
+	}
 	return err
 }
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return &measurer{config: config}
+	return &Measurer{Config: config}
 }

--- a/experiment/urlgetter/getter.go
+++ b/experiment/urlgetter/getter.go
@@ -46,7 +46,11 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 }
 
 func (g Getter) get(ctx context.Context, saver *trace.Saver) (TestKeys, error) {
-	tk := TestKeys{Agent: "redirect", Tunnel: g.Config.Tunnel}
+	tk := TestKeys{
+		Agent:    "redirect",
+		DNSCache: []string{g.Config.DNSCache},
+		Tunnel:   g.Config.Tunnel,
+	}
 	if g.Config.NoFollowRedirects {
 		tk.Agent = "agent"
 	}

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -41,7 +41,9 @@ type TestKeys struct {
 	Tunnel        string                   `json:"tunnel,omitempty"`
 }
 
-func registerExtensions(m *model.Measurement) {
+// RegisterExtensions registers the extensions used by the urlgetter
+// experiment into the provided measurement.
+func RegisterExtensions(m *model.Measurement) {
 	archival.ExtHTTP.AddTo(m)
 	archival.ExtDNS.AddTo(m)
 	archival.ExtNetevents.AddTo(m)
@@ -64,14 +66,13 @@ func (m measurer) Run(
 	ctx context.Context, sess model.ExperimentSession,
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
 ) error {
-	registerExtensions(measurement)
+	RegisterExtensions(measurement)
 	g := Getter{
 		Config:  m.Config,
 		Session: sess,
 		Target:  string(measurement.Input),
 	}
 	tk, err := g.Get(ctx)
-	tk.DNSCache = []string{m.Config.DNSCache}
 	measurement.TestKeys = tk
 	return err
 }

--- a/experiment_test.go
+++ b/experiment_test.go
@@ -116,7 +116,7 @@ func TestNeedsInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if builder.NeedsInput() == false {
+	if builder.InputPolicy() != InputRequired {
 		t.Fatal("web_connectivity certainly needs input")
 	}
 }

--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -286,7 +286,7 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 
 	builder, err := sess.NewExperimentBuilder(experimentName)
 	fatalOnError(err, "cannot create experiment builder")
-	if builder.NeedsInput() {
+	if builder.InputPolicy() == engine.InputRequired {
 		if len(currentOptions.Inputs) <= 0 {
 			log.Info("Fetching test lists")
 			list, err := sess.QueryTestListsURLs(&engine.TestListsURLsConfig{
@@ -297,6 +297,8 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 				currentOptions.Inputs = append(currentOptions.Inputs, entry.URL)
 			}
 		}
+	} else if builder.InputPolicy() == engine.InputOptional {
+		// nothing
 	} else if len(currentOptions.Inputs) != 0 {
 		fatalWithString("this experiment does not expect any input")
 	} else {

--- a/oonimkall/runner.go
+++ b/oonimkall/runner.go
@@ -272,7 +272,7 @@ func (r *runner) Run(ctx context.Context) {
 
 	builder.SetCallbacks(&runnerCallbacks{emitter: r.emitter})
 	if len(r.settings.Inputs) <= 0 {
-		if builder.NeedsInput() {
+		if builder.InputPolicy() == engine.InputRequired {
 			r.emitter.EmitFailureStartup("no input provided")
 			return
 		}
@@ -303,7 +303,7 @@ func (r *runner) Run(ctx context.Context) {
 	// sense, here we're changing the behaviour.
 	//
 	// See https://github.com/measurement-kit/measurement-kit/issues/1922
-	if r.settings.Options.MaxRuntime > 0 && builder.NeedsInput() {
+	if r.settings.Options.MaxRuntime > 0 && builder.InputPolicy() == engine.InputRequired {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(
 			ctx, time.Duration(r.settings.Options.MaxRuntime)*time.Second,


### PR DESCRIPTION
This diff contains the following changes:

1. rewrite psiphon to use the urlgetter experiment

2. hence, get for free performance metrics

3. modify the code such that you can say that an experiment knows
how to handle input but does not require input

4. declare that psiphon is such an experiment

If we want to pass specific URLs with psiphon, this is a matter of
policy in the ooni/probe-cli tool. Nothing more to do here.

Closes https://github.com/ooni/probe-engine/issues/404.