### PR TITLE
refactor: merge bouncer and collector into probeservices

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/iancoleman/strcase"
-	"github.com/ooni/probe-engine/collector"
+	"github.com/ooni/probe-engine/probeservices"
 	"github.com/ooni/probe-engine/experiment/dash"
 	"github.com/ooni/probe-engine/experiment/example"
 	"github.com/ooni/probe-engine/experiment/fbmessenger"
@@ -201,7 +201,7 @@ type Experiment struct {
 	byteCounter   *bytecounter.Counter
 	callbacks     model.ExperimentCallbacks
 	measurer      model.ExperimentMeasurer
-	report        *collector.Report
+	report        *probeservices.Report
 	session       *Session
 	testName      string
 	testStartTime string
@@ -353,7 +353,7 @@ func (e *Experiment) CloseReport() (err error) {
 func (e *Experiment) newMeasurement(input string) *model.Measurement {
 	utctimenow := time.Now().UTC()
 	m := model.Measurement{
-		DataFormatVersion:         collector.DefaultDataFormatVersion,
+		DataFormatVersion:         probeservices.DefaultDataFormatVersion,
 		Input:                     model.MeasurementTarget(input),
 		MeasurementStartTime:      utctimenow.Format(dateFormat),
 		MeasurementStartTimeSaved: utctimenow,
@@ -395,15 +395,15 @@ func (e *Experiment) openReport(ctx context.Context) (err error) {
 			)
 			continue
 		}
-		client := &collector.Client{
+		client := &probeservices.Client{
 			BaseURL:    c.Address,
 			HTTPClient: httpClient,
 			Logger:     e.session.logger,
 			UserAgent:  e.session.UserAgent(),
 		}
-		template := collector.ReportTemplate{
-			DataFormatVersion: collector.DefaultDataFormatVersion,
-			Format:            collector.DefaultFormat,
+		template := probeservices.ReportTemplate{
+			DataFormatVersion: probeservices.DefaultDataFormatVersion,
+			Format:            probeservices.DefaultFormat,
 			ProbeASN:          e.session.ProbeASNString(),
 			ProbeCC:           e.session.ProbeCC(),
 			SoftwareName:      e.session.SoftwareName(),

--- a/experiment.go
+++ b/experiment.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/iancoleman/strcase"
-	"github.com/ooni/probe-engine/probeservices"
 	"github.com/ooni/probe-engine/experiment/dash"
 	"github.com/ooni/probe-engine/experiment/example"
 	"github.com/ooni/probe-engine/experiment/fbmessenger"
@@ -32,6 +31,7 @@ import (
 	"github.com/ooni/probe-engine/netx/bytecounter"
 	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/httptransport"
+	"github.com/ooni/probe-engine/probeservices"
 	"github.com/ooni/probe-engine/version"
 )
 

--- a/experiment/mkhelper/mkhelper_test.go
+++ b/experiment/mkhelper/mkhelper_test.go
@@ -23,8 +23,8 @@ func TestNoHelpers(t *testing.T) {
 func TestNoSuitableHelper(t *testing.T) {
 	sess := &mockable.ExperimentSession{
 		MockableTestHelpers: map[string][]model.Service{
-			"foobar": []model.Service{
-				model.Service{
+			"foobar": {
+				{
 					Address: "mascetti",
 					Type:    "melandri",
 				},
@@ -43,8 +43,8 @@ func TestNoSuitableHelper(t *testing.T) {
 func TestGoodHelper(t *testing.T) {
 	sess := &mockable.ExperimentSession{
 		MockableTestHelpers: map[string][]model.Service{
-			"foobar": []model.Service{
-				model.Service{
+			"foobar": {
+				{
 					Address: "mascetti",
 					Type:    "melandri",
 				},

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -1,20 +1,22 @@
-// Package bouncer contains a OONI bouncer client implementation.
+// Package probeservices contains code to contact OONI probe services.
 //
 // Specifically we implement v2.0.0 of the OONI bouncer specification defined
-// in https://github.com/ooni/spec/blob/master/backends/bk-004-bouncer.md.
-package bouncer
+// in https://github.com/ooni/spec/blob/master/backends/bk-004-bouncer
+//
+// We additionally implement v2.0.0 of the OONI collector specification defined
+// in https://github.com/ooni/spec/blob/master/backends/bk-003-collector.md.
+package probeservices
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/model"
 )
 
-// Client is a client for the OONI bouncer API.
+// Client is a client for the OONI probe services API.
 type Client struct {
-	// BaseURL is the bouncer base URL.
+	// BaseURL is the probe services base URL.
 	BaseURL string
 
 	// HTTPClient is the HTTP client to use.
@@ -29,9 +31,7 @@ type Client struct {
 
 // GetCollectors queries the bouncer for collectors. Returns a list of
 // entries on success; an error on failure.
-func (c *Client) GetCollectors(
-	ctx context.Context,
-) (output []model.Service, err error) {
+func (c *Client) GetCollectors(ctx context.Context) (output []model.Service, err error) {
 	err = (&jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
@@ -43,8 +43,7 @@ func (c *Client) GetCollectors(
 
 // GetTestHelpers is like GetCollectors but for test helpers.
 func (c *Client) GetTestHelpers(
-	ctx context.Context,
-) (output map[string][]model.Service, err error) {
+	ctx context.Context) (output map[string][]model.Service, err error) {
 	err = (&jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -9,6 +9,7 @@ package probeservices
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/model"

--- a/probeservices/bouncer_test.go
+++ b/probeservices/bouncer_test.go
@@ -1,22 +1,11 @@
-package bouncer_test
+package probeservices_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-engine/bouncer"
 )
-
-func makeClient() *bouncer.Client {
-	return &bouncer.Client{
-		BaseURL:    "https://ps-test.ooni.io/",
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		UserAgent:  "ooniprobe-engine/0.1.0",
-	}
-}
 
 func TestGetCollectors(t *testing.T) {
 	log.SetLevel(log.DebugLevel)

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -1,15 +1,10 @@
-// Package collector contains a OONI collector client implementation.
-//
-// Specifically we implement v2.0.0 of the OONI collector specification defined
-// in https://github.com/ooni/spec/blob/master/backends/bk-003-collector.md.
-package collector
+package probeservices
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/model"
@@ -24,21 +19,6 @@ const (
 	// DefaultFormat is the default format
 	DefaultFormat = "json"
 )
-
-// Client is a client for the OONI collector API.
-type Client struct {
-	// BaseURL is the bouncer base URL.
-	BaseURL string
-
-	// HTTPClient is the HTTP client to use.
-	HTTPClient *http.Client
-
-	// Logger is the logger to use.
-	Logger model.Logger
-
-	// UserAgent is the user agent to use.
-	UserAgent string
-}
 
 // ReportTemplate is the template for opening a report
 type ReportTemplate struct {
@@ -84,9 +64,7 @@ type Report struct {
 }
 
 // OpenReport opens a new report.
-func (c *Client) OpenReport(
-	ctx context.Context, rt ReportTemplate,
-) (*Report, error) {
+func (c *Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, error) {
 	if rt.DataFormatVersion != DefaultDataFormatVersion {
 		return nil, errors.New("Unsupported data format version")
 	}
@@ -128,9 +106,7 @@ type updateResponse struct {
 // to the OONI collector. We will unconditionally modify the measurement
 // with the ReportID it should contain. If the collector supports sending
 // back to us a measurement ID, we also update the m.OOID field with it.
-func (r *Report) SubmitMeasurement(
-	ctx context.Context, m *model.Measurement,
-) error {
+func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse updateResponse
 	m.ReportID = r.ID
 	err := (&jsonapi.Client{

--- a/probeservices/collector_test.go
+++ b/probeservices/collector_test.go
@@ -1,4 +1,4 @@
-package collector_test
+package probeservices_test
 
 import (
 	"bytes"
@@ -9,17 +9,17 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-engine/collector"
 	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/probeservices"
 )
 
 type fakeTestKeys struct {
 	Failure *string `json:"failure"`
 }
 
-func makeMeasurement(rt collector.ReportTemplate, ID string) model.Measurement {
+func makeMeasurement(rt probeservices.ReportTemplate, ID string) model.Measurement {
 	return model.Measurement{
-		DataFormatVersion:    collector.DefaultDataFormatVersion,
+		DataFormatVersion:    probeservices.DefaultDataFormatVersion,
 		ID:                   "bdd20d7a-bba5-40dd-a111-9863d7908572",
 		MeasurementRuntime:   5.0565230846405,
 		MeasurementStartTime: "2018-11-01 15:33:20",
@@ -41,8 +41,8 @@ func makeMeasurement(rt collector.ReportTemplate, ID string) model.Measurement {
 	}
 }
 
-func makeClient() *collector.Client {
-	return &collector.Client{
+func makeClient() *probeservices.Client {
+	return &probeservices.Client{
 		BaseURL:    "https://ps-test.ooni.io/",
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,
@@ -53,9 +53,9 @@ func makeClient() *collector.Client {
 func TestReportLifecycle(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
-	template := collector.ReportTemplate{
-		DataFormatVersion: collector.DefaultDataFormatVersion,
-		Format:            collector.DefaultFormat,
+	template := probeservices.ReportTemplate{
+		DataFormatVersion: probeservices.DefaultDataFormatVersion,
+		Format:            probeservices.DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -82,9 +82,9 @@ func TestReportLifecycle(t *testing.T) {
 func TestOpenReportInvalidDataFormatVersion(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
-	template := collector.ReportTemplate{
+	template := probeservices.ReportTemplate{
 		DataFormatVersion: "0.1.0",
-		Format:            collector.DefaultFormat,
+		Format:            probeservices.DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -105,8 +105,8 @@ func TestOpenReportInvalidDataFormatVersion(t *testing.T) {
 func TestOpenReportInvalidFormat(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
-	template := collector.ReportTemplate{
-		DataFormatVersion: collector.DefaultDataFormatVersion,
+	template := probeservices.ReportTemplate{
+		DataFormatVersion: probeservices.DefaultDataFormatVersion,
 		Format:            "yaml",
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
@@ -128,9 +128,9 @@ func TestOpenReportInvalidFormat(t *testing.T) {
 func TestJSONAPIClientCreateFailure(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
-	template := collector.ReportTemplate{
-		DataFormatVersion: collector.DefaultDataFormatVersion,
-		Format:            collector.DefaultFormat,
+	template := probeservices.ReportTemplate{
+		DataFormatVersion: probeservices.DefaultDataFormatVersion,
+		Format:            probeservices.DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -158,9 +158,9 @@ func TestOpenResponseNoJSONSupport(t *testing.T) {
 	defer server.Close()
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
-	template := collector.ReportTemplate{
-		DataFormatVersion: collector.DefaultDataFormatVersion,
-		Format:            collector.DefaultFormat,
+	template := probeservices.ReportTemplate{
+		DataFormatVersion: probeservices.DefaultDataFormatVersion,
+		Format:            probeservices.DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",
@@ -211,9 +211,9 @@ func TestEndToEnd(t *testing.T) {
 	defer server.Close()
 	log.SetLevel(log.DebugLevel)
 	ctx := context.Background()
-	template := collector.ReportTemplate{
-		DataFormatVersion: collector.DefaultDataFormatVersion,
-		Format:            collector.DefaultFormat,
+	template := probeservices.ReportTemplate{
+		DataFormatVersion: probeservices.DefaultDataFormatVersion,
+		Format:            probeservices.DefaultFormat,
 		ProbeASN:          "AS0",
 		ProbeCC:           "ZZ",
 		SoftwareName:      "ooniprobe-engine",


### PR DESCRIPTION
To implement https://github.com/ooni/probe/issues/887, it helps to have all the
logic for speaking with probeservices in the same place.