### PR TITLE
netx/dialer/proxy.go: allow extemporary proxy

### DIFF
--- a/netx/dialer/proxy.go
+++ b/netx/dialer/proxy.go
@@ -12,22 +12,45 @@ import (
 // ProxyDialer is a dialer that uses a proxy. If the ProxyURL is not configured, this
 // dialer is a passthrough for the next Dialer in chain. Otherwise, it will internally
 // create a SOCKS5 dialer that will connect to the proxy using the underlying Dialer.
+//
+// As a special case, you can force a proxy to be used only when. To this end, you
+// can use the WithProxyURL function, to store the proxy URL in the context. This
+// will take precedence over any otherwise configured proxy. The use case for this
+// functionality is when you need a tunnel to contact OONI probe services.
 type ProxyDialer struct {
 	Dialer
 	ProxyURL *url.URL
 }
 
+type proxyKey struct{}
+
+// ContextProxyURL retrieves the proxy URL from the context. This is mainly used
+// to force a tunnel when we fail contacting OONI probe services otherwise.
+func ContextProxyURL(ctx context.Context) *url.URL {
+	url, _ := ctx.Value(proxyKey{}).(*url.URL)
+	return url
+}
+
+// WithProxyURL assigns the proxy URL to the context
+func WithProxyURL(ctx context.Context, url *url.URL) context.Context {
+	return context.WithValue(ctx, proxyKey{}, url)
+}
+
 // DialContext implements Dialer.DialContext
 func (d ProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	if d.ProxyURL == nil {
+	url := ContextProxyURL(ctx) // context URL takes precendence
+	if url == nil {
+		url = d.ProxyURL
+	}
+	if url == nil {
 		return d.Dialer.DialContext(ctx, network, address)
 	}
-	if d.ProxyURL.Scheme != "socks5" {
+	if url.Scheme != "socks5" {
 		return nil, errors.New("Scheme is not socks5")
 	}
 	// the code at proxy/socks5.go never fails; see https://git.io/JfJ4g
 	child, _ := proxy.SOCKS5(
-		network, d.ProxyURL.Host, nil, proxyDialerWrapper{Dialer: d.Dialer})
+		network, url.Host, nil, proxyDialerWrapper{Dialer: d.Dialer})
 	return d.dial(ctx, child, network, address)
 }
 

--- a/netx/dialer/proxy.go
+++ b/netx/dialer/proxy.go
@@ -13,8 +13,8 @@ import (
 // dialer is a passthrough for the next Dialer in chain. Otherwise, it will internally
 // create a SOCKS5 dialer that will connect to the proxy using the underlying Dialer.
 //
-// As a special case, you can force a proxy to be used only when. To this end, you
-// can use the WithProxyURL function, to store the proxy URL in the context. This
+// As a special case, you can force a proxy to be used only extemporarily. To this end,
+// you can use the WithProxyURL function, to store the proxy URL in the context. This
 // will take precedence over any otherwise configured proxy. The use case for this
 // functionality is when you need a tunnel to contact OONI probe services.
 type ProxyDialer struct {

--- a/netx/dialer/proxy_test.go
+++ b/netx/dialer/proxy_test.go
@@ -24,6 +24,23 @@ func TestUnitProxyDialerDialContextNoProxyURL(t *testing.T) {
 	}
 }
 
+func TestUnitProxyDialerContextTakesPrecedence(t *testing.T) {
+	expected := errors.New("mocked error")
+	d := dialer.ProxyDialer{
+		Dialer:   dialer.FakeDialer{Err: expected},
+		ProxyURL: &url.URL{Scheme: "antani"},
+	}
+	ctx := context.Background()
+	ctx = dialer.WithProxyURL(ctx, &url.URL{Scheme: "socks5", Host: "[::1]:443"})
+	conn, err := d.DialContext(ctx, "tcp", "www.google.com:443")
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("conn is not nil")
+	}
+}
+
 func TestUnitProxyDialerDialContextInvalidScheme(t *testing.T) {
 	d := dialer.ProxyDialer{
 		Dialer:   dialer.FakeDialer{},


### PR DESCRIPTION
This diff allows us to use the context in order to setup an extemporary
proxy that is only valid within the context of the context.

While working on https://github.com/ooni/probe/issues/887, I have
determined that this is beneficial to switching over to using a
psiphon tunnel, where everything else fails.

While this is a bit of a hack, and I was not convinced about continuing to use the
context in this way previously, not using the context seems to required lots of
burden because we need to setup and manage an alternative HTTP client.