### PR TITLE
jsonapi probeservices: allow cloudfronting and tunneling

### DIFF
--- a/internal/jsonapi/jsonapi.go
+++ b/internal/jsonapi/jsonapi.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 
 	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/dialer"
 )
 
 // Client is a client for a JSON API.
@@ -26,8 +27,14 @@ type Client struct {
 	// HTTPClient is the http client to use.
 	HTTPClient *http.Client
 
+	// Host allows to set a specific host header.
+	Host string
+
 	// Logger is the logger to use.
 	Logger model.Logger
+
+	// ProxyURL allows to force a proxy URL to fallback to a tunnel.
+	ProxyURL *url.URL
 
 	// UserAgent is the user agent to use.
 	UserAgent string
@@ -63,6 +70,7 @@ func (c *Client) makeRequest(
 	if err != nil {
 		return nil, err
 	}
+	request.Host = c.Host // allow cloudfronting
 	if body != nil {
 		request.Header.Set("Content-Type", "application/json")
 	}
@@ -70,6 +78,7 @@ func (c *Client) makeRequest(
 		request.Header.Set("Authorization", c.Authorization)
 	}
 	request.Header.Set("User-Agent", c.UserAgent)
+	ctx = dialer.WithProxyURL(ctx, c.ProxyURL) // allow tunneling if not nil
 	return request.WithContext(ctx), nil
 }
 

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -10,6 +10,7 @@ package probeservices
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/model"
@@ -23,8 +24,14 @@ type Client struct {
 	// HTTPClient is the HTTP client to use.
 	HTTPClient *http.Client
 
+	// Host allows to force a host header for cloudfronting.
+	Host string
+
 	// Logger is the logger to use.
 	Logger model.Logger
+
+	// ProxyURL allows to force a proxy URL to fallback to a tunnel.
+	ProxyURL *url.URL
 
 	// UserAgent is the user agent to use.
 	UserAgent string
@@ -36,7 +43,9 @@ func (c *Client) GetCollectors(ctx context.Context) (output []model.Service, err
 	err = (&jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
+		Host:       c.Host,
 		Logger:     c.Logger,
+		ProxyURL:   c.ProxyURL,
 		UserAgent:  c.UserAgent,
 	}).Read(ctx, "/api/v1/collectors", &output)
 	return
@@ -48,7 +57,9 @@ func (c *Client) GetTestHelpers(
 	err = (&jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
+		Host:       c.Host,
 		Logger:     c.Logger,
+		ProxyURL:   c.ProxyURL,
 		UserAgent:  c.UserAgent,
 	}).Read(ctx, "/api/v1/test-helpers", &output)
 	return

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -75,7 +75,9 @@ func (c *Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, er
 	err := (&jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
+		Host:       c.Host,
 		Logger:     c.Logger,
+		ProxyURL:   c.ProxyURL,
 		UserAgent:  c.UserAgent,
 	}).Create(ctx, "/report", rt, &or)
 	if err != nil {
@@ -112,7 +114,9 @@ func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) er
 	err := (&jsonapi.Client{
 		BaseURL:    r.client.BaseURL,
 		HTTPClient: r.client.HTTPClient,
+		Host:       r.client.Host,
 		Logger:     r.client.Logger,
+		ProxyURL:   r.client.ProxyURL,
 		UserAgent:  r.client.UserAgent,
 	}).Create(
 		ctx, fmt.Sprintf("/report/%s", r.ID), updateRequest{
@@ -132,7 +136,9 @@ func (r *Report) Close(ctx context.Context) error {
 	err := (&jsonapi.Client{
 		BaseURL:    r.client.BaseURL,
 		HTTPClient: r.client.HTTPClient,
+		Host:       r.client.Host,
 		Logger:     r.client.Logger,
+		ProxyURL:   r.client.ProxyURL,
 		UserAgent:  r.client.UserAgent,
 	}).Create(
 		ctx, fmt.Sprintf("/report/%s/close", r.ID), input, &output,


### PR DESCRIPTION
This diff modifies the code in jsonapi and probeservices such that it
is now possible to configure cloudfronting and tunneling.

Cloudfronting is configured by setting and propagating the Host header.

Tunneling is configured by forcing a specific proxy URL inside of
the context, using 4a39a3bce5d91c1a60d6185220cbb55079b51933.

Part of https://github.com/ooni/probe/issues/887