### PR TITLE
jsonapi, probeservices: refactoring before detecting blocking

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/experiment/web_connectivity"
 	"github.com/ooni/probe-engine/experiment/whatsapp"
+	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/internal/platform"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/bytecounter"
@@ -396,10 +397,12 @@ func (e *Experiment) openReport(ctx context.Context) (err error) {
 			continue
 		}
 		client := &probeservices.Client{
-			BaseURL:    c.Address,
-			HTTPClient: httpClient,
-			Logger:     e.session.logger,
-			UserAgent:  e.session.UserAgent(),
+			Client: jsonapi.Client{
+				BaseURL:    c.Address,
+				HTTPClient: httpClient,
+				Logger:     e.session.logger,
+				UserAgent:  e.session.UserAgent(),
+			},
 		}
 		template := probeservices.ReportTemplate{
 			DataFormatVersion: probeservices.DefaultDataFormatVersion,

--- a/internal/jsonapi/fake_test.go
+++ b/internal/jsonapi/fake_test.go
@@ -1,0 +1,44 @@
+package jsonapi
+
+import (
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type FakeTransport struct {
+	Err  error
+	Func func(*http.Request) (*http.Response, error)
+	Resp *http.Response
+}
+
+func (txp FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	time.Sleep(10 * time.Microsecond)
+	if txp.Func != nil {
+		return txp.Func(req)
+	}
+	if req.Body != nil {
+		ioutil.ReadAll(req.Body)
+		req.Body.Close()
+	}
+	if txp.Err != nil {
+		return nil, txp.Err
+	}
+	txp.Resp.Request = req // non thread safe but it doesn't matter
+	return txp.Resp, nil
+}
+
+func (txp FakeTransport) CloseIdleConnections() {}
+
+type FakeBody struct {
+	Err error
+}
+
+func (fb FakeBody) Read(p []byte) (int, error) {
+	time.Sleep(10 * time.Microsecond)
+	return 0, fb.Err
+}
+
+func (fb FakeBody) Close() error {
+	return nil
+}

--- a/internal/jsonapi/jsonapi.go
+++ b/internal/jsonapi/jsonapi.go
@@ -27,13 +27,15 @@ type Client struct {
 	// HTTPClient is the http client to use.
 	HTTPClient *http.Client
 
-	// Host allows to set a specific host header.
+	// Host allows to set a specific host header. This is useful
+	// to implement, e.g., cloudfronting.
 	Host string
 
 	// Logger is the logger to use.
 	Logger model.Logger
 
-	// ProxyURL allows to force a proxy URL to fallback to a tunnel.
+	// ProxyURL allows to force a proxy URL to fallback to a
+	// tunnel, e.g., Psiphon.
 	ProxyURL *url.URL
 
 	// UserAgent is the user agent to use.

--- a/internal/jsonapi/jsonapi.go
+++ b/internal/jsonapi/jsonapi.go
@@ -49,7 +49,7 @@ func (c Client) makeRequestWithJSONBody(
 	if err != nil {
 		return nil, err
 	}
-	c.Logger.Debugf("jsonapi: request body: %s", string(data))
+	c.Logger.Debugf("jsonapi: request body: %d bytes", len(data))
 	return c.makeRequest(ctx, method, resourcePath, query, bytes.NewReader(data))
 }
 
@@ -99,7 +99,7 @@ func (c Client) dox(
 	if err != nil {
 		return err
 	}
-	c.Logger.Debugf("jsonapi: response body: %s", string(data))
+	c.Logger.Debugf("jsonapi: response body: %d bytes", len(data))
 	return json.Unmarshal(data, output)
 }
 

--- a/internal/jsonapi/jsonapi.go
+++ b/internal/jsonapi/jsonapi.go
@@ -42,10 +42,9 @@ type Client struct {
 	UserAgent string
 }
 
-func (c *Client) makeRequestWithJSONBody(
+func (c Client) makeRequestWithJSONBody(
 	ctx context.Context, method, resourcePath string,
-	query url.Values, body interface{},
-) (*http.Request, error) {
+	query url.Values, body interface{}) (*http.Request, error) {
 	data, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -54,10 +53,9 @@ func (c *Client) makeRequestWithJSONBody(
 	return c.makeRequest(ctx, method, resourcePath, query, bytes.NewReader(data))
 }
 
-func (c *Client) makeRequest(
+func (c Client) makeRequest(
 	ctx context.Context, method, resourcePath string,
-	query url.Values, body io.Reader,
-) (*http.Request, error) {
+	query url.Values, body io.Reader) (*http.Request, error) {
 	URL, err := url.Parse(c.BaseURL)
 	if err != nil {
 		return nil, err
@@ -84,12 +82,11 @@ func (c *Client) makeRequest(
 	return request.WithContext(ctx), nil
 }
 
-func (c *Client) dox(
+func (c Client) dox(
 	do func(req *http.Request) (*http.Response, error),
 	readall func(r io.Reader) ([]byte, error),
 	request *http.Request,
-	output interface{},
-) error {
+	output interface{}) error {
 	response, err := do(request)
 	if err != nil {
 		return err
@@ -106,7 +103,7 @@ func (c *Client) dox(
 	return json.Unmarshal(data, output)
 }
 
-func (c *Client) do(request *http.Request, output interface{}) error {
+func (c Client) do(request *http.Request, output interface{}) error {
 	return c.dox(
 		c.HTTPClient.Do,
 		ioutil.ReadAll,
@@ -117,17 +114,14 @@ func (c *Client) do(request *http.Request, output interface{}) error {
 // Read reads the JSON resource at resourcePath and unmarshals the
 // results into output. The request is bounded by the lifetime of the
 // context passed as argument. Returns the error that occurred.
-func (c *Client) Read(
-	ctx context.Context, resourcePath string, output interface{},
-) error {
+func (c Client) Read(ctx context.Context, resourcePath string, output interface{}) error {
 	return c.ReadWithQuery(ctx, resourcePath, nil, output)
 }
 
 // ReadWithQuery is like Read but also has a query.
-func (c *Client) ReadWithQuery(
+func (c Client) ReadWithQuery(
 	ctx context.Context, resourcePath string,
-	query url.Values, output interface{},
-) error {
+	query url.Values, output interface{}) error {
 	request, err := c.makeRequest(ctx, "GET", resourcePath, query, nil)
 	if err != nil {
 		return err
@@ -139,9 +133,8 @@ func (c *Client) ReadWithQuery(
 // using the JSON document at input and returning the result into the
 // JSON document at output. The request is bounded by the context's
 // lifetime. Returns the error that occurred.
-func (c *Client) Create(
-	ctx context.Context, resourcePath string, input, output interface{},
-) error {
+func (c Client) Create(
+	ctx context.Context, resourcePath string, input, output interface{}) error {
 	request, err := c.makeRequestWithJSONBody(ctx, "POST", resourcePath, nil, input)
 	if err != nil {
 		return err
@@ -151,9 +144,8 @@ func (c *Client) Create(
 
 // Update updates a JSON resource at a specific path and returns
 // the error that occurred and possibly an output document
-func (c *Client) Update(
-	ctx context.Context, resourcePath string, input, output interface{},
-) error {
+func (c Client) Update(
+	ctx context.Context, resourcePath string, input, output interface{}) error {
 	request, err := c.makeRequestWithJSONBody(ctx, "PUT", resourcePath, nil, input)
 	if err != nil {
 		return err

--- a/internal/jsonapi/jsonapi_test.go
+++ b/internal/jsonapi/jsonapi_test.go
@@ -1,25 +1,22 @@
-package jsonapi
+package jsonapi_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
-type httpbinheaders struct {
-	Headers map[string]string `json:"headers"`
-}
-
-func makeclient() Client {
-	return Client{
+func newClient() jsonapi.Client {
+	return jsonapi.Client{
 		BaseURL:    "https://httpbin.org",
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,
@@ -27,9 +24,200 @@ func makeclient() Client {
 	}
 }
 
+func TestNewRequestWithJSONBodyJSONMarshalFailure(t *testing.T) {
+	client := newClient()
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", nil, make(chan interface{}),
+	)
+	if err == nil || !strings.HasPrefix(err.Error(), "json: unsupported type") {
+		t.Fatal("not the error we expected")
+	}
+	if req != nil {
+		t.Fatal("expected nil request here")
+	}
+}
+
+func TestNewRequestWithJSONBodyNewRequestFailure(t *testing.T) {
+	client := newClient()
+	client.BaseURL = "\t\t\t" // cause URL parse error
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", nil, nil,
+	)
+	if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
+		t.Fatal("not the error we expected")
+	}
+	if req != nil {
+		t.Fatal("expected nil request here")
+	}
+}
+
+func TestNewRequestWithQuery(t *testing.T) {
+	client := newClient()
+	q := url.Values{}
+	q.Add("antani", "mascetti")
+	q.Add("melandri", "conte")
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", q, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.URL.Query().Get("antani") != "mascetti" {
+		t.Fatal("expected different query string here")
+	}
+	if req.URL.Query().Get("melandri") != "conte" {
+		t.Fatal("expected different query string here")
+	}
+}
+
+func TestNewRequestNewRequestFailure(t *testing.T) {
+	client := newClient()
+	req, err := client.NewRequest(
+		context.Background(), "\t\t\t", "/", nil, nil,
+	)
+	if err == nil || !strings.HasPrefix(err.Error(), "net/http: invalid method") {
+		t.Fatal("not the error we expected")
+	}
+	if req != nil {
+		t.Fatal("expected nil request here")
+	}
+}
+
+func TestNewRequestCloudfronting(t *testing.T) {
+	client := newClient()
+	client.Host = "www.x.org"
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Host != client.Host {
+		t.Fatal("expected different req.Host here")
+	}
+}
+
+func TestNewRequestContentTypeIsSet(t *testing.T) {
+	client := newClient()
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", nil, []string{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Header.Get("Content-Type") != "application/json" {
+		t.Fatal("expected different Content-Type here")
+	}
+}
+
+func TestNewRequestAuthorizationHeader(t *testing.T) {
+	client := newClient()
+	client.Authorization = "deadbeef"
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Header.Get("Authorization") != client.Authorization {
+		t.Fatal("expected different Authorization here")
+	}
+}
+
+func TestNewRequestUserAgentIsSet(t *testing.T) {
+	client := newClient()
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Header.Get("User-Agent") != client.UserAgent {
+		t.Fatal("expected different User-Agent here")
+	}
+}
+
+func TestNewRequestTunnelingIsPossible(t *testing.T) {
+	client := newClient()
+	client.ProxyURL = &url.URL{Scheme: "socks5", Host: "[::1]:54321"}
+	req, err := client.NewRequest(
+		context.Background(), "GET", "/", nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmp := cmp.Diff(dialer.ContextProxyURL(req.Context()), client.ProxyURL)
+	if cmp != "" {
+		t.Fatal(cmp)
+	}
+}
+
+func TestClientDoClientDoFailure(t *testing.T) {
+	expected := errors.New("mocked error")
+	client := newClient()
+	client.HTTPClient = &http.Client{Transport: jsonapi.FakeTransport{
+		Err: expected,
+	}}
+	err := client.Do(&http.Request{URL: &url.URL{Scheme: "https", Host: "x.org"}}, nil)
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestClientDoResponseNotSuccessful(t *testing.T) {
+	client := newClient()
+	client.HTTPClient = &http.Client{Transport: jsonapi.FakeTransport{
+		Resp: &http.Response{
+			StatusCode: 401,
+			Body:       jsonapi.FakeBody{},
+		},
+	}}
+	err := client.Do(&http.Request{URL: &url.URL{Scheme: "https", Host: "x.org"}}, nil)
+	if err == nil || !strings.HasPrefix(err.Error(), "jsonapi: request failed") {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestClientDoResponseReadingBodyError(t *testing.T) {
+	expected := errors.New("mocked error")
+	client := newClient()
+	client.HTTPClient = &http.Client{Transport: jsonapi.FakeTransport{
+		Resp: &http.Response{
+			StatusCode: 200,
+			Body: jsonapi.FakeBody{
+				Err: expected,
+			},
+		},
+	}}
+	err := client.Do(&http.Request{URL: &url.URL{Scheme: "https", Host: "x.org"}}, nil)
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestClientDoResponseIsNotJSON(t *testing.T) {
+	client := newClient()
+	client.HTTPClient = &http.Client{Transport: jsonapi.FakeTransport{
+		Resp: &http.Response{
+			StatusCode: 200,
+			Body: jsonapi.FakeBody{
+				Err: io.EOF,
+			},
+		},
+	}}
+	err := client.Do(&http.Request{URL: &url.URL{Scheme: "https", Host: "x.org"}}, nil)
+	if err == nil || err.Error() != "unexpected end of JSON input" {
+		t.Fatal("not the error we expected")
+	}
+}
+
+type httpbinheaders struct {
+	Headers map[string]string `json:"headers"`
+}
+
 func TestIntegrationReadSuccess(t *testing.T) {
 	var headers httpbinheaders
-	err := makeclient().Read(context.Background(), "/headers", &headers)
+	err := newClient().Read(context.Background(), "/headers", &headers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,16 +226,6 @@ func TestIntegrationReadSuccess(t *testing.T) {
 	}
 	if headers.Headers["User-Agent"] != "miniooni/0.1.0-dev" {
 		t.Fatal("unexpected Host header")
-	}
-}
-
-func TestUnitReadFailure(t *testing.T) {
-	var headers httpbinheaders
-	client := makeclient()
-	client.BaseURL = "\t\t\t\t"
-	err := client.Read(context.Background(), "/headers", &headers)
-	if err == nil {
-		t.Fatal("expected an error here")
 	}
 }
 
@@ -62,22 +240,12 @@ func TestIntegrationCreateSuccess(t *testing.T) {
 		},
 	}
 	var response httpbinpost
-	err := makeclient().Create(context.Background(), "/post", &headers, &response)
+	err := newClient().Create(context.Background(), "/post", &headers, &response)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if response.Data != `{"headers":{"Foo":"bar"}}` {
 		t.Fatal(response.Data)
-	}
-}
-
-func TestUnitCreateFailure(t *testing.T) {
-	var headers httpbinheaders
-	client := makeclient()
-	client.BaseURL = "\t\t\t\t"
-	err := client.Create(context.Background(), "/headers", &headers, &headers)
-	if err == nil {
-		t.Fatal("expected an error here")
 	}
 }
 
@@ -92,7 +260,7 @@ func TestIntegrationUpdateSuccess(t *testing.T) {
 		},
 	}
 	var response httpbinpost
-	err := makeclient().Update(context.Background(), "/put", &headers, &response)
+	err := newClient().Update(context.Background(), "/put", &headers, &response)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,176 +268,33 @@ func TestIntegrationUpdateSuccess(t *testing.T) {
 		t.Fatal(response.Data)
 	}
 }
+
+func TestUnitReadFailure(t *testing.T) {
+	var headers httpbinheaders
+	client := newClient()
+	client.BaseURL = "\t\t\t\t"
+	err := client.Read(context.Background(), "/headers", &headers)
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+}
+
+func TestUnitCreateFailure(t *testing.T) {
+	var headers httpbinheaders
+	client := newClient()
+	client.BaseURL = "\t\t\t\t"
+	err := client.Create(context.Background(), "/headers", &headers, &headers)
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+}
+
 func TestUnitUpdateFailure(t *testing.T) {
 	var headers httpbinheaders
-	client := makeclient()
+	client := newClient()
 	client.BaseURL = "\t\t\t\t"
 	err := client.Update(context.Background(), "/headers", &headers, &headers)
 	if err == nil {
 		t.Fatal("expected an error here")
-	}
-}
-
-func TestUnitMakeRequestWithJSONBodyFailure(t *testing.T) {
-	client := makeclient()
-	ch := make(chan interface{})
-	req, err := client.makeRequestWithJSONBody(
-		context.Background(), "PUT", "/", nil, ch,
-	)
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if req != nil {
-		t.Fatal("expected nil req here")
-	}
-}
-
-func TestUnitMakeRequestWithQuery(t *testing.T) {
-	client := makeclient()
-	query := url.Values{}
-	query.Add("Foo", "bar")
-	req, err := client.makeRequest(
-		context.Background(), "PUT", "/", query, nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req == nil {
-		t.Fatal("expected non-nil req here")
-	}
-	if req.URL.Query().Get("Foo") != "bar" {
-		t.Fatal("unexpected query")
-	}
-}
-
-func TestUnitMakeRequestWithInvalidMethod(t *testing.T) {
-	client := makeclient()
-	req, err := client.makeRequest(
-		context.Background(), "\t", "/", nil, nil,
-	)
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if req != nil {
-		t.Fatal("expected nil req here")
-	}
-}
-
-func TestUnitMakeRequestWithAuthorization(t *testing.T) {
-	client := makeclient()
-	client.Authorization = "foo"
-	req, err := client.makeRequest(
-		context.Background(), "PUT", "/", nil, nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req == nil {
-		t.Fatal("expected non-nil req here")
-	}
-	if req.Header.Get("Authorization") != "foo" {
-		t.Fatal("unexpected authorization")
-	}
-}
-
-func TestIntegrationDoBadRequest(t *testing.T) {
-	client := makeclient()
-	req, err := client.makeRequest(
-		context.Background(), "GET", "/status/404", nil, nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := client.do(req, nil); err == nil {
-		t.Fatal("expected an error here")
-	}
-}
-
-func TestUnitDoxDoFailure(t *testing.T) {
-	client := makeclient()
-	req, err := client.makeRequest(
-		context.Background(), "GET", "/status/404", nil, nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := errors.New("mocked error")
-	err = client.dox(
-		func(req *http.Request) (*http.Response, error) {
-			return nil, expected
-		},
-		ioutil.ReadAll,
-		req, nil,
-	)
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-}
-
-func TestUnitDoxReadallFailure(t *testing.T) {
-	client := makeclient()
-	req, err := client.makeRequest(
-		context.Background(), "GET", "/status/404", nil, nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := errors.New("mocked error")
-	err = client.dox(
-		func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(nil)),
-			}, nil
-		},
-		func(r io.Reader) ([]byte, error) {
-			return nil, expected
-		},
-		req, nil,
-	)
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-}
-
-func TestUnitCloudFronting(t *testing.T) {
-	client := makeclient()
-	client.Host = "www.x.org"
-	req, err := client.makeRequest(
-		context.Background(), "GET", "/status/404", nil, nil,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := errors.New("mocked error")
-	err = client.dox(
-		func(req *http.Request) (*http.Response, error) {
-			if req.Host != "www.x.org" {
-				return nil, errors.New("expected req.Host to be set")
-			}
-			return nil, expected
-		}, nil, req, nil)
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
-	}
-}
-
-func TestUnitProxyTunnel(t *testing.T) {
-	client := makeclient()
-	client.ProxyURL = &url.URL{Scheme: "socks5", Host: "[::1]:443"}
-	req, err := client.makeRequest(context.Background(), "GET", "/status/404", nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := errors.New("mocked error")
-	err = client.dox(
-		func(req *http.Request) (*http.Response, error) {
-			url := dialer.ContextProxyURL(req.Context())
-			if url == nil || url.Scheme != "socks5" || url.Host != "[::1]:443" {
-				return nil, errors.New("expected a different context URL")
-			}
-			return nil, expected
-		}, nil, req, nil)
-	if !errors.Is(err, expected) {
-		t.Fatal("not the error we expected")
 	}
 }

--- a/internal/jsonapi/jsonapi_test.go
+++ b/internal/jsonapi/jsonapi_test.go
@@ -18,8 +18,8 @@ type httpbinheaders struct {
 	Headers map[string]string `json:"headers"`
 }
 
-func makeclient() *Client {
-	return &Client{
+func makeclient() Client {
+	return Client{
 		BaseURL:    "https://httpbin.org",
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -40,7 +40,7 @@ type Client struct {
 // GetCollectors queries the bouncer for collectors. Returns a list of
 // entries on success; an error on failure.
 func (c *Client) GetCollectors(ctx context.Context) (output []model.Service, err error) {
-	err = (&jsonapi.Client{
+	err = (jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
 		Host:       c.Host,
@@ -54,7 +54,7 @@ func (c *Client) GetCollectors(ctx context.Context) (output []model.Service, err
 // GetTestHelpers is like GetCollectors but for test helpers.
 func (c *Client) GetTestHelpers(
 	ctx context.Context) (output map[string][]model.Service, err error) {
-	err = (&jsonapi.Client{
+	err = (jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
 		Host:       c.Host,

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -21,13 +21,13 @@ type Client struct {
 
 // GetCollectors queries the bouncer for collectors. Returns a list of
 // entries on success; an error on failure.
-func (c *Client) GetCollectors(ctx context.Context) (output []model.Service, err error) {
+func (c Client) GetCollectors(ctx context.Context) (output []model.Service, err error) {
 	err = c.Client.Read(ctx, "/api/v1/collectors", &output)
 	return
 }
 
 // GetTestHelpers is like GetCollectors but for test helpers.
-func (c *Client) GetTestHelpers(
+func (c Client) GetTestHelpers(
 	ctx context.Context) (output map[string][]model.Service, err error) {
 	err = c.Client.Read(ctx, "/api/v1/test-helpers", &output)
 	return

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -9,8 +9,6 @@ package probeservices
 
 import (
 	"context"
-	"net/http"
-	"net/url"
 
 	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/model"
@@ -18,49 +16,19 @@ import (
 
 // Client is a client for the OONI probe services API.
 type Client struct {
-	// BaseURL is the probe services base URL.
-	BaseURL string
-
-	// HTTPClient is the HTTP client to use.
-	HTTPClient *http.Client
-
-	// Host allows to force a host header for cloudfronting.
-	Host string
-
-	// Logger is the logger to use.
-	Logger model.Logger
-
-	// ProxyURL allows to force a proxy URL to fallback to a tunnel.
-	ProxyURL *url.URL
-
-	// UserAgent is the user agent to use.
-	UserAgent string
+	jsonapi.Client
 }
 
 // GetCollectors queries the bouncer for collectors. Returns a list of
 // entries on success; an error on failure.
 func (c *Client) GetCollectors(ctx context.Context) (output []model.Service, err error) {
-	err = (jsonapi.Client{
-		BaseURL:    c.BaseURL,
-		HTTPClient: c.HTTPClient,
-		Host:       c.Host,
-		Logger:     c.Logger,
-		ProxyURL:   c.ProxyURL,
-		UserAgent:  c.UserAgent,
-	}).Read(ctx, "/api/v1/collectors", &output)
+	err = c.Client.Read(ctx, "/api/v1/collectors", &output)
 	return
 }
 
 // GetTestHelpers is like GetCollectors but for test helpers.
 func (c *Client) GetTestHelpers(
 	ctx context.Context) (output map[string][]model.Service, err error) {
-	err = (jsonapi.Client{
-		BaseURL:    c.BaseURL,
-		HTTPClient: c.HTTPClient,
-		Host:       c.Host,
-		Logger:     c.Logger,
-		ProxyURL:   c.ProxyURL,
-		UserAgent:  c.UserAgent,
-	}).Read(ctx, "/api/v1/test-helpers", &output)
+	err = c.Client.Read(ctx, "/api/v1/test-helpers", &output)
 	return
 }

--- a/probeservices/bouncer_test.go
+++ b/probeservices/bouncer_test.go
@@ -13,7 +13,9 @@ func TestGetCollectors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Infof("%+v", collectors)
+	if len(collectors) <= 1 {
+		t.Fatal("no returned collectors?!")
+	}
 }
 
 func TestGetTestHelpers(t *testing.T) {
@@ -22,5 +24,7 @@ func TestGetTestHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Infof("%+v", testhelpers)
+	if len(testhelpers) <= 1 {
+		t.Fatal("no returned test helpers?!")
+	}
 }

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -59,11 +59,11 @@ type Report struct {
 	ID string
 
 	// client is the client that was used.
-	client *Client
+	client Client
 }
 
 // OpenReport opens a new report.
-func (c *Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, error) {
+func (c Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, error) {
 	if rt.DataFormatVersion != DefaultDataFormatVersion {
 		return nil, errors.New("Unsupported data format version")
 	}
@@ -100,7 +100,7 @@ type updateResponse struct {
 // to the OONI collector. We will unconditionally modify the measurement
 // with the ReportID it should contain. If the collector supports sending
 // back to us a measurement ID, we also update the m.OOID field with it.
-func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
+func (r Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse updateResponse
 	m.ReportID = r.ID
 	err := r.client.Client.Create(
@@ -116,7 +116,7 @@ func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) er
 }
 
 // Close closes the report. Returns nil on success; an error on failure.
-func (r *Report) Close(ctx context.Context) error {
+func (r Report) Close(ctx context.Context) error {
 	var input, output struct{}
 	err := r.client.Client.Create(
 		ctx, fmt.Sprintf("/report/%s/close", r.ID), input, &output,
@@ -126,8 +126,7 @@ func (r *Report) Close(ctx context.Context) error {
 	// instead return an empty string. Intercept this error
 	// and turn it to nil, since we cannot really act upon
 	// this error, and we ought be flexible.
-	if _, ok := err.(*json.SyntaxError); ok &&
-		err.Error() == "unexpected end of JSON input" {
+	if _, ok := err.(*json.SyntaxError); ok && err.Error() == "unexpected end of JSON input" {
 		r.client.Logger.Debug(
 			"collector.go: working around collector returning empty string bug",
 		)

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -72,14 +71,7 @@ func (c *Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, er
 		return nil, errors.New("Unsupported format")
 	}
 	var or openResponse
-	err := (jsonapi.Client{
-		BaseURL:    c.BaseURL,
-		HTTPClient: c.HTTPClient,
-		Host:       c.Host,
-		Logger:     c.Logger,
-		ProxyURL:   c.ProxyURL,
-		UserAgent:  c.UserAgent,
-	}).Create(ctx, "/report", rt, &or)
+	err := c.Client.Create(ctx, "/report", rt, &or)
 	if err != nil {
 		return nil, err
 	}
@@ -111,14 +103,7 @@ type updateResponse struct {
 func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse updateResponse
 	m.ReportID = r.ID
-	err := (jsonapi.Client{
-		BaseURL:    r.client.BaseURL,
-		HTTPClient: r.client.HTTPClient,
-		Host:       r.client.Host,
-		Logger:     r.client.Logger,
-		ProxyURL:   r.client.ProxyURL,
-		UserAgent:  r.client.UserAgent,
-	}).Create(
+	err := r.client.Client.Create(
 		ctx, fmt.Sprintf("/report/%s", r.ID), updateRequest{
 			Format:  "json",
 			Content: m,
@@ -133,14 +118,7 @@ func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) er
 // Close closes the report. Returns nil on success; an error on failure.
 func (r *Report) Close(ctx context.Context) error {
 	var input, output struct{}
-	err := (jsonapi.Client{
-		BaseURL:    r.client.BaseURL,
-		HTTPClient: r.client.HTTPClient,
-		Host:       r.client.Host,
-		Logger:     r.client.Logger,
-		ProxyURL:   r.client.ProxyURL,
-		UserAgent:  r.client.UserAgent,
-	}).Create(
+	err := r.client.Client.Create(
 		ctx, fmt.Sprintf("/report/%s/close", r.ID), input, &output,
 	)
 	// Implementation note: the server is not compliant with

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -72,7 +72,7 @@ func (c *Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, er
 		return nil, errors.New("Unsupported format")
 	}
 	var or openResponse
-	err := (&jsonapi.Client{
+	err := (jsonapi.Client{
 		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
 		Host:       c.Host,
@@ -111,7 +111,7 @@ type updateResponse struct {
 func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse updateResponse
 	m.ReportID = r.ID
-	err := (&jsonapi.Client{
+	err := (jsonapi.Client{
 		BaseURL:    r.client.BaseURL,
 		HTTPClient: r.client.HTTPClient,
 		Host:       r.client.Host,
@@ -133,7 +133,7 @@ func (r *Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) er
 // Close closes the report. Returns nil on success; an error on failure.
 func (r *Report) Close(ctx context.Context) error {
 	var input, output struct{}
-	err := (&jsonapi.Client{
+	err := (jsonapi.Client{
 		BaseURL:    r.client.BaseURL,
 		HTTPClient: r.client.HTTPClient,
 		Host:       r.client.Host,

--- a/probeservices/collector_test.go
+++ b/probeservices/collector_test.go
@@ -42,8 +42,8 @@ func makeMeasurement(rt probeservices.ReportTemplate, ID string) model.Measureme
 	}
 }
 
-func makeClient() *probeservices.Client {
-	return &probeservices.Client{
+func makeClient() probeservices.Client {
+	return probeservices.Client{
 		Client: jsonapi.Client{
 			BaseURL:    "https://ps-test.ooni.io/",
 			HTTPClient: http.DefaultClient,

--- a/probeservices/collector_test.go
+++ b/probeservices/collector_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/probeservices"
 )
@@ -43,10 +44,12 @@ func makeMeasurement(rt probeservices.ReportTemplate, ID string) model.Measureme
 
 func makeClient() *probeservices.Client {
 	return &probeservices.Client{
-		BaseURL:    "https://ps-test.ooni.io/",
-		HTTPClient: http.DefaultClient,
-		Logger:     log.Log,
-		UserAgent:  "ooniprobe-engine/0.1.0",
+		Client: jsonapi.Client{
+			BaseURL:    "https://ps-test.ooni.io/",
+			HTTPClient: http.DefaultClient,
+			Logger:     log.Log,
+			UserAgent:  "ooniprobe-engine/0.1.0",
+		},
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ooni/probe-engine/geoiplookup/mmdblookup"
 	"github.com/ooni/probe-engine/geoiplookup/resolverlookup"
 	"github.com/ooni/probe-engine/internal/httpheader"
+	"github.com/ooni/probe-engine/internal/jsonapi"
 	"github.com/ooni/probe-engine/internal/kvstore"
 	"github.com/ooni/probe-engine/internal/orchestra"
 	"github.com/ooni/probe-engine/internal/orchestra/metadata"
@@ -543,10 +544,12 @@ func (s *Session) queryBouncer(ctx context.Context, query func(*probeservices.Cl
 			continue
 		}
 		err := query(&probeservices.Client{
-			BaseURL:    e.Address,
-			HTTPClient: s.DefaultHTTPClient(),
-			Logger:     s.logger,
-			UserAgent:  s.UserAgent(),
+			Client: jsonapi.Client{
+				BaseURL:    e.Address,
+				HTTPClient: s.DefaultHTTPClient(),
+				Logger:     s.logger,
+				UserAgent:  s.UserAgent(),
+			},
 		})
 		if err == nil {
 			return nil


### PR DESCRIPTION
This PR contains a but of unrelated diffs that perform refactoring of jsonapi and probeservices. I want these changes to be in before continuing with https://github.com/ooni/probe/issues/887.