### PR TITLE
[API CHANGE] session: significantly simplify initialization

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -69,8 +69,21 @@ func newSessionForTestingNoLookupsWithProxyURL(t *testing.T, URL *url.URL) *Sess
 		t.Fatal(err)
 	}
 	sess, err := NewSession(SessionConfig{
-		AssetsDir:       "testdata",
-		Logger:          log.Log,
+		AssetsDir: "testdata",
+		AvailableBouncers: []model.Service{{
+			Address: "https://ps-test.ooni.io",
+			Type:    "https",
+		}},
+		AvailableCollectors: []model.Service{{
+			Address: "https://ps-test.ooni.io",
+			Type:    "https",
+		}},
+		Logger: log.Log,
+		PrivacySettings: model.PrivacySettings{
+			IncludeASN:     true,
+			IncludeCountry: true,
+			IncludeIP:      false,
+		},
 		ProxyURL:        URL,
 		SoftwareName:    "ooniprobe-engine",
 		SoftwareVersion: "0.0.1",
@@ -79,11 +92,6 @@ func newSessionForTestingNoLookupsWithProxyURL(t *testing.T, URL *url.URL) *Sess
 	if err != nil {
 		t.Fatal(err)
 	}
-	sess.AddAvailableHTTPSBouncer("https://ps-test.ooni.io")
-	sess.AddAvailableHTTPSCollector("https://ps-test.ooni.io")
-	sess.SetIncludeProbeASN(true)
-	sess.SetIncludeProbeCC(true)
-	sess.SetIncludeProbeIP(false)
 	return sess
 }
 


### PR DESCRIPTION
This diff significantly simplifies the way in which the session
is initialized. Now all options are set as part of the session
configuration and then everything follows nicely(TM).

This means that we don't need to worry when the session is alive
whether the programmer has changed, e.g., the collector URL.

Yak shaving as part of https://github.com/ooni/probe/issues/887.