### PR TITLE
session: use cloudflare doh by default, system as fallback

### DIFF
--- a/internal/sessionresolver/sessionresolver.go
+++ b/internal/sessionresolver/sessionresolver.go
@@ -1,0 +1,63 @@
+// Package sessionresolver contains the resolver used by the session. This
+// resolver uses Cloudflare DoH by default and falls back on the system
+// provided resolver if Cloudflare DoH is not working.
+package sessionresolver
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/atomicx"
+	"github.com/ooni/probe-engine/internal/runtimex"
+	"github.com/ooni/probe-engine/netx/httptransport"
+)
+
+// Resolver is the session resolver.
+type Resolver struct {
+	Primary         httptransport.DNSClient
+	PrimaryFailure  *atomicx.Int64
+	Fallback        httptransport.DNSClient
+	FallbackFailure *atomicx.Int64
+}
+
+// New creates a new session resolver.
+func New(config httptransport.Config) *Resolver {
+	primary, err := httptransport.NewDNSClient(config, "doh://cloudflare")
+	runtimex.PanicOnError(err, "cannot create cloudflare resolver")
+	fallback, err := httptransport.NewDNSClient(config, "system:///")
+	runtimex.PanicOnError(err, "cannot create system resolver")
+	return &Resolver{
+		Primary:         primary,
+		PrimaryFailure:  atomicx.NewInt64(),
+		Fallback:        fallback,
+		FallbackFailure: atomicx.NewInt64(),
+	}
+}
+
+// CloseIdleConnections closes the idle connections, if any
+func (r *Resolver) CloseIdleConnections() {
+	r.Primary.CloseIdleConnections()
+	r.Fallback.CloseIdleConnections()
+}
+
+// LookupHost implements Resolver.LookupHost
+func (r *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+	addrs, err := r.Primary.LookupHost(ctx, hostname)
+	if err != nil {
+		r.PrimaryFailure.Add(1)
+		addrs, err = r.Fallback.LookupHost(ctx, hostname)
+		if err != nil {
+			r.FallbackFailure.Add(1)
+		}
+	}
+	return addrs, err
+}
+
+// Network implements Resolver.Network
+func (r *Resolver) Network() string {
+	return "sessionresolver"
+}
+
+// Address implements Resolver.Address
+func (r *Resolver) Address() string {
+	return ""
+}

--- a/internal/sessionresolver/sessionresolver_test.go
+++ b/internal/sessionresolver/sessionresolver_test.go
@@ -1,0 +1,34 @@
+package sessionresolver_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ooni/probe-engine/internal/sessionresolver"
+	"github.com/ooni/probe-engine/netx/httptransport"
+)
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	reso := sessionresolver.New(httptransport.Config{})
+	defer reso.CloseIdleConnections()
+	if reso.Network() != "sessionresolver" {
+		t.Fatal("unexpected Network")
+	}
+	if reso.Address() != "" {
+		t.Fatal("unexpected Address")
+	}
+	addrs, err := reso.LookupHost(context.Background(), "antani.ooni.io")
+	if err == nil || !strings.HasSuffix(err.Error(), "no such host") {
+		t.Fatal("not the error we expected")
+	}
+	if addrs != nil {
+		t.Fatal("expected nil addrs here")
+	}
+	if reso.PrimaryFailure.Load() != 1 || reso.FallbackFailure.Load() != 1 {
+		t.Fatal("not the counters we expected to see here")
+	}
+}

--- a/oonimkall/task_test.go
+++ b/oonimkall/task_test.go
@@ -653,8 +653,8 @@ func TestIntegrationNonblock(t *testing.T) {
 		t.Fatal("The runner should be running at this point")
 	}
 	// Assumption: the example experiment emits less than bufsiz = 128
-	// events and runs for less than 10 seconds (should be five).
-	time.Sleep(10 * time.Second)
+	// events and runs for less than 15 seconds (should be five).
+	time.Sleep(15 * time.Second)
 	if task.IsRunning() {
 		t.Fatal("The runner should be stopped by now")
 	}


### PR DESCRIPTION
This is useful at least as far as we're talking with OONI servers.

Closes https://github.com/ooni/probe-engine/issues/521.

Part of https://github.com/ooni/probe/issues/887.