### PR TITLE
More confidence that we can use tor to contact probe services

### DIFF
--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -319,7 +319,9 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 			}
 		}
 	} else if builder.InputPolicy() == engine.InputOptional {
-		// nothing
+		if len(currentOptions.Inputs) == 0 {
+			currentOptions.Inputs = append(currentOptions.Inputs, "")
+		}
 	} else if len(currentOptions.Inputs) != 0 {
 		fatalWithString("this experiment does not expect any input")
 	} else {

--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -4,6 +4,7 @@
 package libminiooni
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -41,6 +42,7 @@ type Options struct {
 	SelfCensorSpec string
 	TorArgs        []string
 	TorBinary      string
+	Tunnel         string
 	Verbose        bool
 }
 
@@ -104,6 +106,10 @@ func init() {
 	getopt.FlagLong(
 		&globalOptions.TorBinary, "tor-binary", 0,
 		"Specify path to a specific tor binary",
+	)
+	getopt.FlagLong(
+		&globalOptions.Tunnel, "tunnel", 0,
+		"Name of the tunnel to use (one of `tor`, `psiphon`)",
 	)
 	getopt.FlagLong(
 		&globalOptions.Verbose, "verbose", 'v', "Increase verbosity",
@@ -284,6 +290,9 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 			humanizex.SI(sess.KibiBytesSent()*1024, "byte"),
 		)
 	}()
+
+	err = sess.MaybeStartTunnel(context.Background(), currentOptions.Tunnel)
+	fatalOnError(err, "cannot start session tunnel")
 
 	if !currentOptions.NoBouncer {
 		log.Info("Looking up OONI backends; please be patient...")


### PR DESCRIPTION
This PR contains a set of small diffs that I implemented while making sure that if we selfcensor us a lot, we can still route around that censorship using a tor tunnel. So, specifically:

1. I added the possibility of starting a tunnel to `miniooni`

2. I made sure an existing `tor` tunnel is not mistakenly interpreted as a `psiphon` tunnel and viceversa; also, in this vein, I clarified the tunnel rules with more tests

3. fixed a `miniooni` issue that prevented running `psiphon`

This work is part of https://github.com/ooni/probe/issues/887.