### PR TITLE
netx: implement the tcp:// and dot:// schemes for DNS

### DIFF
--- a/netx/httptransport/httptransport.go
+++ b/netx/httptransport/httptransport.go
@@ -266,6 +266,30 @@ func NewDNSClient(config Config, URL string) (DNSClient, error) {
 		}
 		c.Resolver = resolver.NewSerialResolver(txp)
 		return c, nil
+	case "dot":
+		tlsDialer := NewTLSDialer(config)
+		var txp resolver.RoundTripper = resolver.NewDNSOverTLS(
+			tlsDialer.DialTLSContext, resolverURL.Host)
+		if config.ResolveSaver != nil {
+			txp = resolver.SaverDNSTransport{
+				RoundTripper: txp,
+				Saver:        config.ResolveSaver,
+			}
+		}
+		c.Resolver = resolver.NewSerialResolver(txp)
+		return c, nil
+	case "tcp":
+		dialer := NewDialer(config)
+		var txp resolver.RoundTripper = resolver.NewDNSOverTCP(
+			dialer.DialContext, resolverURL.Host)
+		if config.ResolveSaver != nil {
+			txp = resolver.SaverDNSTransport{
+				RoundTripper: txp,
+				Saver:        config.ResolveSaver,
+			}
+		}
+		c.Resolver = resolver.NewSerialResolver(txp)
+		return c, nil
 	default:
 		return c, errors.New("unsupported resolver scheme")
 	}

--- a/netx/httptransport/httptransport_test.go
+++ b/netx/httptransport/httptransport_test.go
@@ -915,22 +915,6 @@ func TestNewDNSClientCloudflareDoH(t *testing.T) {
 	dnsclient.CloseIdleConnections()
 }
 
-func TestNewDNSClientUDP(t *testing.T) {
-	dnsclient, err := httptransport.NewDNSClient(
-		httptransport.Config{}, "udp://8.8.8.8:53")
-	if err != nil {
-		t.Fatal(err)
-	}
-	r, ok := dnsclient.Resolver.(resolver.SerialResolver)
-	if !ok {
-		t.Fatal("not the resolver we expected")
-	}
-	if _, ok := r.Transport().(resolver.DNSOverUDP); !ok {
-		t.Fatal("not the transport we expected")
-	}
-	dnsclient.CloseIdleConnections()
-}
-
 func TestNewDNSClientCloudflareDoHSaver(t *testing.T) {
 	saver := new(trace.Saver)
 	dnsclient, err := httptransport.NewDNSClient(
@@ -952,7 +936,23 @@ func TestNewDNSClientCloudflareDoHSaver(t *testing.T) {
 	dnsclient.CloseIdleConnections()
 }
 
-func TestNewDNSClientDNSSaver(t *testing.T) {
+func TestNewDNSClientUDP(t *testing.T) {
+	dnsclient, err := httptransport.NewDNSClient(
+		httptransport.Config{}, "udp://8.8.8.8:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := dnsclient.Resolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	if _, ok := r.Transport().(resolver.DNSOverUDP); !ok {
+		t.Fatal("not the transport we expected")
+	}
+	dnsclient.CloseIdleConnections()
+}
+
+func TestNewDNSClientUDPDNSSaver(t *testing.T) {
 	saver := new(trace.Saver)
 	dnsclient, err := httptransport.NewDNSClient(
 		httptransport.Config{ResolveSaver: saver}, "udp://8.8.8.8:53")
@@ -969,6 +969,96 @@ func TestNewDNSClientDNSSaver(t *testing.T) {
 	}
 	if _, ok := txp.RoundTripper.(resolver.DNSOverUDP); !ok {
 		t.Fatal("not the transport we expected")
+	}
+	dnsclient.CloseIdleConnections()
+}
+
+func TestNewDNSClientTCP(t *testing.T) {
+	dnsclient, err := httptransport.NewDNSClient(
+		httptransport.Config{}, "tcp://8.8.8.8:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := dnsclient.Resolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	txp, ok := r.Transport().(resolver.DNSOverTCP)
+	if !ok {
+		t.Fatal("not the transport we expected")
+	}
+	if txp.Network() != "tcp" {
+		t.Fatal("not the Network we expected")
+	}
+	dnsclient.CloseIdleConnections()
+}
+
+func TestNewDNSClientTCPDNSSaver(t *testing.T) {
+	saver := new(trace.Saver)
+	dnsclient, err := httptransport.NewDNSClient(
+		httptransport.Config{ResolveSaver: saver}, "tcp://8.8.8.8:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := dnsclient.Resolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	txp, ok := r.Transport().(resolver.SaverDNSTransport)
+	if !ok {
+		t.Fatal("not the transport we expected")
+	}
+	dotcp, ok := txp.RoundTripper.(resolver.DNSOverTCP)
+	if !ok {
+		t.Fatal("not the transport we expected")
+	}
+	if dotcp.Network() != "tcp" {
+		t.Fatal("not the Network we expected")
+	}
+	dnsclient.CloseIdleConnections()
+}
+
+func TestNewDNSClientDoT(t *testing.T) {
+	dnsclient, err := httptransport.NewDNSClient(
+		httptransport.Config{}, "dot://8.8.8.8:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := dnsclient.Resolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	txp, ok := r.Transport().(resolver.DNSOverTCP)
+	if !ok {
+		t.Fatal("not the transport we expected")
+	}
+	if txp.Network() != "dot" {
+		t.Fatal("not the Network we expected")
+	}
+	dnsclient.CloseIdleConnections()
+}
+
+func TestNewDNSClientDoTDNSSaver(t *testing.T) {
+	saver := new(trace.Saver)
+	dnsclient, err := httptransport.NewDNSClient(
+		httptransport.Config{ResolveSaver: saver}, "dot://8.8.8.8:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := dnsclient.Resolver.(resolver.SerialResolver)
+	if !ok {
+		t.Fatal("not the resolver we expected")
+	}
+	txp, ok := r.Transport().(resolver.SaverDNSTransport)
+	if !ok {
+		t.Fatal("not the transport we expected")
+	}
+	dotls, ok := txp.RoundTripper.(resolver.DNSOverTCP)
+	if !ok {
+		t.Fatal("not the transport we expected")
+	}
+	if dotls.Network() != "dot" {
+		t.Fatal("not the Network we expected")
 	}
 	dnsclient.CloseIdleConnections()
 }


### PR DESCRIPTION
Needed to do https://github.com/ooni/probe-engine/issues/581

Usage:

```bash
./miniooni -OResolverURL=dot://8.8.8.8:853 -i dnslookup://example.com urlgetter
./miniooni -OResolverURL=tcp://8.8.8.8:53  -i dnslookup://example.com urlgetter
```