### PR TITLE
Save ASN and ASOrgName of each DNS lookup

### DIFF
--- a/experiment/urlgetter/getter.go
+++ b/experiment/urlgetter/getter.go
@@ -31,7 +31,8 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 	}
 	events := saver.Read()
 	tk.Queries = append(
-		tk.Queries, archival.NewDNSQueriesList(begin, events)...,
+		tk.Queries, archival.NewDNSQueriesList(
+			begin, events, g.Session.ASNDatabasePath())...,
 	)
 	tk.NetworkEvents = append(
 		tk.NetworkEvents, archival.NewNetworkEventsList(begin, events)...,

--- a/geoiplookup/mmdblookup/mmdblookup.go
+++ b/geoiplookup/mmdblookup/mmdblookup.go
@@ -8,13 +8,11 @@ import (
 	"github.com/oschwald/geoip2-golang"
 )
 
-// LookupASN maps the ip to the probe ASN and org using the
+// ASN maps the ip to the probe ASN and org using the
 // MMDB database located at path, or returns an error. In case
 // the IP is not valid, this function will fail with an error
 // complaining that geoip2 was passed a nil IP.
-func LookupASN(
-	path, ip string, logger model.Logger,
-) (asn uint, org string, err error) {
+func ASN(path, ip string) (asn uint, org string, err error) {
 	asn, org = model.DefaultProbeASN, model.DefaultProbeNetworkName
 	db, err := geoip2.Open(path)
 	if err != nil {
@@ -25,7 +23,6 @@ func LookupASN(
 	if err != nil {
 		return
 	}
-	logger.Debugf("mmdblookup: ASN: %+v", record)
 	asn = record.AutonomousSystemNumber
 	if record.AutonomousSystemOrganization != "" {
 		org = record.AutonomousSystemOrganization
@@ -33,10 +30,8 @@ func LookupASN(
 	return
 }
 
-// LookupCC is like LookupASN but for the country code.
-func LookupCC(
-	path, ip string, logger model.Logger,
-) (cc string, err error) {
+// CC is like LookupASN but for the country code.
+func CC(path, ip string) (cc string, err error) {
 	cc = model.DefaultProbeCC
 	db, err := geoip2.Open(path)
 	if err != nil {
@@ -47,7 +42,6 @@ func LookupCC(
 	if err != nil {
 		return
 	}
-	logger.Debugf("mmdblookup: Country: %+v", record)
 	// With MaxMind DB we used record.RegisteredCountry.IsoCode but that does
 	// not seem to work with the db-ip.com database. The record is empty, at
 	// least for my own IP address in Italy. --Simone (2020-02-25)

--- a/geoiplookup/mmdblookup/mmdblookup_test.go
+++ b/geoiplookup/mmdblookup/mmdblookup_test.go
@@ -31,7 +31,7 @@ func maybeFetchResources(t *testing.T) {
 
 func TestLookupProbeASN(t *testing.T) {
 	maybeFetchResources(t)
-	asn, org, err := mmdblookup.LookupASN(asnDBPath, ipAddr, log.Log)
+	asn, org, err := mmdblookup.ASN(asnDBPath, ipAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func TestLookupProbeASN(t *testing.T) {
 
 func TestLookupProbeASNInvalidFile(t *testing.T) {
 	maybeFetchResources(t)
-	asn, org, err := mmdblookup.LookupASN("/nonexistent", ipAddr, log.Log)
+	asn, org, err := mmdblookup.ASN("/nonexistent", ipAddr)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -55,7 +55,7 @@ func TestLookupProbeASNInvalidFile(t *testing.T) {
 
 func TestLookupProbeASNInvalidIP(t *testing.T) {
 	maybeFetchResources(t)
-	asn, org, err := mmdblookup.LookupASN(asnDBPath, "xxx", log.Log)
+	asn, org, err := mmdblookup.ASN(asnDBPath, "xxx")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -69,7 +69,7 @@ func TestLookupProbeASNInvalidIP(t *testing.T) {
 
 func TestLookupProbeCC(t *testing.T) {
 	maybeFetchResources(t)
-	cc, err := mmdblookup.LookupCC(countryDBPath, ipAddr, log.Log)
+	cc, err := mmdblookup.CC(countryDBPath, ipAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestLookupProbeCC(t *testing.T) {
 
 func TestLookupProbeCCInvalidFile(t *testing.T) {
 	maybeFetchResources(t)
-	cc, err := mmdblookup.LookupCC("/nonexistent", ipAddr, log.Log)
+	cc, err := mmdblookup.CC("/nonexistent", ipAddr)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -89,7 +89,7 @@ func TestLookupProbeCCInvalidFile(t *testing.T) {
 
 func TestLookupProbeCCInvalidIP(t *testing.T) {
 	maybeFetchResources(t)
-	cc, err := mmdblookup.LookupCC(asnDBPath, "xxx", log.Log)
+	cc, err := mmdblookup.CC(asnDBPath, "xxx")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/libooniffi/ooniffi_test.go
+++ b/libooniffi/ooniffi_test.go
@@ -20,15 +20,15 @@ func TestUnitTaskStartInvalidJSON(t *testing.T) {
 
 func TestUnitTaskStartIdxWrapping(t *testing.T) {
 	settings := cstring(`{
-		"assets_dir": "../../testdata/oonimkall/assets",
+		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
 		"name": "Example",
 		"options": {
 			"software_name": "oonimkall-test",
 			"software_version": "0.1.0"
 		},
-		"state_dir": "../../testdata/oonimkall/state",
-		"temp_dir": "../../testdata/oonimkall/tmp"
+		"state_dir": "../testdata/oonimkall/state",
+		"temp_dir": "../testdata/oonimkall/tmp"
 	}`)
 	defer freestring(settings)
 	o := setmaxidx()
@@ -74,15 +74,15 @@ func TestUnitTaskDestroyNullPointer(t *testing.T) {
 
 func TestIntegrationExampleNormalUsage(t *testing.T) {
 	settings := cstring(`{
-		"assets_dir": "../../testdata/oonimkall/assets",
+		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
 		"name": "Example",
 		"options": {
 			"software_name": "oonimkall-test",
 			"software_version": "0.1.0"
 		},
-		"state_dir": "../../testdata/oonimkall/state",
-		"temp_dir": "../../testdata/oonimkall/tmp"
+		"state_dir": "../testdata/oonimkall/state",
+		"temp_dir": "../testdata/oonimkall/tmp"
 	}`)
 	defer freestring(settings)
 	task := ooniffi_task_start_(settings)
@@ -99,15 +99,15 @@ func TestIntegrationExampleNormalUsage(t *testing.T) {
 
 func TestIntegrationExampleInterruptAndDestroy(t *testing.T) {
 	settings := cstring(`{
-		"assets_dir": "../../testdata/oonimkall/assets",
+		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
 		"name": "Example",
 		"options": {
 			"software_name": "oonimkall-test",
 			"software_version": "0.1.0"
 		},
-		"state_dir": "../../testdata/oonimkall/state",
-		"temp_dir": "../../testdata/oonimkall/tmp"
+		"state_dir": "../testdata/oonimkall/state",
+		"temp_dir": "../testdata/oonimkall/tmp"
 	}`)
 	defer freestring(settings)
 	task := ooniffi_task_start_(settings)
@@ -120,15 +120,15 @@ func TestIntegrationExampleInterruptAndDestroy(t *testing.T) {
 
 func TestIntegrationExampleDestroyImmediately(t *testing.T) {
 	settings := cstring(`{
-		"assets_dir": "../../testdata/oonimkall/assets",
+		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
 		"name": "Example",
 		"options": {
 			"software_name": "oonimkall-test",
 			"software_version": "0.1.0"
 		},
-		"state_dir": "../../testdata/oonimkall/state",
-		"temp_dir": "../../testdata/oonimkall/tmp"
+		"state_dir": "../testdata/oonimkall/state",
+		"temp_dir": "../testdata/oonimkall/tmp"
 	}`)
 	defer freestring(settings)
 	task := ooniffi_task_start_(settings)

--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -374,7 +374,14 @@ func NewDNSQueriesList(begin time.Time, events []trace.Event, dbpath string) []D
 						entry.Answers, qtype.makeanswerentry(addr, dbpath))
 				}
 			}
-			if len(entry.Answers) <= 0 {
+			if len(entry.Answers) <= 0 && ev.Err == nil {
+				// This allows us to skip cases where the server does not have
+				// an IPv6 address but has an IPv4 address. Instead, when we
+				// receive an error, we want to track its existence. The main
+				// issue here is that we are cheating, because we are creating
+				// entries representing queries, but we don't know what the
+				// resolver actually did, especially the system resolver. So,
+				// this output is just our best guess.
 				continue
 			}
 			out = append(out, entry)

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/websocket"
+	"github.com/ooni/probe-engine/internal/resources"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
 	"github.com/ooni/probe-engine/netx/modelx"
@@ -208,10 +210,20 @@ func TestNewRequestList(t *testing.T) {
 }
 
 func TestNewDNSQueriesList(t *testing.T) {
+	err := (&resources.Client{
+		HTTPClient: http.DefaultClient,
+		Logger:     log.Log,
+		UserAgent:  "miniooni/0.1.0-dev",
+		WorkDir:    "../../testdata",
+	}).Ensure(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 	begin := time.Now()
 	type args struct {
 		begin  time.Time
 		events []trace.Event
+		dbpath string
 	}
 	tests := []struct {
 		name string
@@ -284,10 +296,34 @@ func TestNewDNSQueriesList(t *testing.T) {
 			QueryType: "AAAA",
 			T:         0.2,
 		}},
+	}, {
+		name: "run with ASN DB",
+		args: args{
+			begin: begin,
+			events: []trace.Event{{
+				Addresses: []string{"2001:4860:4860::8888"},
+				Hostname:  "dns.google.com",
+				Name:      "resolve_done",
+				Time:      begin.Add(200 * time.Millisecond),
+			}},
+			dbpath: "../../testdata/asn.mmdb",
+		},
+		want: []archival.DNSQueryEntry{{
+			Answers: []archival.DNSAnswerEntry{{
+				ASN:        15169,
+				ASOrgName:  "Google LLC",
+				AnswerType: "AAAA",
+				IPv6:       "2001:4860:4860::8888",
+			}},
+			Hostname:  "dns.google.com",
+			QueryType: "AAAA",
+			T:         0.2,
+		}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := archival.NewDNSQueriesList(tt.args.begin, tt.args.events); !reflect.DeepEqual(got, tt.want) {
+			if got := archival.NewDNSQueriesList(
+				tt.args.begin, tt.args.events, tt.args.dbpath); !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(got, tt.want))
 			}
 		})

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -319,6 +319,33 @@ func TestNewDNSQueriesList(t *testing.T) {
 			QueryType: "AAAA",
 			T:         0.2,
 		}},
+	}, {
+		name: "run with errors",
+		args: args{
+			begin: begin,
+			events: []trace.Event{{
+				Err:      &modelx.ErrWrapper{Failure: modelx.FailureDNSNXDOMAINError},
+				Hostname: "dns.google.com",
+				Name:     "resolve_done",
+				Time:     begin.Add(200 * time.Millisecond),
+			}},
+			dbpath: "../../testdata/asn.mmdb",
+		},
+		want: []archival.DNSQueryEntry{{
+			Answers: nil,
+			Failure: archival.NewFailure(
+				&modelx.ErrWrapper{Failure: modelx.FailureDNSNXDOMAINError}),
+			Hostname:  "dns.google.com",
+			QueryType: "A",
+			T:         0.2,
+		}, {
+			Answers: nil,
+			Failure: archival.NewFailure(
+				&modelx.ErrWrapper{Failure: modelx.FailureDNSNXDOMAINError}),
+			Hostname:  "dns.google.com",
+			QueryType: "AAAA",
+			T:         0.2,
+		}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -429,7 +429,7 @@ func (s *Session) initOrchestraClient(
 }
 
 func (s *Session) lookupASN(dbPath, ip string) (uint, string, error) {
-	return mmdblookup.LookupASN(dbPath, ip, s.logger)
+	return mmdblookup.ASN(dbPath, ip)
 }
 
 func (s *Session) lookupProbeIP(ctx context.Context) (string, error) {
@@ -441,7 +441,7 @@ func (s *Session) lookupProbeIP(ctx context.Context) (string, error) {
 }
 
 func (s *Session) lookupProbeCC(dbPath, probeIP string) (string, error) {
-	return mmdblookup.LookupCC(dbPath, probeIP, s.logger)
+	return mmdblookup.CC(dbPath, probeIP)
 }
 
 func (s *Session) lookupResolverIP(ctx context.Context) (string, error) {


### PR DESCRIPTION
In addition to being useful for analysing data, this extra bit of information seems also super valuable when our objective is that of assessing the goodness of our ASN database.

In fact, it means we submit to ourselves annotated IP addresses. So we can use other databases to verify how good are our annotations, and whether we need to improve.

This work has been done to move forward https://github.com/ooni/probe-engine/issues/584.

While carrying out this work, I noticed and fixed two bugs, which are separate commits.