### PR TITLE
model/model.go: use 127.0.0.2 for unknown resolver IP

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -282,7 +282,7 @@ const (
 	DefaultResolverASN uint = 0
 
 	// DefaultResolverIP is the default resolver IP.
-	DefaultResolverIP = "127.0.0.1"
+	DefaultResolverIP = "127.0.0.2"
 
 	// DefaultResolverNetworkName is the default resolver network name.
 	DefaultResolverNetworkName = ""


### PR DESCRIPTION
This has been recommended by @hellais some time ago. With the
merge of this diff, we can close https://github.com/measurement-kit/measurement-kit/issues/1884.

(I didn't bother with changing with in MK, since we are decommissioning
it, and I just acted upon probe-engine.)