### PR TITLE
torx: save tor logs to a file in tempdir

### DIFF
--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -239,7 +239,7 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 	log.Infof("miniooni state directory: %s", miniooniDir)
 	tempDir, err := ioutil.TempDir("", "miniooni")
 	fatalOnError(err, "cannot get a temporary directory")
-	log.Debugf("miniooni temporary directory: %s", tempDir)
+	log.Infof("miniooni temporary directory: %s", tempDir)
 
 	var proxyURL *url.URL
 	if currentOptions.Proxy != "" {


### PR DESCRIPTION
The location of the file can always be deduced given a session. This means
we can read the logs after a tor tunnel has been used.

Closes https://github.com/ooni/probe-engine/issues/625.