### PR TITLE
engine: replace bouncer and collector with probe services

### DIFF
--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -281,13 +281,7 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 		TorBinary:       currentOptions.TorBinary,
 	}
 	if currentOptions.ProbeServicesURL != "" {
-		// TODO(bassosimone): in a follow-up commit we will unify
-		// these two config variables into a single variable
-		config.AvailableBouncers = []model.Service{{
-			Address: currentOptions.ProbeServicesURL,
-			Type:    "https",
-		}}
-		config.AvailableCollectors = []model.Service{{
+		config.AvailableProbeServices = []model.Service{{
 			Address: currentOptions.ProbeServicesURL,
 			Type:    "https",
 		}}

--- a/session_internal_test.go
+++ b/session_internal_test.go
@@ -14,22 +14,18 @@ func (s *Session) FetchResourcesIdempotent(ctx context.Context) error {
 	return s.fetchResourcesIdempotent(ctx)
 }
 
-func (s *Session) GetAvailableBouncers() []model.Service {
-	return s.getAvailableBouncers()
+func (s *Session) GetAvailableProbeServices() []model.Service {
+	return s.getAvailableProbeServices()
 }
 
-func (s *Session) AppendAvailableBouncer(bouncer model.Service) {
-	s.availableBouncers = append(s.availableBouncers, bouncer)
+func (s *Session) AppendAvailableProbeService(svc model.Service) {
+	s.availableProbeServices = append(s.availableProbeServices, svc)
 }
 
 func (s *Session) MaybeLookupBackendsContext(ctx context.Context) (err error) {
 	return s.maybeLookupBackends(ctx)
 }
 
-func (s *Session) MaybeLookupTestHelpersContext(ctx context.Context) error {
-	return s.maybeLookupTestHelpers(ctx)
-}
-
-func (s *Session) QueryBouncerCount() int64 {
-	return s.queryBouncerCount.Load()
+func (s *Session) QueryProbeServicesCount() int64 {
+	return s.queryProbeServicesCount.Load()
 }

--- a/session_test.go
+++ b/session_test.go
@@ -65,6 +65,45 @@ func newSessionMustFail(t *testing.T, config SessionConfig) {
 	}
 }
 
+func TestSessionTorArgsTorBinary(t *testing.T) {
+	sess, err := NewSession(SessionConfig{
+		AssetsDir: "testdata",
+		AvailableProbeServices: []model.Service{{
+			Address: "https://ps-test.ooni.io",
+			Type:    "https",
+		}},
+		Logger: log.Log,
+		PrivacySettings: model.PrivacySettings{
+			IncludeASN:     true,
+			IncludeCountry: true,
+			IncludeIP:      false,
+		},
+		SoftwareName:    "ooniprobe-engine",
+		SoftwareVersion: "0.0.1",
+		TempDir:         "tempdir",
+		TorArgs:         []string{"antani1", "antani2", "antani3"},
+		TorBinary:       "mascetti",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.TorBinary() != "mascetti" {
+		t.Fatal("not the TorBinary we expected")
+	}
+	if len(sess.TorArgs()) != 3 {
+		t.Fatal("not the TorArgs length we expected")
+	}
+	if sess.TorArgs()[0] != "antani1" {
+		t.Fatal("not the TorArgs[0] we expected")
+	}
+	if sess.TorArgs()[1] != "antani2" {
+		t.Fatal("not the TorArgs[1] we expected")
+	}
+	if sess.TorArgs()[2] != "antani3" {
+		t.Fatal("not the TorArgs[2] we expected")
+	}
+}
+
 func newSessionForTestingNoLookupsWithProxyURL(t *testing.T, URL *url.URL) *Session {
 	tempdir, err := ioutil.TempDir("testdata", "enginetests")
 	if err != nil {
@@ -72,11 +111,7 @@ func newSessionForTestingNoLookupsWithProxyURL(t *testing.T, URL *url.URL) *Sess
 	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir: "testdata",
-		AvailableBouncers: []model.Service{{
-			Address: "https://ps-test.ooni.io",
-			Type:    "https",
-		}},
-		AvailableCollectors: []model.Service{{
+		AvailableProbeServices: []model.Service{{
 			Address: "https://ps-test.ooni.io",
 			Type:    "https",
 		}},
@@ -101,7 +136,7 @@ func newSessionForTestingNoLookups(t *testing.T) *Session {
 	return newSessionForTestingNoLookupsWithProxyURL(t, nil)
 }
 
-func newSessionForTesting(t *testing.T) *Session {
+func newSessionForTestingNoBackendsLookup(t *testing.T) *Session {
 	sess := newSessionForTestingNoLookups(t)
 	if err := sess.MaybeLookupLocation(); err != nil {
 		t.Fatal(err)
@@ -116,6 +151,11 @@ func newSessionForTesting(t *testing.T) *Session {
 	log.Infof("ResolverASNString: %s", sess.ResolverASNString())
 	log.Infof("ResolverIP: %s", sess.ResolverIP())
 	log.Infof("ResolverNetworkName: %s", sess.ResolverNetworkName())
+	return sess
+}
+
+func newSessionForTesting(t *testing.T) *Session {
+	sess := newSessionForTestingNoBackendsLookup(t)
 	if err := sess.MaybeLookupBackends(); err != nil {
 		t.Fatal(err)
 	}
@@ -203,6 +243,19 @@ func TestBouncerError(t *testing.T) {
 	}
 }
 
+func TestMaybeLookupBackendsNewClientError(t *testing.T) {
+	sess := newSessionForTestingNoLookups(t)
+	sess.availableProbeServices = []model.Service{{
+		Type:    "onion",
+		Address: "httpo://jehhrikjjqrlpufu.onion",
+	}}
+	defer sess.Close()
+	err := sess.MaybeLookupBackends()
+	if err.Error() != "all available probe services failed" {
+		t.Fatal("not the error we expected")
+	}
+}
+
 func TestIntegrationMaybeStartTunnel(t *testing.T) {
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
@@ -287,7 +340,7 @@ func TestIntegrationSessionDownloadResources(t *testing.T) {
 	}
 }
 
-func TestUnitGetAvailableBouncers(t *testing.T) {
+func TestUnitGetAvailableProbeServices(t *testing.T) {
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
 		Logger:          log.Log,
@@ -299,7 +352,7 @@ func TestUnitGetAvailableBouncers(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer sess.Close()
-	all := sess.GetAvailableBouncers()
+	all := sess.GetAvailableProbeServices()
 	diff := cmp.Diff(all, probeservices.Default())
 	if diff != "" {
 		t.Fatal(diff)
@@ -321,7 +374,7 @@ func TestUnitMaybeLookupBackendsFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // so we fail immediately
 	err = sess.MaybeLookupBackendsContext(ctx)
-	if !strings.HasSuffix(err.Error(), "All available bouncers failed") {
+	if !strings.HasSuffix(err.Error(), "all available probe services failed") {
 		t.Fatal("unexpected error")
 	}
 }
@@ -339,18 +392,18 @@ func TestIntegrationMaybeLookupTestHelpersIdempotent(t *testing.T) {
 	}
 	defer sess.Close()
 	ctx := context.Background()
-	if err = sess.MaybeLookupTestHelpersContext(ctx); err != nil {
+	if err = sess.MaybeLookupBackendsContext(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if err = sess.MaybeLookupTestHelpersContext(ctx); err != nil {
+	if err = sess.MaybeLookupBackendsContext(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if sess.QueryBouncerCount() != 1 {
+	if sess.QueryProbeServicesCount() != 1 {
 		t.Fatal("unexpected number of queries sent to the bouncer")
 	}
 }
 
-func TestUnitAllBouncersUnsupported(t *testing.T) {
+func TestUnitAllProbeServicesUnsupported(t *testing.T) {
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
 		Logger:          log.Log,
@@ -362,12 +415,12 @@ func TestUnitAllBouncersUnsupported(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer sess.Close()
-	sess.AppendAvailableBouncer(model.Service{
+	sess.AppendAvailableProbeService(model.Service{
 		Address: "mascetti",
 		Type:    "antani",
 	})
 	err = sess.MaybeLookupBackends()
-	if !strings.HasSuffix(err.Error(), "All available bouncers failed") {
+	if !strings.HasSuffix(err.Error(), "all available probe services failed") {
 		t.Fatal("unexpected error")
 	}
 }


### PR DESCRIPTION
The distinction between bouncer and collector has vanished! Now we have
probe services that we query when using the bouncer protocol and that
we later use when opening/updating/closing the report.

This is part of https://github.com/ooni/probe-engine/issues/621.