### PR TITLE
fix(task_test.go): fix test logic to avoid races

### DIFF
--- a/oonimkall/task_test.go
+++ b/oonimkall/task_test.go
@@ -588,11 +588,11 @@ func TestIntegrationNonblock(t *testing.T) {
 	if !task.IsRunning() {
 		t.Fatal("The runner should be running at this point")
 	}
-	// Assumption: the example experiment emits less than bufsiz = 128
-	// events and runs for less than 15 seconds (should be five).
-	time.Sleep(15 * time.Second)
-	if task.IsRunning() {
-		t.Fatal("The runner should be stopped by now")
+	// If the task blocks because it emits too much events, this test
+	// will run forever and will be killed. Because we have room for up
+	// to 128 events in the buffer, we should hopefully be fine.
+	for task.IsRunning() {
+		time.Sleep(time.Second)
 	}
 	for !task.IsDone() {
 		task.WaitForNextEvent()


### PR DESCRIPTION
It still beats me how it's possible that the test takes more than 15
seconds to complete. But maybe I don't understand the internals of how
GitHub actions run with high parallelism. Or there is something else
that is broken and I don't know for sure that it is.

Example of broken build: https://github.com/ooni/probe-engine/pull/497/checks?check_run_id=713886264

I have now rewritten this test such that it runs forever if the task
is stuck somewhere. So, this will give me more information.

Spotted while working on https://github.com/ooni/probe-engine/issues/498