### PR TITLE
Make sure we declare the tunnel data format when needed

### DIFF
--- a/experiment/dash/dash.go
+++ b/experiment/dash/dash.go
@@ -18,6 +18,7 @@ import (
 	"github.com/montanaflynn/stats"
 	"github.com/ooni/probe-engine/internal/humanizex"
 	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/archival"
 	"github.com/ooni/probe-engine/netx/httptransport"
 	"github.com/ooni/probe-engine/netx/trace"
 )
@@ -65,6 +66,10 @@ type TestKeys struct {
 	ReceiverData  []clientResults `json:"receiver_data"`
 	SOCKSProxy    string          `json:"socksproxy,omitempty"`
 	Tunnel        string          `json:"tunnel,omitempty"`
+}
+
+func registerExtensions(m *model.Measurement) {
+	archival.ExtTunnel.AddTo(m)
 }
 
 type runner struct {
@@ -257,6 +262,7 @@ func (m measurer) Run(
 ) error {
 	tk := new(TestKeys)
 	measurement.TestKeys = tk
+	registerExtensions(measurement)
 	tk.Tunnel = m.config.Tunnel
 	if err := sess.MaybeStartTunnel(ctx, m.config.Tunnel); err != nil {
 		s := err.Error()

--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ooni/probe-engine/internal/humanizex"
 	"github.com/ooni/probe-engine/internal/mlablocatev2"
 	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/archival"
 	"github.com/ooni/probe-engine/netx/httptransport"
 )
 
@@ -74,6 +75,10 @@ type TestKeys struct {
 
 	// Upload contains upload results
 	Upload []spec.Measurement `json:"upload"`
+}
+
+func registerExtensions(m *model.Measurement) {
+	archival.ExtTunnel.AddTo(m)
 }
 
 type measurer struct {
@@ -222,6 +227,7 @@ func (m *measurer) Run(
 	tk := new(TestKeys)
 	tk.Protocol = 7
 	measurement.TestKeys = tk
+	registerExtensions(measurement)
 	tk.Tunnel = m.config.Tunnel
 	if err := sess.MaybeStartTunnel(ctx, m.config.Tunnel); err != nil {
 		s := err.Error()

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -49,6 +49,7 @@ func RegisterExtensions(m *model.Measurement) {
 	archival.ExtDNS.AddTo(m)
 	archival.ExtNetevents.AddTo(m)
 	archival.ExtTLSHandshake.AddTo(m)
+	archival.ExtTunnel.AddTo(m)
 }
 
 type measurer struct {

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -31,7 +31,7 @@ func TestMeasurer(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
 	}
-	if len(measurement.Extensions) != 4 {
+	if len(measurement.Extensions) != 5 {
 		t.Fatal("not the expected number of extensions")
 	}
 }
@@ -57,7 +57,7 @@ func TestMeasurerDNSCache(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
 	}
-	if len(measurement.Extensions) != 4 {
+	if len(measurement.Extensions) != 5 {
 		t.Fatal("not the expected number of extensions")
 	}
 	tk := measurement.TestKeys.(urlgetter.TestKeys)

--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -52,6 +52,9 @@ var (
 
 	// ExtTLSHandshake is the version of df-006-tlshandshake.md
 	ExtTLSHandshake = ExtSpec{Name: "tlshandshake", V: 0}
+
+	// ExtTunnel is the version of df-009-tunnel.md
+	ExtTunnel = ExtSpec{Name: "tunnel", V: 0}
 )
 
 // TCPConnectStatus contains the TCP connect status.

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -907,3 +907,10 @@ func TestNewFailure(t *testing.T) {
 		})
 	}
 }
+
+func TestDNSQueryTypeInvalidIPOfType(t *testing.T) {
+	qtype := archival.DNSQueryType("ANTANI")
+	if qtype.IPOfType("8.8.8.8") != false {
+		t.Fatal("unexpected return value")
+	}
+}

--- a/netx/archival/archival_test_internal.go
+++ b/netx/archival/archival_test_internal.go
@@ -1,0 +1,7 @@
+package archival
+
+type DNSQueryType = dnsQueryType
+
+func (qtype dnsQueryType) IPOfType(addr string) bool {
+	return qtype.ipoftype(addr)
+}


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/533

While there, bring coverage in `netx/archival` to 100%.