### PR TITLE
tls/timeout: use deadline rather than context

### DIFF
--- a/netx/dialer/eof_test.go
+++ b/netx/dialer/eof_test.go
@@ -48,6 +48,18 @@ func (EOFConn) RemoteAddr() net.Addr {
 	return EOFAddr{}
 }
 
+func (EOFConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (EOFConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (EOFConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
 type EOFAddr struct{}
 
 func (EOFAddr) Network() string {

--- a/netx/selfcensor/selfcensor_test.go
+++ b/netx/selfcensor/selfcensor_test.go
@@ -2,7 +2,6 @@ package selfcensor_test
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -108,7 +107,7 @@ func TestResolveCauseTimeout(t *testing.T) {
 		t.Fatal("we expected self censorship to be enabled now")
 	}
 	addrs, err := selfcensor.SystemResolver{}.LookupHost(ctx, "dns.google")
-	if !errors.Is(err, context.DeadlineExceeded) {
+	if err == nil || err.Error() != "i/o timeout" {
 		t.Fatal("not the error we expected")
 	}
 	if addrs != nil {
@@ -181,7 +180,7 @@ func TestDialCauseTimeout(t *testing.T) {
 		t.Fatal("we expected self censorship to be enabled now")
 	}
 	addrs, err := selfcensor.SystemDialer{}.DialContext(ctx, "tcp", "8.8.8.8:443")
-	if !errors.Is(err, context.DeadlineExceeded) {
+	if err == nil || err.Error() != "i/o timeout" {
 		t.Fatal("not the error we expected")
 	}
 	if addrs != nil {


### PR DESCRIPTION
This should lead to a more understandable sequence of low level events
where we don't see anymore the "use of closed network connection".

Part of https://github.com/ooni/probe-engine/issues/576.