### PR TITLE
Use ps.ooni.io wherever it makes sense to do so

### DIFF
--- a/internal/orchestra/orchestra.go
+++ b/internal/orchestra/orchestra.go
@@ -41,8 +41,8 @@ func NewClient(
 	return &Client{
 		HTTPClient:         httpClient,
 		Logger:             logger,
-		OrchestrateBaseURL: "https://orchestrate.ooni.io",
-		RegistryBaseURL:    "https://registry.ooni.io",
+		OrchestrateBaseURL: "https://ps.ooni.io",
+		RegistryBaseURL:    "https://ps.ooni.io",
 		StateFile:          stateFile,
 		UserAgent:          userAgent,
 	}

--- a/internal/orchestra/testlists/urls/urls_test.go
+++ b/internal/orchestra/testlists/urls/urls_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestIntegrationSuccess(t *testing.T) {
 	config := Config{
-		BaseURL:           "https://orchestrate.ooni.io",
+		BaseURL:           "https://ps.ooni.io",
 		CountryCode:       "IT",
 		EnabledCategories: []string{"NEWS", "CULTR"},
 		HTTPClient:        http.DefaultClient,

--- a/internal/sessionresolver/sessionresolver_test.go
+++ b/internal/sessionresolver/sessionresolver_test.go
@@ -21,7 +21,7 @@ func TestIntegration(t *testing.T) {
 	if reso.Address() != "" {
 		t.Fatal("unexpected Address")
 	}
-	addrs, err := reso.LookupHost(context.Background(), "antani.ooni.io")
+	addrs, err := reso.LookupHost(context.Background(), "antani.ooni.nu")
 	if err == nil || !strings.HasSuffix(err.Error(), "no such host") {
 		t.Fatal("not the error we expected")
 	}

--- a/netx/dialer/dns_test.go
+++ b/netx/dialer/dns_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestUnitDNSDialerNoPort(t *testing.T) {
 	dialer := dialer.DNSDialer{Dialer: new(net.Dialer), Resolver: new(net.Resolver)}
-	conn, err := dialer.DialContext(context.Background(), "tcp", "antani.ooni.io")
+	conn, err := dialer.DialContext(context.Background(), "tcp", "antani.ooni.nu")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/netx/http_test.go
+++ b/netx/http_test.go
@@ -114,7 +114,7 @@ func TestHTTPNewClientProxy(t *testing.T) {
 	httpProxyTestMain(t, client.HTTPClient, 451)
 }
 
-const httpProxyTestsURL = "http://explorer.ooni.io"
+const httpProxyTestsURL = "http://explorer.ooni.org"
 
 func httpProxyTestMain(t *testing.T, client *http.Client, expect int) {
 	req, err := http.NewRequest("GET", httpProxyTestsURL, nil)

--- a/testlists.go
+++ b/testlists.go
@@ -48,7 +48,7 @@ func (s *Session) QueryTestListsURLs(conf *TestListsURLsConfig) (*TestListsURLsR
 	if conf == nil {
 		return nil, errors.New("QueryTestListURLs: passed nil config")
 	}
-	baseURL := "https://orchestrate.ooni.io"
+	baseURL := "https://ps.ooni.io"
 	if conf.BaseURL != "" {
 		baseURL = conf.BaseURL
 	}


### PR DESCRIPTION
Prodded by @hellais. Will give us better performance. Yet, this is just
half of the job. I need to open a follow up issue suggesting that we should
always be using the same probe service that we selected. Otherwise, some
parts of our infra will be less resilient than others.

Such follow up issue is https://github.com/ooni/probe-engine/issues/651.