### PR TITLE
MOBILE/template.pem: make sure Bintray/JCenter accepts the POM

### DIFF
--- a/MOBILE/template.pom
+++ b/MOBILE/template.pom
@@ -6,4 +6,28 @@
   <artifactId>oonimkall</artifactId>
   <version>@VERSION@</version>
   <packaging>aar</packaging>
+  <name>oonimkall</name>
+  <description>OONI Probe Engine for Android</description>
+  <url>https://github.com/ooni/probe-engine</url>
+  <licenses>
+    <license>
+      <name>The 3-Clause BSD License</name>
+      <url>https://opensource.org/licenses/BSD-3-Clause</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/ooni/probe-engine</url>
+    <connection>https://github.com/ooni/probe-engine.git</connection>
+  </scm>
+  <developers>
+    <developer>
+      <name>Simone Basso</name>
+      <email>simone@openobservatory.org</email>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>Europe/Rome</timezone>
+    </developer>
+  </developers>
 </project>


### PR DESCRIPTION
I found a stackoverflow issue by @KilianB where he mentioned that, like me,
he could not upload their package to Bintray/JCenter:

https://stackoverflow.com/q/52459232

An answer mentioned that fields needed to be added to the POM but it was
not 100% clear to me what to put inside these fields.

So, I looked at the POM file of https://github.com/KilianB/pcg-java and
understood what values were required by fields.

(I could not find easily documentation explaining to me what POM fields are
required, what are not, and what their content should be <sadz>.)

After this change, Bintray/JCenter stopped saying that the POM file was
broken and instead told me that "the message was accepted".

As far as I know, the approval is manual and takes time, so this means we
are really making progress towards publishing on JCenter.

Related issue: https://github.com/ooni/probe-engine/issues/623.