### PR TITLE
urlgetter: add tcp_connect to test_keys

### DIFF
--- a/experiment/urlgetter/getter.go
+++ b/experiment/urlgetter/getter.go
@@ -40,6 +40,9 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 	tk.Requests = append(
 		tk.Requests, archival.NewRequestList(begin, events)...,
 	)
+	tk.TCPConnect = append(
+		tk.TCPConnect, archival.NewTCPConnectList(begin, events)...,
+	)
 	tk.TLSHandshakes = append(
 		tk.TLSHandshakes, archival.NewTLSHandshakesList(begin, events)...,
 	)

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -30,16 +30,17 @@ type Config struct {
 
 // TestKeys contains the experiment's result.
 type TestKeys struct {
-	Agent         string                   `json:"agent"`
-	BootstrapTime float64                  `json:"bootstrap_time,omitempty"`
-	DNSCache      []string                 `json:"dns_cache,omitempty"`
-	Failure       *string                  `json:"failure"`
-	NetworkEvents []archival.NetworkEvent  `json:"network_events"`
-	Queries       []archival.DNSQueryEntry `json:"queries"`
-	Requests      []archival.RequestEntry  `json:"requests"`
-	SOCKSProxy    string                   `json:"socksproxy,omitempty"`
-	TLSHandshakes []archival.TLSHandshake  `json:"tls_handshakes"`
-	Tunnel        string                   `json:"tunnel,omitempty"`
+	Agent         string                     `json:"agent"`
+	BootstrapTime float64                    `json:"bootstrap_time,omitempty"`
+	DNSCache      []string                   `json:"dns_cache,omitempty"`
+	Failure       *string                    `json:"failure"`
+	NetworkEvents []archival.NetworkEvent    `json:"network_events"`
+	Queries       []archival.DNSQueryEntry   `json:"queries"`
+	Requests      []archival.RequestEntry    `json:"requests"`
+	TCPConnect    []archival.TCPConnectEntry `json:"tcp_connect"`
+	SOCKSProxy    string                     `json:"socksproxy,omitempty"`
+	TLSHandshakes []archival.TLSHandshake    `json:"tls_handshakes"`
+	Tunnel        string                     `json:"tunnel,omitempty"`
 }
 
 // RegisterExtensions registers the extensions used by the urlgetter


### PR DESCRIPTION
This was planned inside https://github.com/ooni/probe-engine/issues/656.

It actually also helps with https://github.com/ooni/probe-engine/issues/646.