### PR TITLE
urlgetter: allow to configure the method

### DIFF
--- a/experiment/urlgetter/getter_test.go
+++ b/experiment/urlgetter/getter_test.go
@@ -71,6 +71,65 @@ func TestGetterWithCancelledContextVanilla(t *testing.T) {
 	}
 }
 
+func TestGetterWithCancelledContextAndMethod(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	g := urlgetter.Getter{
+		Config:  urlgetter.Config{Method: "POST"},
+		Session: &mockable.ExperimentSession{},
+		Target:  "https://www.google.com",
+	}
+	tk, err := g.Get(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("not the error we expected")
+	}
+	if tk.Agent != "redirect" {
+		t.Fatal("not the Agent we expected")
+	}
+	if tk.BootstrapTime != 0 {
+		t.Fatal("not the BootstrapTime we expected")
+	}
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+		t.Fatal("not the Failure we expected")
+	}
+	if len(tk.NetworkEvents) != 3 {
+		t.Fatal("not the NetworkEvents we expected")
+	}
+	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
+		t.Fatal("not the NetworkEvents[0].Operation we expected")
+	}
+	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+		t.Fatal("not the NetworkEvents[1].Operation we expected")
+	}
+	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
+		t.Fatal("not the NetworkEvents[2].Operation we expected")
+	}
+	if len(tk.Queries) != 0 {
+		t.Fatal("not the Queries we expected")
+	}
+	if len(tk.TCPConnect) != 0 {
+		t.Fatal("not the TCPConnect we expected")
+	}
+	if len(tk.Requests) != 1 {
+		t.Fatal("not the Requests we expected")
+	}
+	if tk.Requests[0].Request.Method != "POST" {
+		t.Fatal("not the Method we expected")
+	}
+	if tk.Requests[0].Request.URL != "https://www.google.com" {
+		t.Fatal("not the URL we expected")
+	}
+	if tk.SOCKSProxy != "" {
+		t.Fatal("not the SOCKSProxy we expected")
+	}
+	if len(tk.TLSHandshakes) != 0 {
+		t.Fatal("not the TLSHandshakes we expected")
+	}
+	if tk.Tunnel != "" {
+		t.Fatal("not the Tunnel we expected")
+	}
+}
+
 func TestGetterWithCancelledContextNoFollowRedirects(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/experiment/urlgetter/runner.go
+++ b/experiment/urlgetter/runner.go
@@ -43,7 +43,8 @@ func (r Runner) Run(ctx context.Context) error {
 }
 
 func (r Runner) httpGet(ctx context.Context, url string) error {
-	req, err := http.NewRequest("GET", url, nil)
+	// Implementation note: empty Method implies using the GET method
+	req, err := http.NewRequest(r.Config.Method, url, nil)
 	runtimex.PanicOnError(err, "http.NewRequest failed")
 	req = req.WithContext(ctx)
 	req.Header.Set("Accept", httpheader.RandomAccept())

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -19,6 +19,7 @@ const (
 type Config struct {
 	DNSCache          string `ooni:"Add 'DOMAIN IP...' to cache"`
 	HTTPHost          string `ooni:"Force using specific HTTP Host header"`
+	Method            string `ooni:"Force HTTP method different than GET"`
 	NoFollowRedirects bool   `ooni:"Disable following redirects"`
 	NoTLSVerify       bool   `ooni:"Disable TLS verification"`
 	RejectDNSBogons   bool   `ooni:"Fail DNS lookup if response contains bogons"`


### PR DESCRIPTION
We need this to reimplement the telegram experiment in terms of
the urlgetter experiment, to simplify the code.

See https://github.com/ooni/probe-engine/issues/646.