### PR TITLE
urlgetter: introduce the Multi urlgetter

### DIFF
--- a/experiment/urlgetter/multi.go
+++ b/experiment/urlgetter/multi.go
@@ -1,0 +1,127 @@
+package urlgetter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ooni/probe-engine/model"
+)
+
+// MultiInput is the input for Multi.Run().
+type MultiInput struct {
+	// Config contains the configuration for this target.
+	Config Config
+
+	// Target contains the target URL to measure.
+	Target string
+}
+
+// MultiOutput is the output returned by Multi.Run()
+type MultiOutput struct {
+	// Input is the input for which we measured.
+	Input MultiInput
+
+	// Err contains the measurement error.
+	Err error
+
+	// TestKeys contains the measured test keys.
+	TestKeys TestKeys
+}
+
+// MultiGetter allows to override the behaviour of Multi for testing purposes.
+type MultiGetter func(ctx context.Context, g Getter) (TestKeys, error)
+
+// defaultMultiGetter is the default MultiGetter
+func defaultMultiGetter(ctx context.Context, g Getter) (TestKeys, error) {
+	return g.Get(ctx)
+}
+
+// Multi allows to run several urlgetters in paraller.
+type Multi struct {
+	// Getter is the Getter func to be used. If this is nil we use
+	// the default getter, which is what you typically want.
+	Getter MultiGetter
+
+	// Parallelism is the optional parallelism to be used. If this is
+	// zero, or negative, we use a reasonable default.
+	Parallelism int
+
+	// Session is the session to be used. If this is nil, the Run
+	// method will panic with a nil pointer error.
+	Session model.ExperimentSession
+}
+
+// Run performs several urlgetters in parallel. This function returns a channel
+// where each result is posted. This function will always perform all the requested
+// measurements: if the ctx is canceled or its deadline expires, then you will see
+// a bunch of failed measurements. Since all measurements are always performed,
+// you know you're done when you've read len(inputs) results in output.
+func (m Multi) Run(ctx context.Context, inputs []MultiInput) <-chan MultiOutput {
+	parallelism := m.Parallelism
+	if parallelism <= 0 {
+		const defaultParallelism = 3
+		parallelism = defaultParallelism
+	}
+	inputch := make(chan MultiInput)
+	outputch := make(chan MultiOutput)
+	go m.source(inputs, inputch)
+	for i := 0; i < parallelism; i++ {
+		go m.do(ctx, inputch, outputch)
+	}
+	return outputch
+}
+
+// Collect prints on the output channel the result of running urlgetter
+// on every provided input. It closes the output channel when done.
+func (m Multi) Collect(ctx context.Context, inputs []MultiInput,
+	prefix string, callbacks model.ExperimentCallbacks) <-chan MultiOutput {
+	outputch := make(chan MultiOutput)
+	go m.collect(len(inputs), prefix, callbacks, m.Run(ctx, inputs), outputch)
+	return outputch
+}
+
+// collect drains inputch, prints progress, and emits to outputch. When done, this
+// function will close outputch to notify the calller.
+func (m Multi) collect(expect int, prefix string, callbacks model.ExperimentCallbacks,
+	inputch <-chan MultiOutput, outputch chan<- MultiOutput) {
+	var count int
+	defer close(outputch)
+	for count < expect {
+		entry := <-inputch
+		count++
+		percentage := float64(count) / float64(expect)
+		callbacks.OnProgress(percentage, fmt.Sprintf(
+			"%s: measure %s: %+v", prefix, entry.Input.Target, entry.Err,
+		))
+		outputch <- entry
+	}
+}
+
+// source posts all the inputs in the inputch. When done, this
+// method will close the input channel to notify the reader.
+func (m Multi) source(inputs []MultiInput, inputch chan<- MultiInput) {
+	defer close(inputch)
+	for _, input := range inputs {
+		inputch <- input
+	}
+}
+
+// do performs urlgetter on all the inputs read from the in channel and
+// writes the results on the out channel. If the context is canceled, or
+// its deadline expires, this function will continue performing all the
+// required measurements, which will all fail.
+func (m Multi) do(ctx context.Context, in <-chan MultiInput, out chan<- MultiOutput) {
+	for input := range in {
+		g := Getter{
+			Config:  input.Config,
+			Session: m.Session,
+			Target:  input.Target,
+		}
+		fn := m.Getter
+		if fn == nil {
+			fn = defaultMultiGetter
+		}
+		tk, err := fn(ctx, g)
+		out <- MultiOutput{Input: input, Err: err, TestKeys: tk}
+	}
+}

--- a/experiment/urlgetter/multi_test.go
+++ b/experiment/urlgetter/multi_test.go
@@ -1,0 +1,124 @@
+package urlgetter_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/experiment/handler"
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/internal/mockable"
+)
+
+func TestMultiIntegration(t *testing.T) {
+	multi := urlgetter.Multi{Session: &mockable.ExperimentSession{}}
+	inputs := []urlgetter.MultiInput{{
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.google.com",
+	}, {
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.facebook.com",
+	}, {
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.kernel.org",
+	}, {
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.instagram.com",
+	}}
+	outputs := multi.Collect(context.Background(), inputs, "integration-test",
+		handler.NewPrinterCallbacks(log.Log))
+	var count int
+	for result := range outputs {
+		count++
+		switch result.Input.Target {
+		case "https://www.google.com":
+		case "https://www.facebook.com":
+		case "https://www.kernel.org":
+		case "https://www.instagram.com":
+		default:
+			t.Fatal("unexpected Input.Target")
+		}
+		if result.Input.Config.Method != "HEAD" {
+			t.Fatal("unexpected Input.Config.Method")
+		}
+		if result.Err != nil {
+			t.Fatal(result.Err)
+		}
+		if result.TestKeys.Agent != "agent" {
+			t.Fatal("invalid TestKeys.Agent")
+		}
+		if len(result.TestKeys.Queries) != 2 {
+			t.Fatal("invalid number of Queries")
+		}
+		if len(result.TestKeys.Requests) != 1 {
+			t.Fatal("invalid number of Requests")
+		}
+		if len(result.TestKeys.TCPConnect) != 1 {
+			t.Fatal("invalid number of TCPConnects")
+		}
+		if len(result.TestKeys.TLSHandshakes) != 1 {
+			t.Fatal("invalid number of TLSHandshakes")
+		}
+	}
+	if count != 4 {
+		t.Fatal("invalid number of outputs")
+	}
+}
+
+func TestMultiContextCanceled(t *testing.T) {
+	multi := urlgetter.Multi{Session: &mockable.ExperimentSession{}}
+	inputs := []urlgetter.MultiInput{{
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.google.com",
+	}, {
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.facebook.com",
+	}, {
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.kernel.org",
+	}, {
+		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
+		Target: "https://www.instagram.com",
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	outputs := multi.Collect(ctx, inputs, "integration-test",
+		handler.NewPrinterCallbacks(log.Log))
+	var count int
+	for result := range outputs {
+		count++
+		switch result.Input.Target {
+		case "https://www.google.com":
+		case "https://www.facebook.com":
+		case "https://www.kernel.org":
+		case "https://www.instagram.com":
+		default:
+			t.Fatal("unexpected Input.Target")
+		}
+		if result.Input.Config.Method != "HEAD" {
+			t.Fatal("unexpected Input.Config.Method")
+		}
+		if !errors.Is(result.Err, context.Canceled) {
+			t.Fatal("unexpected error")
+		}
+		if result.TestKeys.Agent != "agent" {
+			t.Fatal("invalid TestKeys.Agent")
+		}
+		if len(result.TestKeys.Queries) != 0 {
+			t.Fatal("invalid number of Queries")
+		}
+		if len(result.TestKeys.Requests) != 1 {
+			t.Fatal("invalid number of Requests")
+		}
+		if len(result.TestKeys.TCPConnect) != 0 {
+			t.Fatal("invalid number of TCPConnects")
+		}
+		if len(result.TestKeys.TLSHandshakes) != 0 {
+			t.Fatal("invalid number of TLSHandshakes")
+		}
+	}
+	if count != 4 {
+		t.Fatal("invalid number of outputs")
+	}
+}


### PR DESCRIPTION
With the Multi urlgetter you can perform operations in parallel with a
specific degree of parallelism. You get results back as they arrive via
a channel that is returned on output.

We'll use this functionality pretty much soon to rewrite the Telegram
experiment in terms of the urlgetter experiment.

Reference issue: https://github.com/ooni/probe-engine/issues/646