### PR TITLE
netx/archival: extract the operation that failed

### DIFF
--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -115,6 +115,21 @@ func NewFailure(err error) *string {
 	return &s
 }
 
+// NewFailedOperation creates a failed operation string from the given error.
+func NewFailedOperation(err error) *string {
+	if err == nil {
+		return nil
+	}
+	var (
+		errWrapper *modelx.ErrWrapper
+		s          = modelx.UnknownOperation
+	)
+	if errors.As(err, &errWrapper) && errWrapper.Operation != "" {
+		s = errWrapper.Operation
+	}
+	return &s
+}
+
 // HTTPTor contains Tor information
 type HTTPTor struct {
 	ExitIP   *string `json:"exit_ip"`

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -914,3 +914,72 @@ func TestDNSQueryTypeInvalidIPOfType(t *testing.T) {
 		t.Fatal("unexpected return value")
 	}
 }
+
+func TestNewFailedOperation(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want *string
+	}{{
+		name: "With no error",
+		args: args{
+			err: nil, // explicit
+		},
+		want: nil, // explicit
+	}, {
+		name: "With wrapped error and non-empty operation",
+		args: args{
+			err: &modelx.ErrWrapper{
+				Failure:   modelx.FailureConnectionRefused,
+				Operation: modelx.ConnectOperation,
+			},
+		},
+		want: (func() *string {
+			s := modelx.ConnectOperation
+			return &s
+		})(),
+	}, {
+		name: "With wrapped error and empty operation",
+		args: args{
+			err: &modelx.ErrWrapper{
+				Failure: modelx.FailureConnectionRefused,
+			},
+		},
+		want: (func() *string {
+			s := modelx.UnknownOperation
+			return &s
+		})(),
+	}, {
+		name: "With non wrapped error",
+		args: args{
+			err: io.EOF,
+		},
+		want: (func() *string {
+			s := modelx.UnknownOperation
+			return &s
+		})(),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := archival.NewFailedOperation(tt.args.err)
+			if got == nil && tt.want == nil {
+				return
+			}
+			if got == nil && tt.want != nil {
+				t.Errorf("NewFailedOperation() = %v, want %v", got, tt.want)
+				return
+			}
+			if got != nil && tt.want == nil {
+				t.Errorf("NewFailedOperation() = %v, want %v", got, tt.want)
+				return
+			}
+			if got != nil && tt.want != nil && *got != *tt.want {
+				t.Errorf("NewFailedOperation() = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}

--- a/netx/modelx/modelx.go
+++ b/netx/modelx/modelx.go
@@ -136,6 +136,9 @@ const (
 
 	// WriteOperation is when we write to a socket
 	WriteOperation = "write"
+
+	// UnknownOperation is when we cannot determine the operation
+	UnknownOperation = "unknown"
 )
 
 // ErrWrapper is our error wrapper for Go errors. The key objective of


### PR DESCRIPTION
This will be useful to more easily classify the cause of blocking.

This is part of https://github.com/ooni/probe-engine/issues/646