### PR TITLE
urlgetter.TestKeys: add extra fields to simplify analysis

### DIFF
--- a/experiment/urlgetter/getter.go
+++ b/experiment/urlgetter/getter.go
@@ -47,6 +47,11 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 	tk.Requests = append(
 		tk.Requests, archival.NewRequestList(begin, events)...,
 	)
+	if len(tk.Requests) > 0 {
+		// OONI's convention is that the last request appears first
+		tk.HTTPResponseStatus = tk.Requests[0].Response.Code
+		tk.HTTPResponseBody = tk.Requests[0].Response.Body.Value
+	}
 	tk.TCPConnect = append(
 		tk.TCPConnect, archival.NewTCPConnectList(begin, events)...,
 	)

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -31,6 +31,7 @@ type Config struct {
 
 // TestKeys contains the experiment's result.
 type TestKeys struct {
+	// The following fields are part of the typical JSON emitted by OONI.
 	Agent           string                     `json:"agent"`
 	BootstrapTime   float64                    `json:"bootstrap_time,omitempty"`
 	DNSCache        []string                   `json:"dns_cache,omitempty"`
@@ -43,6 +44,11 @@ type TestKeys struct {
 	SOCKSProxy      string                     `json:"socksproxy,omitempty"`
 	TLSHandshakes   []archival.TLSHandshake    `json:"tls_handshakes"`
 	Tunnel          string                     `json:"tunnel,omitempty"`
+
+	// The following fields are not serialised but are useful to simplify
+	// analysing the measurements in telegram, etc.
+	HTTPResponseStatus int64  `json:"-"`
+	HTTPResponseBody   string `json:"-"`
 }
 
 // RegisterExtensions registers the extensions used by the urlgetter

--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -304,7 +304,7 @@ func addheaders(
 
 // NewRequestList returns the list for "requests"
 func NewRequestList(begin time.Time, events []trace.Event) []RequestEntry {
-	// OONI wants the least request to appear first
+	// OONI wants the last request to appear first
 	var out []RequestEntry
 	tmp := newRequestList(begin, events)
 	for i := len(tmp) - 1; i >= 0; i-- {


### PR DESCRIPTION
We often need to check the status code of the last response in the chain
and/or to see the body of such response.

To simplify these use cases, introduce two new variables that contain such
values. These variables are not JSON serialised, because it does not make
sense for us to do that. One can always recompute these fields, and the point
of this patch is just to avoid duplicating code.

Added an extra integration test to make sure that the value of these new
variables is okay not only when the context is canceled but also when we're
not doing HTTP but something else, e.g., just TLS.

Part of https://github.com/ooni/probe-engine/issues/646.

We will use this new code to simplify post processing of Telegram results.