### PR TITLE
netx/errorx: wrap context.Canceled

### DIFF
--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -287,7 +287,7 @@ func TestUnitDefautFlexibleConnectDirPort(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
-	if !strings.HasSuffix(err.Error(), "context canceled") {
+	if !strings.HasSuffix(err.Error(), "interrupted") {
 		t.Fatal("not the error we expected")
 	}
 	if tk.HTTPRequests == nil {

--- a/experiment/urlgetter/getter_test.go
+++ b/experiment/urlgetter/getter_test.go
@@ -34,7 +34,7 @@ func TestGetterWithCancelledContextVanilla(t *testing.T) {
 	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
-	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
 		t.Fatal("not the Failure we expected")
 	}
 	if len(tk.NetworkEvents) != 3 {
@@ -102,7 +102,7 @@ func TestGetterWithCancelledContextAndMethod(t *testing.T) {
 	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
-	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
 		t.Fatal("not the Failure we expected")
 	}
 	if len(tk.NetworkEvents) != 3 {
@@ -172,7 +172,7 @@ func TestGetterWithCancelledContextNoFollowRedirects(t *testing.T) {
 	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
-	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
 		t.Fatal("not the Failure we expected")
 	}
 	if len(tk.NetworkEvents) != 3 {
@@ -300,7 +300,7 @@ func TestGetterWithCancelledContextWithTunnel(t *testing.T) {
 	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
-	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "context canceled") {
+	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
 		t.Fatal("not the Failure we expected")
 	}
 	if len(tk.NetworkEvents) != 3 {

--- a/netx/errorx/errorx.go
+++ b/netx/errorx/errorx.go
@@ -2,6 +2,7 @@
 package errorx
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -56,6 +57,9 @@ func toFailureString(err error) string {
 
 	if errors.Is(err, modelx.ErrDNSBogon) {
 		return modelx.FailureDNSBogonError // not in MK
+	}
+	if errors.Is(err, context.Canceled) {
+		return modelx.FailureInterrupted
 	}
 
 	var x509HostnameError x509.HostnameError

--- a/netx/errorx/errorx_test.go
+++ b/netx/errorx/errorx_test.go
@@ -54,6 +54,11 @@ func TestToFailureString(t *testing.T) {
 			t.Fatal("unexpected result")
 		}
 	})
+	t.Run("for context.Canceled", func(t *testing.T) {
+		if toFailureString(context.Canceled) != modelx.FailureInterrupted {
+			t.Fatal("unexpected result")
+		}
+	})
 	t.Run("for x509.HostnameError", func(t *testing.T) {
 		var err x509.HostnameError
 		if toFailureString(err) != modelx.FailureSSLInvalidHostname {

--- a/netx/modelx/modelx.go
+++ b/netx/modelx/modelx.go
@@ -104,6 +104,9 @@ const (
 	// FailureGenericTimeoutError means we got some timer has expired.
 	FailureGenericTimeoutError = "generic_timeout_error"
 
+	// FailureInterrupted means that the user interrupted us.
+	FailureInterrupted = "interrupted"
+
 	// FailureSSLInvalidHostname means we got certificate is not valid for SNI.
 	FailureSSLInvalidHostname = "ssl_invalid_hostname"
 


### PR DESCRIPTION
Like for MK errors, use the same naming of the C++11 library.

This error will happen when the mobile app will interrupt specific
tests, so better to have a clear naming for it.

Part of https://github.com/ooni/probe-engine/issues/646.