### PR TITLE
rename: internal/jsonapi => internal/httpx

### DIFF
--- a/experiment_test.go
+++ b/experiment_test.go
@@ -569,7 +569,7 @@ func TestOpenReportFailure(t *testing.T) {
 		Type:    "https",
 	}
 	err = exp.OpenReport()
-	if !strings.HasPrefix(err.Error(), "jsonapi: request failed") {
+	if !strings.HasPrefix(err.Error(), "httpx: request failed") {
 		t.Fatal("not the error we expected")
 	}
 }

--- a/geoiplookup/iplookup/avast/avast.go
+++ b/geoiplookup/iplookup/avast/avast.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -21,12 +21,12 @@ func Do(
 	userAgent string,
 ) (string, error) {
 	var v response
-	err := (&jsonapi.Client{
+	err := (&httpx.Client{
 		BaseURL:    "https://ip-info.ff.avast.com",
 		HTTPClient: httpClient,
 		Logger:     logger,
 		UserAgent:  userAgent,
-	}).Read(ctx, "/v1/info", &v)
+	}).ReadJSON(ctx, "/v1/info", &v)
 	if err != nil {
 		return model.DefaultProbeIP, err
 	}

--- a/internal/httpx/fake_test.go
+++ b/internal/httpx/fake_test.go
@@ -1,4 +1,4 @@
-package jsonapi
+package httpx
 
 import (
 	"io/ioutil"

--- a/internal/orchestra/login.go
+++ b/internal/orchestra/login.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -33,12 +33,12 @@ type LoginAuth struct {
 // Login logs this probe in with OONI orchestra
 func Login(ctx context.Context, config LoginConfig) (*LoginAuth, error) {
 	var resp LoginAuth
-	err := (&jsonapi.Client{
+	err := (&httpx.Client{
 		BaseURL:    config.BaseURL,
 		HTTPClient: config.HTTPClient,
 		Logger:     config.Logger,
 		UserAgent:  config.UserAgent,
-	}).Create(ctx, "/api/v1/login", config.Credentials, &resp)
+	}).CreateJSON(ctx, "/api/v1/login", config.Credentials, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/orchestra/register.go
+++ b/internal/orchestra/register.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -35,12 +35,12 @@ func Register(ctx context.Context, config RegisterConfig) (*RegisterResult, erro
 		Password: config.Password,
 	}
 	var resp RegisterResult
-	err := (&jsonapi.Client{
+	err := (&httpx.Client{
 		BaseURL:    config.BaseURL,
 		HTTPClient: config.HTTPClient,
 		Logger:     config.Logger,
 		UserAgent:  config.UserAgent,
-	}).Create(ctx, "/api/v1/register", req, &resp)
+	}).CreateJSON(ctx, "/api/v1/register", req, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/orchestra/tor.go
+++ b/internal/orchestra/tor.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -25,12 +25,12 @@ func TorQuery(ctx context.Context, config TorConfig) (result map[string]model.To
 		return nil, errors.New("config.Auth is nil")
 	}
 	authorization := fmt.Sprintf("Bearer %s", config.Auth.Token)
-	err = (&jsonapi.Client{
+	err = (&httpx.Client{
 		Authorization: authorization,
 		BaseURL:       config.BaseURL,
 		HTTPClient:    config.HTTPClient,
 		Logger:        config.Logger,
 		UserAgent:     config.UserAgent,
-	}).Read(ctx, "/api/v1/test-list/tor-targets", &result)
+	}).ReadJSON(ctx, "/api/v1/test-list/tor-targets", &result)
 	return
 }

--- a/internal/orchestra/update.go
+++ b/internal/orchestra/update.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -34,11 +34,11 @@ func Update(ctx context.Context, config UpdateConfig) error {
 	req := &updateRequest{Metadata: config.Metadata}
 	var resp struct{}
 	urlpath := fmt.Sprintf("/api/v1/update/%s", config.ClientID)
-	return (&jsonapi.Client{
+	return (&httpx.Client{
 		Authorization: authorization,
 		BaseURL:       config.BaseURL,
 		HTTPClient:    config.HTTPClient,
 		Logger:        config.Logger,
 		UserAgent:     config.UserAgent,
-	}).Update(ctx, urlpath, req, &resp)
+	}).UpdateJSON(ctx, urlpath, req, &resp)
 }

--- a/internal/orchestra/urls.go
+++ b/internal/orchestra/urls.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -40,12 +40,12 @@ func URLsQuery(ctx context.Context, config URLsConfig) (*URLsResult, error) {
 		query.Set("category_codes", strings.Join(config.EnabledCategories, ","))
 	}
 	var response URLsResult
-	err := (&jsonapi.Client{
+	err := (&httpx.Client{
 		BaseURL:    config.BaseURL,
 		HTTPClient: config.HTTPClient,
 		Logger:     config.Logger,
 		UserAgent:  config.UserAgent,
-	}).ReadWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
+	}).ReadJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -16,13 +16,13 @@ import (
 // GetCollectors queries the bouncer for collectors. Returns a list of
 // entries on success; an error on failure.
 func (c Client) GetCollectors(ctx context.Context) (output []model.Service, err error) {
-	err = c.Client.Read(ctx, "/api/v1/collectors", &output)
+	err = c.Client.ReadJSON(ctx, "/api/v1/collectors", &output)
 	return
 }
 
 // GetTestHelpers is like GetCollectors but for test helpers.
 func (c Client) GetTestHelpers(
 	ctx context.Context) (output map[string][]model.Service, err error) {
-	err = c.Client.Read(ctx, "/api/v1/test-helpers", &output)
+	err = c.Client.ReadJSON(ctx, "/api/v1/test-helpers", &output)
 	return
 }

--- a/probeservices/client.go
+++ b/probeservices/client.go
@@ -6,14 +6,14 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/internal/orchestra"
 	"github.com/ooni/probe-engine/model"
 )
 
 // Client is a client for the OONI probe services API.
 type Client struct {
-	jsonapi.Client
+	httpx.Client
 	StateFile *orchestra.StateFile
 }
 
@@ -31,7 +31,7 @@ var (
 // NewClient creates a new client for the specified probe services endpoint.
 func NewClient(sess model.ExperimentSession, endpoint model.Service) (*Client, error) {
 	client := &Client{
-		Client: jsonapi.Client{
+		Client: httpx.Client{
 			BaseURL:    endpoint.Address,
 			HTTPClient: sess.DefaultHTTPClient(),
 			Logger:     sess.Logger(),

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -71,7 +71,7 @@ func (c Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, err
 		return nil, errors.New("Unsupported format")
 	}
 	var or openResponse
-	err := c.Client.Create(ctx, "/report", rt, &or)
+	err := c.Client.CreateJSON(ctx, "/report", rt, &or)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ type updateResponse struct {
 func (r Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse updateResponse
 	m.ReportID = r.ID
-	err := r.client.Client.Create(
+	err := r.client.Client.CreateJSON(
 		ctx, fmt.Sprintf("/report/%s", r.ID), updateRequest{
 			Format:  "json",
 			Content: m,
@@ -118,7 +118,7 @@ func (r Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) err
 // Close closes the report. Returns nil on success; an error on failure.
 func (r Report) Close(ctx context.Context) error {
 	var input, output struct{}
-	err := r.client.Client.Create(
+	err := r.client.Client.CreateJSON(
 		ctx, fmt.Sprintf("/report/%s/close", r.ID), input, &output,
 	)
 	// Implementation note: the server is not compliant with

--- a/probeservices/collector_test.go
+++ b/probeservices/collector_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-engine/internal/jsonapi"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/probeservices"
 )
@@ -44,7 +44,7 @@ func makeMeasurement(rt probeservices.ReportTemplate, ID string) model.Measureme
 
 func makeClient() probeservices.Client {
 	return probeservices.Client{
-		Client: jsonapi.Client{
+		Client: httpx.Client{
 			BaseURL:    "https://ps-test.ooni.io/",
 			HTTPClient: http.DefaultClient,
 			Logger:     log.Log,


### PR DESCRIPTION
To merge orchestra and probeservices, I also need to merge the two
supporting packages: jsonapi and fetch.

Specifically, we need to make fetch as cool as jsonapi and support also
cloudfronted and proxying via Tor/psiphon etc.

To this end, rename jsonapi to httpx, and start renaming the methods
such that it's clear that they deal with JSON input/output.

The next step will be to merge fetch with httpx.

Part of https://github.com/ooni/probe-engine/issues/651.