### PR TITLE
orchestra: remove distinction between registry and orchestra base URLs

### DIFF
--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -101,8 +101,7 @@ func (sess *ExperimentSession) NewOrchestraClient(ctx context.Context) (model.Ex
 		"miniooni/0.1.0-dev",
 		orchestra.NewStateFile(kvstore.NewMemoryKeyValueStore()),
 	)
-	clnt.OrchestrateBaseURL = "https://ps-test.ooni.io"
-	clnt.RegistryBaseURL = "https://ps-test.ooni.io"
+	clnt.BaseURL = "https://ps-test.ooni.io"
 	meta := OrchestraMetadataFixture()
 	if err := clnt.MaybeRegister(ctx, meta); err != nil {
 		return nil, err

--- a/internal/orchestra/orchestra.go
+++ b/internal/orchestra/orchestra.go
@@ -17,14 +17,13 @@ import (
 
 // Client is a client for OONI orchestra
 type Client struct {
-	HTTPClient         *http.Client
-	Logger             model.Logger
-	LoginCalls         *atomicx.Int64
-	OrchestrateBaseURL string
-	RegisterCalls      *atomicx.Int64
-	RegistryBaseURL    string
-	StateFile          *StateFile
-	UserAgent          string
+	BaseURL       string
+	HTTPClient    *http.Client
+	Logger        model.Logger
+	LoginCalls    *atomicx.Int64
+	RegisterCalls *atomicx.Int64
+	StateFile     *StateFile
+	UserAgent     string
 }
 
 // NewClient creates a new client.
@@ -33,14 +32,13 @@ func NewClient(
 	userAgent string, stateFile *StateFile,
 ) *Client {
 	return &Client{
-		HTTPClient:         httpClient,
-		Logger:             logger,
-		LoginCalls:         atomicx.NewInt64(),
-		OrchestrateBaseURL: "https://ps.ooni.io",
-		RegisterCalls:      atomicx.NewInt64(),
-		RegistryBaseURL:    "https://ps.ooni.io",
-		StateFile:          stateFile,
-		UserAgent:          userAgent,
+		BaseURL:       "https://ps.ooni.io",
+		HTTPClient:    httpClient,
+		Logger:        logger,
+		LoginCalls:    atomicx.NewInt64(),
+		RegisterCalls: atomicx.NewInt64(),
+		StateFile:     stateFile,
+		UserAgent:     userAgent,
 	}
 }
 
@@ -64,7 +62,7 @@ func (c *Client) MaybeRegister(
 	c.RegisterCalls.Add(1)
 	pwd := randomPassword(64)
 	result, err := Register(ctx, RegisterConfig{
-		BaseURL:    c.RegistryBaseURL,
+		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
 		Logger:     c.Logger,
 		Metadata:   metadata,
@@ -91,7 +89,7 @@ func (c *Client) MaybeLogin(ctx context.Context) error {
 	}
 	c.LoginCalls.Add(1)
 	auth, err := Login(ctx, LoginConfig{
-		BaseURL:     c.RegistryBaseURL,
+		BaseURL:     c.BaseURL,
 		Credentials: *creds,
 		HTTPClient:  c.HTTPClient,
 		Logger:      c.Logger,
@@ -131,7 +129,7 @@ func (c *Client) Update(
 	}
 	return Update(context.Background(), UpdateConfig{
 		Auth:       auth,
-		BaseURL:    c.OrchestrateBaseURL,
+		BaseURL:    c.BaseURL,
 		ClientID:   creds.ClientID,
 		HTTPClient: c.HTTPClient,
 		Logger:     c.Logger,
@@ -148,7 +146,7 @@ func (c *Client) FetchPsiphonConfig(ctx context.Context) ([]byte, error) {
 	}
 	return PsiphonQuery(ctx, PsiphonConfig{
 		Auth:       auth,
-		BaseURL:    c.OrchestrateBaseURL,
+		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
 		Logger:     c.Logger,
 		UserAgent:  c.UserAgent,
@@ -163,7 +161,7 @@ func (c *Client) FetchTorTargets(ctx context.Context) (map[string]model.TorTarge
 	}
 	return TorQuery(ctx, TorConfig{
 		Auth:       auth,
-		BaseURL:    c.OrchestrateBaseURL,
+		BaseURL:    c.BaseURL,
 		HTTPClient: c.HTTPClient,
 		Logger:     c.Logger,
 		UserAgent:  c.UserAgent,

--- a/internal/orchestra/orchestra_test.go
+++ b/internal/orchestra/orchestra_test.go
@@ -57,7 +57,7 @@ func TestUnitMaybeRegister(t *testing.T) {
 	})
 	t.Run("when the API call fails", func(t *testing.T) {
 		clnt := newclient()
-		clnt.RegistryBaseURL = "\t\t\t"
+		clnt.BaseURL = "\t\t\t"
 		ctx := context.Background()
 		metadata := mockable.OrchestraMetadataFixture()
 		if err := clnt.MaybeRegister(ctx, metadata); err == nil {
@@ -111,7 +111,7 @@ func TestUnitMaybeLogin(t *testing.T) {
 	})
 	t.Run("when the API call fails", func(t *testing.T) {
 		clnt := newclient()
-		clnt.RegistryBaseURL = "\t\t\t"
+		clnt.BaseURL = "\t\t\t"
 		state := orchestra.State{
 			ClientID: "xx-xxx-x-xxxx",
 			Password: "xx",
@@ -184,7 +184,7 @@ func TestUnitUpdate(t *testing.T) {
 	})
 	t.Run("when the API call fails", func(t *testing.T) {
 		clnt := newclient()
-		clnt.RegistryBaseURL = "\t\t\t"
+		clnt.BaseURL = "\t\t\t"
 		state := orchestra.State{
 			ClientID: "xx-xxx-x-xxxx",
 			Expire:   time.Now().Add(time.Hour),
@@ -284,7 +284,6 @@ func newclient() *orchestra.Client {
 		"miniooni/0.1.0-dev",
 		orchestra.NewStateFile(kvstore.NewMemoryKeyValueStore()),
 	)
-	clnt.OrchestrateBaseURL = "https://ps-test.ooni.io"
-	clnt.RegistryBaseURL = "https://ps-test.ooni.io"
+	clnt.BaseURL = "https://ps-test.ooni.io"
 	return clnt
 }


### PR DESCRIPTION
We're using probe-services now, so there's no need to distinguish.

Part of https://github.com/ooni/probe-engine/issues/651.