### PR TITLE
internal/orchestra: rewrite to have same constructor as probeservices

### DIFF
--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -3,6 +3,7 @@ package tor
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -476,5 +477,8 @@ func TestUnitFillToplevelKeys(t *testing.T) {
 }
 
 func newsession() model.ExperimentSession {
-	return &mockable.ExperimentSession{MockableLogger: log.Log}
+	return &mockable.ExperimentSession{
+		MockableLogger:     log.Log,
+		MockableHTTPClient: http.DefaultClient,
+	}
 }

--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/apex/log"
 	"github.com/ooni/probe-engine/internal/kvstore"
 	"github.com/ooni/probe-engine/internal/orchestra"
+	"github.com/ooni/probe-engine/internal/runtimex"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -95,13 +95,11 @@ func (sess *ExperimentSession) NewOrchestraClient(ctx context.Context) (model.Ex
 	if sess.MockableOrchestraClientError != nil {
 		return nil, sess.MockableOrchestraClientError
 	}
-	clnt := orchestra.NewClient(
-		http.DefaultClient,
-		log.Log,
-		"miniooni/0.1.0-dev",
-		orchestra.NewStateFile(kvstore.NewMemoryKeyValueStore()),
-	)
-	clnt.BaseURL = "https://ps-test.ooni.io"
+	clnt, err := orchestra.NewClient(sess, model.Service{
+		Address: "https://ps-test.ooni.io/",
+		Type:    "https",
+	})
+	runtimex.PanicOnError(err, "orchestra.NewClient should not fail here")
 	meta := OrchestraMetadataFixture()
 	if err := clnt.MaybeRegister(ctx, meta); err != nil {
 		return nil, err

--- a/internal/orchestra/orchestra_test.go
+++ b/internal/orchestra/orchestra_test.go
@@ -4,17 +4,23 @@ import (
 	"net/http"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-engine/atomicx"
+	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/internal/kvstore"
 	"github.com/ooni/probe-engine/internal/orchestra"
 )
 
 func newclient() *orchestra.Client {
-	clnt := orchestra.NewClient(
-		http.DefaultClient,
-		log.Log,
-		"miniooni/0.1.0-dev",
-		orchestra.NewStateFile(kvstore.NewMemoryKeyValueStore()),
-	)
-	clnt.BaseURL = "https://ps-test.ooni.io"
-	return clnt
+	client := &orchestra.Client{
+		Client: httpx.Client{
+			BaseURL:    "https://ps-test.ooni.io/",
+			HTTPClient: http.DefaultClient,
+			Logger:     log.Log,
+			UserAgent:  "miniooni/0.1.0",
+		},
+		LoginCalls:    atomicx.NewInt64(),
+		RegisterCalls: atomicx.NewInt64(),
+		StateFile:     orchestra.NewStateFile(kvstore.NewMemoryKeyValueStore()),
+	}
+	return client
 }

--- a/session.go
+++ b/session.go
@@ -258,12 +258,11 @@ func (s *Session) NewExperimentBuilder(name string) (*ExperimentBuilder, error) 
 // NewOrchestraClient creates a new orchestra client. This client is registered
 // and logged in with the OONI orchestra. An error is returned on failure.
 func (s *Session) NewOrchestraClient(ctx context.Context) (model.ExperimentOrchestraClient, error) {
-	clnt := orchestra.NewClient(
-		s.DefaultHTTPClient(),
-		s.logger,
-		s.UserAgent(),
-		orchestra.NewStateFile(s.kvStore),
-	)
+	clnt, err := orchestra.NewClient(s, model.Service{
+		Address: "https://ps.ooni.io/",
+		Type:    "https",
+	})
+	runtimex.PanicOnError(err, "orchestra.NewClient should not fail here")
 	return s.initOrchestraClient(
 		ctx, clnt, clnt.MaybeLogin,
 	)

--- a/session_test.go
+++ b/session_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
-	"github.com/ooni/probe-engine/internal/kvstore"
 	"github.com/ooni/probe-engine/internal/orchestra"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/probeservices"
@@ -176,12 +175,13 @@ func TestUnitInitOrchestraClientMaybeRegisterError(t *testing.T) {
 	cancel() // so we fail immediately
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
-	clnt := orchestra.NewClient(
-		sess.DefaultHTTPClient(),
-		sess.Logger(),
-		sess.UserAgent(),
-		orchestra.NewStateFile(kvstore.NewMemoryKeyValueStore()),
-	)
+	clnt, err := orchestra.NewClient(sess, model.Service{
+		Address: "https://ps-test.ooni.io/",
+		Type:    "https",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	outclnt, err := sess.initOrchestraClient(
 		ctx, clnt, clnt.MaybeLogin,
 	)
@@ -197,12 +197,13 @@ func TestUnitInitOrchestraClientMaybeLoginError(t *testing.T) {
 	ctx := context.Background()
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
-	clnt := orchestra.NewClient(
-		sess.DefaultHTTPClient(),
-		sess.Logger(),
-		sess.UserAgent(),
-		orchestra.NewStateFile(kvstore.NewMemoryKeyValueStore()),
-	)
+	clnt, err := orchestra.NewClient(sess, model.Service{
+		Address: "https://ps-test.ooni.io/",
+		Type:    "https",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	expected := errors.New("mocked error")
 	outclnt, err := sess.initOrchestraClient(
 		ctx, clnt, func(context.Context) error {


### PR DESCRIPTION
This should be one of the last steps. The orchestra client and the probeservices
client now have basically the same fields and the same constructor.

This means that it should be possible, in a follow-up step, to merge them.

In this diff, I am slightly reducing the code coverage. This will be amended in
a follow-up PR, once I have merged orchestra into probeservices.

Part of https://github.com/ooni/probe-engine/issues/651