### PR TITLE
probeservices: sketch out new API to access test lists

### DIFF
--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -165,6 +165,8 @@ type ExperimentOrchestraClient struct {
 	MockableFetchPsiphonConfigErr    error
 	MockableFetchTorTargetsResult    map[string]model.TorTarget
 	MockableFetchTorTargetsErr       error
+	MockableFetchURLListResult       []model.URLInfo
+	MockableFetchURLListErr          error
 }
 
 // FetchPsiphonConfig implements ExperimentOrchestraClient.FetchPsiphonConfig
@@ -177,6 +179,12 @@ func (c ExperimentOrchestraClient) FetchPsiphonConfig(
 func (c ExperimentOrchestraClient) FetchTorTargets(
 	ctx context.Context) (map[string]model.TorTarget, error) {
 	return c.MockableFetchTorTargetsResult, c.MockableFetchTorTargetsErr
+}
+
+// FetchURLList implements ExperimentOrchestraClient.FetchURLList.
+func (c ExperimentOrchestraClient) FetchURLList(
+	ctx context.Context, config model.URLListConfig) ([]model.URLInfo, error) {
+	return c.MockableFetchURLListResult, c.MockableFetchURLListErr
 }
 
 var _ model.ExperimentOrchestraClient = ExperimentOrchestraClient{}

--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -321,11 +321,14 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 	if builder.InputPolicy() == engine.InputRequired {
 		if len(currentOptions.Inputs) <= 0 {
 			log.Info("Fetching test lists")
-			list, err := sess.QueryTestListsURLs(&engine.TestListsURLsConfig{
-				Limit: 16,
+			client, err := sess.NewOrchestraClient(context.Background())
+			fatalOnError(err, "cannot create new orchestra client")
+			list, err := client.FetchURLList(context.Background(), model.URLListConfig{
+				CountryCode: sess.ProbeCC(),
+				Limit:       17,
 			})
 			fatalOnError(err, "cannot fetch test lists")
-			for _, entry := range list.Result {
+			for _, entry := range list {
 				currentOptions.Inputs = append(currentOptions.Inputs, entry.URL)
 			}
 		}

--- a/model/model.go
+++ b/model/model.go
@@ -346,11 +346,19 @@ type Logger interface {
 	Warnf(format string, v ...interface{})
 }
 
+// URLListConfig contains configuration for fetching the URL list.
+type URLListConfig struct {
+	Categories  []string // Categories to query for (empty means all)
+	CountryCode string   // CountryCode is the optional country code
+	Limit       int64    // Max number of URLs (<= 0 means no limit)
+}
+
 // ExperimentOrchestraClient is the experiment's view of
-// a client for querying the OONI orchestra.
+// a client for querying the OONI orchestra API.
 type ExperimentOrchestraClient interface {
 	FetchPsiphonConfig(ctx context.Context) ([]byte, error)
 	FetchTorTargets(ctx context.Context) (map[string]TorTarget, error)
+	FetchURLList(ctx context.Context, config URLListConfig) ([]URLInfo, error)
 }
 
 // ExperimentSession is the experiment's view of a session.

--- a/probeservices/urls.go
+++ b/probeservices/urls.go
@@ -30,12 +30,7 @@ func (c Client) FetchURLList(ctx context.Context, config model.URLListConfig) ([
 		query.Set("category_codes", strings.Join(config.Categories, ","))
 	}
 	var response urlListResult
-	err := (httpx.Client{
-		BaseURL:    c.BaseURL,
-		HTTPClient: c.HTTPClient,
-		Logger:     c.Logger,
-		UserAgent:  c.UserAgent,
-	}).ReadJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
+	err := c.Client.ReadJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/probeservices/urls.go
+++ b/probeservices/urls.go
@@ -11,7 +11,40 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
+type urlListResult struct {
+	Results []model.URLInfo `json:"results"`
+}
+
+// FetchURLList fetches the list of URLs used by WebConnectivity. The config
+// argument contains the optional settings. Returns the list of URLs, on success,
+// or an explanatory error, in case of failure.
+func (c Client) FetchURLList(ctx context.Context, config model.URLListConfig) ([]model.URLInfo, error) {
+	query := url.Values{}
+	if config.CountryCode != "" {
+		query.Set("probe_cc", config.CountryCode)
+	}
+	if config.Limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", config.Limit))
+	}
+	if len(config.Categories) > 0 {
+		query.Set("category_codes", strings.Join(config.Categories, ","))
+	}
+	var response urlListResult
+	err := (httpx.Client{
+		BaseURL:    c.BaseURL,
+		HTTPClient: c.HTTPClient,
+		Logger:     c.Logger,
+		UserAgent:  c.UserAgent,
+	}).ReadJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
+	if err != nil {
+		return nil, err
+	}
+	return response.Results, nil
+}
+
 // URLsConfig contains configs for querying tests-lists/urls
+//
+// This structure is deprecated and will be removed in the future.
 type URLsConfig struct {
 	BaseURL           string
 	CountryCode       string
@@ -23,11 +56,13 @@ type URLsConfig struct {
 }
 
 // URLsResult contains the result returned by tests-lists/urls
-type URLsResult struct {
-	Results []model.URLInfo `json:"results"`
-}
+//
+// This structure is deprecated and will be removed in the future.
+type URLsResult urlListResult
 
 // URLsQuery retrieves the test list for the specified country.
+//
+// This function is deprecated and will be removed in the future.
 func URLsQuery(ctx context.Context, config URLsConfig) (*URLsResult, error) {
 	query := url.Values{}
 	if config.CountryCode != "" {

--- a/probeservices/urls_test.go
+++ b/probeservices/urls_test.go
@@ -3,11 +3,54 @@ package probeservices_test
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/probeservices"
 )
+
+func TestFetchURLListSuccess(t *testing.T) {
+	client := newclient()
+	client.BaseURL = "https://ps.ooni.io" // ps-test.ooni.io is broken
+	config := model.URLListConfig{
+		Categories:  []string{"NEWS", "CULTR"},
+		CountryCode: "IT",
+		Limit:       17,
+	}
+	ctx := context.Background()
+	result, err := client.FetchURLList(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 17 {
+		t.Fatal("unexpected number of results")
+	}
+	for _, entry := range result {
+		if entry.CategoryCode != "NEWS" && entry.CategoryCode != "CULTR" {
+			t.Fatal("unexpected category code")
+		}
+	}
+}
+
+func TestFetchURLListFailure(t *testing.T) {
+	client := newclient()
+	client.BaseURL = "https://\t\t\t/" // cause test to fail
+	config := model.URLListConfig{
+		Categories:  []string{"NEWS", "CULTR"},
+		CountryCode: "IT",
+		Limit:       17,
+	}
+	ctx := context.Background()
+	result, err := client.FetchURLList(ctx, config)
+	if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
+		t.Fatal("not the error we expected")
+	}
+	if len(result) != 0 {
+		t.Fatal("results?!")
+	}
+}
 
 func TestURLsSuccess(t *testing.T) {
 	config := probeservices.URLsConfig{

--- a/testlists.go
+++ b/testlists.go
@@ -8,10 +8,9 @@ import (
 	"github.com/ooni/probe-engine/probeservices"
 )
 
-// TODO(bassosimone): this API can probably be deprecated in
-// favour of always using session.NewOrchestraClient.
-
 // TestListsURLsConfig config config for test-lists/urls API.
+//
+// This structure is deprecated and will be removed in the future.
 type TestListsURLsConfig struct {
 	BaseURL    string   // URL to use (empty means default)
 	Categories []string // Categories to query for (empty means all)
@@ -20,22 +19,30 @@ type TestListsURLsConfig struct {
 
 // AddCategory adds a category to the list of categories to query. Not
 // adding any categories will query for URLs in all categories.
+//
+// This function is deprecated and will be removed in the future.
 func (c *TestListsURLsConfig) AddCategory(s string) {
 	c.Categories = append(c.Categories, s)
 }
 
 // TestListsURLsResult contains the results of calling the
 // test-lists/urls OONI orchestra API.
+//
+// This structure is deprecated and will be removed in the future.
 type TestListsURLsResult struct {
 	Result []model.URLInfo
 }
 
 // Count returns the number of returned URLs
+//
+// This function is deprecated and will be removed in the future.
 func (r *TestListsURLsResult) Count() int64 {
 	return int64(len(r.Result))
 }
 
 // At returns the URL at the given index or nil
+//
+// This function is deprecated and will be removed in the future.
 func (r *TestListsURLsResult) At(idx int64) (out *model.URLInfo) {
 	if idx >= 0 && idx < int64(len(r.Result)) {
 		out = &r.Result[int(idx)]
@@ -44,6 +51,9 @@ func (r *TestListsURLsResult) At(idx int64) (out *model.URLInfo) {
 }
 
 // QueryTestListsURLs queries the test-lists/urls API.
+//
+// This function is deprecated and will be removed in the future. Please
+// create and use a new orchestra client using the session instead.
 func (s *Session) QueryTestListsURLs(conf *TestListsURLsConfig) (*TestListsURLsResult, error) {
 	if conf == nil {
 		return nil, errors.New("QueryTestListURLs: passed nil config")


### PR DESCRIPTION
I want to replace the old test-list/urls API with this new API. The main
reason for doing so is that the new API uses the OrchestraClient instance
return by the session. The nice property of such client is that it will
use the endpoint we have settled to use when doing the selection of the best
probe service. Therefore, this would allow the apps to use either the fastest
service or the right circumvention method.

As part of merging this diff, I shall also create an issue about making sure
all users of the old API are migrated to the new API, such that we can remove
the old API. For now, the old API is just marked as deprecated.

Part of https://github.com/ooni/probe-engine/issues/651.