### PR TITLE
probeservices: remove bouncer GetCollector API

### DIFF
--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -6,7 +6,7 @@
 // We additionally implement v2.0.0 of the OONI collector specification defined
 // in https://github.com/ooni/spec/blob/master/backends/bk-003-collector.md.
 //
-// We additonally implement the orchestra API. Orchestra is a set of                         
+// We additonally implement the orchestra API. Orchestra is a set of
 // OONI APIs for probe orchestration. We currently mainly using it for
 // fetching inputs for the tor, psiphon, and web experiments.
 package probeservices
@@ -16,13 +16,6 @@ import (
 
 	"github.com/ooni/probe-engine/model"
 )
-
-// GetCollectors queries the bouncer for collectors. Returns a list of
-// entries on success; an error on failure.
-func (c Client) GetCollectors(ctx context.Context) (output []model.Service, err error) {
-	err = c.Client.ReadJSON(ctx, "/api/v1/collectors", &output)
-	return
-}
 
 // GetTestHelpers is like GetCollectors but for test helpers.
 func (c Client) GetTestHelpers(

--- a/probeservices/bouncer_test.go
+++ b/probeservices/bouncer_test.go
@@ -7,17 +7,6 @@ import (
 	"github.com/apex/log"
 )
 
-func TestGetCollectors(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
-	collectors, err := makeClient().GetCollectors(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(collectors) <= 1 {
-		t.Fatal("no returned collectors?!")
-	}
-}
-
 func TestGetTestHelpers(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	testhelpers, err := makeClient().GetTestHelpers(context.Background())


### PR DESCRIPTION
We have now migrated to probeservices. The probeservices implement the
bouncer API, therefore, no need to keep the bouncer API around.

Cleanup as part of https://github.com/ooni/probe-engine/issues/651.