### PR TITLE
probeservices: tor, psiphon: use more compact code pattern

### DIFF
--- a/probeservices/psiphon.go
+++ b/probeservices/psiphon.go
@@ -3,8 +3,6 @@ package probeservices
 import (
 	"context"
 	"fmt"
-
-	"github.com/ooni/probe-engine/internal/httpx"
 )
 
 // FetchPsiphonConfig fetches psiphon config from authenticated OONI orchestra.
@@ -14,11 +12,7 @@ func (c Client) FetchPsiphonConfig(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 	authorization := fmt.Sprintf("Bearer %s", auth.Token)
-	return (httpx.Client{
-		Authorization: authorization,
-		BaseURL:       c.BaseURL,
-		HTTPClient:    c.HTTPClient,
-		Logger:        c.Logger,
-		UserAgent:     c.UserAgent,
-	}).FetchResource(ctx, "/api/v1/test-list/psiphon-config")
+	client := c.Client
+	client.Authorization = authorization
+	return client.FetchResource(ctx, "/api/v1/test-list/psiphon-config")
 }

--- a/probeservices/tor.go
+++ b/probeservices/tor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -15,12 +14,8 @@ func (c Client) FetchTorTargets(ctx context.Context) (result map[string]model.To
 		return nil, err
 	}
 	authorization := fmt.Sprintf("Bearer %s", auth.Token)
-	err = (httpx.Client{
-		Authorization: authorization,
-		BaseURL:       c.BaseURL,
-		HTTPClient:    c.HTTPClient,
-		Logger:        c.Logger,
-		UserAgent:     c.UserAgent,
-	}).ReadJSON(ctx, "/api/v1/test-list/tor-targets", &result)
+	client := c.Client
+	client.Authorization = authorization
+	err = client.ReadJSON(ctx, "/api/v1/test-list/tor-targets", &result)
 	return
 }


### PR DESCRIPTION
This code pattern also happens to be less error prone.

Cleanup as part of https://github.com/ooni/probe-engine/issues/651