### PR TITLE
httpx: more intuitive names for jsonapi

### DIFF
--- a/geoiplookup/iplookup/avast/avast.go
+++ b/geoiplookup/iplookup/avast/avast.go
@@ -26,7 +26,7 @@ func Do(
 		HTTPClient: httpClient,
 		Logger:     logger,
 		UserAgent:  userAgent,
-	}).ReadJSON(ctx, "/v1/info", &v)
+	}).GetJSON(ctx, "/v1/info", &v)
 	if err != nil {
 		return model.DefaultProbeIP, err
 	}

--- a/internal/httpx/jsonapi.go
+++ b/internal/httpx/jsonapi.go
@@ -115,15 +115,15 @@ func (c Client) DoJSON(request *http.Request, output interface{}) error {
 	return json.Unmarshal(data, output)
 }
 
-// ReadJSON reads the JSON resource at resourcePath and unmarshals the
+// GetJSON reads the JSON resource at resourcePath and unmarshals the
 // results into output. The request is bounded by the lifetime of the
 // context passed as argument. Returns the error that occurred.
-func (c Client) ReadJSON(ctx context.Context, resourcePath string, output interface{}) error {
-	return c.ReadJSONWithQuery(ctx, resourcePath, nil, output)
+func (c Client) GetJSON(ctx context.Context, resourcePath string, output interface{}) error {
+	return c.GetJSONWithQuery(ctx, resourcePath, nil, output)
 }
 
-// ReadJSONWithQuery is like Read but also has a query.
-func (c Client) ReadJSONWithQuery(
+// GetJSONWithQuery is like GetJSON but also has a query.
+func (c Client) GetJSONWithQuery(
 	ctx context.Context, resourcePath string,
 	query url.Values, output interface{}) error {
 	request, err := c.NewRequest(ctx, "GET", resourcePath, query, nil)
@@ -133,11 +133,11 @@ func (c Client) ReadJSONWithQuery(
 	return c.DoJSON(request, output)
 }
 
-// CreateJSON creates a JSON subresource of the resource at resourcePath
+// PostJSON creates a JSON subresource of the resource at resourcePath
 // using the JSON document at input and returning the result into the
 // JSON document at output. The request is bounded by the context's
 // lifetime. Returns the error that occurred.
-func (c Client) CreateJSON(
+func (c Client) PostJSON(
 	ctx context.Context, resourcePath string, input, output interface{}) error {
 	request, err := c.NewRequestWithJSONBody(ctx, "POST", resourcePath, nil, input)
 	if err != nil {
@@ -146,9 +146,9 @@ func (c Client) CreateJSON(
 	return c.DoJSON(request, output)
 }
 
-// UpdateJSON updates a JSON resource at a specific path and returns
+// PutJSON updates a JSON resource at a specific path and returns
 // the error that occurred and possibly an output document
-func (c Client) UpdateJSON(
+func (c Client) PutJSON(
 	ctx context.Context, resourcePath string, input, output interface{}) error {
 	request, err := c.NewRequestWithJSONBody(ctx, "PUT", resourcePath, nil, input)
 	if err != nil {

--- a/internal/httpx/jsonapi_test.go
+++ b/internal/httpx/jsonapi_test.go
@@ -217,7 +217,7 @@ type httpbinheaders struct {
 
 func TestIntegrationReadJSONSuccess(t *testing.T) {
 	var headers httpbinheaders
-	err := newClient().ReadJSON(context.Background(), "/headers", &headers)
+	err := newClient().GetJSON(context.Background(), "/headers", &headers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestIntegrationCreateJSONSuccess(t *testing.T) {
 		},
 	}
 	var response httpbinpost
-	err := newClient().CreateJSON(context.Background(), "/post", &headers, &response)
+	err := newClient().PostJSON(context.Background(), "/post", &headers, &response)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestIntegrationUpdateJSONSuccess(t *testing.T) {
 		},
 	}
 	var response httpbinpost
-	err := newClient().UpdateJSON(context.Background(), "/put", &headers, &response)
+	err := newClient().PutJSON(context.Background(), "/put", &headers, &response)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +273,7 @@ func TestUnitReadJSONFailure(t *testing.T) {
 	var headers httpbinheaders
 	client := newClient()
 	client.BaseURL = "\t\t\t\t"
-	err := client.ReadJSON(context.Background(), "/headers", &headers)
+	err := client.GetJSON(context.Background(), "/headers", &headers)
 	if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
 		t.Fatal("not the error we expected")
 	}
@@ -283,7 +283,7 @@ func TestUnitCreateJSONFailure(t *testing.T) {
 	var headers httpbinheaders
 	client := newClient()
 	client.BaseURL = "\t\t\t\t"
-	err := client.CreateJSON(context.Background(), "/headers", &headers, &headers)
+	err := client.PostJSON(context.Background(), "/headers", &headers, &headers)
 	if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
 		t.Fatal("not the error we expected")
 	}
@@ -293,7 +293,7 @@ func TestUnitUpdateJSONFailure(t *testing.T) {
 	var headers httpbinheaders
 	client := newClient()
 	client.BaseURL = "\t\t\t\t"
-	err := client.UpdateJSON(context.Background(), "/headers", &headers, &headers)
+	err := client.PutJSON(context.Background(), "/headers", &headers, &headers)
 	if err == nil || !strings.HasSuffix(err.Error(), "invalid control character in URL") {
 		t.Fatal("not the error we expected")
 	}

--- a/probeservices/bouncer.go
+++ b/probeservices/bouncer.go
@@ -20,6 +20,6 @@ import (
 // GetTestHelpers is like GetCollectors but for test helpers.
 func (c Client) GetTestHelpers(
 	ctx context.Context) (output map[string][]model.Service, err error) {
-	err = c.Client.ReadJSON(ctx, "/api/v1/test-helpers", &output)
+	err = c.Client.GetJSON(ctx, "/api/v1/test-helpers", &output)
 	return
 }

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -71,7 +71,7 @@ func (c Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, err
 		return nil, errors.New("Unsupported format")
 	}
 	var or openResponse
-	err := c.Client.CreateJSON(ctx, "/report", rt, &or)
+	err := c.Client.PostJSON(ctx, "/report", rt, &or)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ type updateResponse struct {
 func (r Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse updateResponse
 	m.ReportID = r.ID
-	err := r.client.Client.CreateJSON(
+	err := r.client.Client.PostJSON(
 		ctx, fmt.Sprintf("/report/%s", r.ID), updateRequest{
 			Format:  "json",
 			Content: m,
@@ -118,7 +118,7 @@ func (r Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) err
 // Close closes the report. Returns nil on success; an error on failure.
 func (r Report) Close(ctx context.Context) error {
 	var input, output struct{}
-	err := r.client.Client.CreateJSON(
+	err := r.client.Client.PostJSON(
 		ctx, fmt.Sprintf("/report/%s/close", r.ID), input, &output,
 	)
 	// Implementation note: the server is not compliant with

--- a/probeservices/login.go
+++ b/probeservices/login.go
@@ -29,7 +29,7 @@ func (c Client) MaybeLogin(ctx context.Context) error {
 	}
 	c.LoginCalls.Add(1)
 	var auth LoginAuth
-	err := c.Client.CreateJSON(ctx, "/api/v1/login", *creds, &auth)
+	err := c.Client.PostJSON(ctx, "/api/v1/login", *creds, &auth)
 	if err != nil {
 		return err
 	}

--- a/probeservices/register.go
+++ b/probeservices/register.go
@@ -29,7 +29,7 @@ func (c Client) MaybeRegister(ctx context.Context, metadata Metadata) error {
 		Password: pwd,
 	}
 	var resp registerResult
-	err := c.Client.CreateJSON(ctx, "/api/v1/register", req, &resp)
+	err := c.Client.PostJSON(ctx, "/api/v1/register", req, &resp)
 	if err != nil {
 		return err
 	}

--- a/probeservices/tor.go
+++ b/probeservices/tor.go
@@ -16,6 +16,6 @@ func (c Client) FetchTorTargets(ctx context.Context) (result map[string]model.To
 	authorization := fmt.Sprintf("Bearer %s", auth.Token)
 	client := c.Client
 	client.Authorization = authorization
-	err = client.ReadJSON(ctx, "/api/v1/test-list/tor-targets", &result)
+	err = client.GetJSON(ctx, "/api/v1/test-list/tor-targets", &result)
 	return
 }

--- a/probeservices/urls.go
+++ b/probeservices/urls.go
@@ -30,7 +30,7 @@ func (c Client) FetchURLList(ctx context.Context, config model.URLListConfig) ([
 		query.Set("category_codes", strings.Join(config.Categories, ","))
 	}
 	var response urlListResult
-	err := c.Client.ReadJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
+	err := c.Client.GetJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func URLsQuery(ctx context.Context, config URLsConfig) (*URLsResult, error) {
 		HTTPClient: config.HTTPClient,
 		Logger:     config.Logger,
 		UserAgent:  config.UserAgent,
-	}).ReadJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
+	}).GetJSONWithQuery(ctx, "/api/v1/test-list/urls", query, &response)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We used to use CRUD names. Naming the method explicitly is more intuitive.

Part of https://github.com/ooni/probe-engine/issues/651.