### PR TITLE
refactor(probeservices): move testing fixtures in subpackage

### DIFF
--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ooni/probe-engine/internal/runtimex"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/probeservices"
+	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
 // ExperimentSession is a mockable ExperimentSession.
@@ -86,7 +87,7 @@ func (sess *ExperimentSession) NewOrchestraClient(ctx context.Context) (model.Ex
 		Type:    "https",
 	})
 	runtimex.PanicOnError(err, "orchestra.NewClient should not fail here")
-	meta := probeservices.OrchestraMetadataFixture()
+	meta := testorchestra.MetadataFixture()
 	if err := clnt.MaybeRegister(ctx, meta); err != nil {
 		return nil, err
 	}

--- a/probeservices/login_test.go
+++ b/probeservices/login_test.go
@@ -56,7 +56,7 @@ func TestUnitMaybeLogin(t *testing.T) {
 func TestIntegrationMaybeLoginIdempotent(t *testing.T) {
 	clnt := newclient()
 	ctx := context.Background()
-	metadata := probeservices.OrchestraMetadataFixture()
+	metadata := testorchestra.MetadataFixture()
 	if err := clnt.MaybeRegister(ctx, metadata); err != nil {
 		t.Fatal(err)
 	}

--- a/probeservices/login_test.go
+++ b/probeservices/login_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/probeservices"
+	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
 func TestUnitMaybeLogin(t *testing.T) {

--- a/probeservices/orchestra.go
+++ b/probeservices/orchestra.go
@@ -35,18 +35,3 @@ func randomPassword(n int) string {
 	}
 	return string(b)
 }
-
-// OrchestraMetadataFixture returns a valid metadata struct. This is mostly
-// useful for testing. (We should see if we can make this private.)
-func OrchestraMetadataFixture() Metadata {
-	return Metadata{
-		Platform:        "linux",
-		ProbeASN:        "AS15169",
-		ProbeCC:         "US",
-		SoftwareName:    "miniooni",
-		SoftwareVersion: "0.1.0-dev",
-		SupportedTests: []string{
-			"web_connectivity",
-		},
-	}
-}

--- a/probeservices/psiphon_test.go
+++ b/probeservices/psiphon_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-engine/probeservices"
+	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
 func TestIntegrationFetchPsiphonConfig(t *testing.T) {
 	clnt := newclient()
 	if err := clnt.MaybeRegister(
 		context.Background(),
-		probeservices.OrchestraMetadataFixture(),
+		testorchestra.MetadataFixture(),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/probeservices/register_test.go
+++ b/probeservices/register_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-engine/probeservices"
+	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
 func TestUnitMaybeRegister(t *testing.T) {
@@ -26,7 +27,7 @@ func TestUnitMaybeRegister(t *testing.T) {
 			t.Fatal(err)
 		}
 		ctx := context.Background()
-		metadata := probeservices.OrchestraMetadataFixture()
+		metadata := testorchestra.MetadataFixture()
 		if err := clnt.MaybeRegister(ctx, metadata); err != nil {
 			t.Fatal(err)
 		}
@@ -35,7 +36,7 @@ func TestUnitMaybeRegister(t *testing.T) {
 		clnt := newclient()
 		clnt.BaseURL = "\t\t\t"
 		ctx := context.Background()
-		metadata := probeservices.OrchestraMetadataFixture()
+		metadata := testorchestra.MetadataFixture()
 		if err := clnt.MaybeRegister(ctx, metadata); err == nil {
 			t.Fatal("expected an error here")
 		}
@@ -45,7 +46,7 @@ func TestUnitMaybeRegister(t *testing.T) {
 func TestIntegrationMaybeRegisterIdempotent(t *testing.T) {
 	clnt := newclient()
 	ctx := context.Background()
-	metadata := probeservices.OrchestraMetadataFixture()
+	metadata := testorchestra.MetadataFixture()
 	if err := clnt.MaybeRegister(ctx, metadata); err != nil {
 		t.Fatal(err)
 	}

--- a/probeservices/testorchestra/testorchestra.go
+++ b/probeservices/testorchestra/testorchestra.go
@@ -1,0 +1,19 @@
+// Package testorchestra helps with testing the OONI orchestra API.
+package testorchestra
+
+import "github.com/ooni/probe-engine/probeservices"
+
+// MetadataFixture returns a valid metadata struct. This is mostly
+// useful for testing. (We should see if we can make this private.)
+func MetadataFixture() probeservices.Metadata {
+	return probeservices.Metadata{
+		Platform:        "linux",
+		ProbeASN:        "AS15169",
+		ProbeCC:         "US",
+		SoftwareName:    "miniooni",
+		SoftwareVersion: "0.1.0-dev",
+		SupportedTests: []string{
+			"web_connectivity",
+		},
+	}
+}

--- a/probeservices/tor_test.go
+++ b/probeservices/tor_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-engine/probeservices"
+	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
 func TestIntegrationFetchTorTargets(t *testing.T) {
 	clnt := newclient()
 	if err := clnt.MaybeRegister(
 		context.Background(),
-		probeservices.OrchestraMetadataFixture(),
+		testorchestra.MetadataFixture(),
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/651