### PR TITLE
refactor(probeservices): StateFile does not need to be a pointer

### DIFF
--- a/probeservices/probeservices.go
+++ b/probeservices/probeservices.go
@@ -31,7 +31,7 @@ type Client struct {
 	httpx.Client
 	LoginCalls    *atomicx.Int64
 	RegisterCalls *atomicx.Int64
-	StateFile     *StateFile
+	StateFile     StateFile
 }
 
 func (c Client) getCredsAndAuth() (*LoginCredentials, *LoginAuth, error) {

--- a/probeservices/statefile.go
+++ b/probeservices/statefile.go
@@ -47,15 +47,15 @@ type StateFile struct {
 }
 
 // NewStateFile creates a new state file backed by a key-value store
-func NewStateFile(kvstore model.KeyValueStore) *StateFile {
-	return &StateFile{
+func NewStateFile(kvstore model.KeyValueStore) StateFile {
+	return StateFile{
 		key:   "orchestra.state",
 		Store: kvstore,
 	}
 }
 
 // SetMockable is a mockable version of Set
-func (sf *StateFile) SetMockable(s State, mf func(interface{}) ([]byte, error)) error {
+func (sf StateFile) SetMockable(s State, mf func(interface{}) ([]byte, error)) error {
 	data, err := mf(s)
 	if err != nil {
 		return err
@@ -64,12 +64,12 @@ func (sf *StateFile) SetMockable(s State, mf func(interface{}) ([]byte, error)) 
 }
 
 // Set saves the current state on the key-value store.
-func (sf *StateFile) Set(s State) error {
+func (sf StateFile) Set(s State) error {
 	return sf.SetMockable(s, json.Marshal)
 }
 
 // GetMockable is a mockable version of Get
-func (sf *StateFile) GetMockable(
+func (sf StateFile) GetMockable(
 	sfget func(string) ([]byte, error),
 	unmarshal func([]byte, interface{}) error,
 ) (State, error) {
@@ -86,7 +86,7 @@ func (sf *StateFile) GetMockable(
 
 // Get returns the current state. In case of any error with the
 // underlying key-value store, we return an empty state.
-func (sf *StateFile) Get() (state State) {
+func (sf StateFile) Get() (state State) {
 	state, _ = sf.GetMockable(sf.Store.Get, json.Unmarshal)
 	return
 }

--- a/probeservices/statefile_test.go
+++ b/probeservices/statefile_test.go
@@ -65,9 +65,6 @@ func TestStateCredentials(t *testing.T) {
 
 func TestStateFileMemoryIntegration(t *testing.T) {
 	sf := probeservices.NewStateFile(kvstore.NewMemoryKeyValueStore())
-	if sf == nil {
-		t.Fatal("expected non nil pointer here")
-	}
 	s := probeservices.State{
 		Expire:   time.Now(),
 		Password: "xy",
@@ -94,9 +91,6 @@ func TestStateFileMemoryIntegration(t *testing.T) {
 
 func TestStateFileSetMarshalError(t *testing.T) {
 	sf := probeservices.NewStateFile(kvstore.NewMemoryKeyValueStore())
-	if sf == nil {
-		t.Fatal("expected non nil pointer here")
-	}
 	s := probeservices.State{
 		Expire:   time.Now(),
 		Password: "xy",
@@ -114,9 +108,6 @@ func TestStateFileSetMarshalError(t *testing.T) {
 
 func TestStateFileGetKVStoreGetError(t *testing.T) {
 	sf := probeservices.NewStateFile(kvstore.NewMemoryKeyValueStore())
-	if sf == nil {
-		t.Fatal("expected non nil pointer here")
-	}
 	expected := errors.New("mocked error")
 	failingfunc := func(string) ([]byte, error) {
 		return nil, expected
@@ -141,9 +132,6 @@ func TestStateFileGetKVStoreGetError(t *testing.T) {
 
 func TestStateFileGetUnmarshalError(t *testing.T) {
 	sf := probeservices.NewStateFile(kvstore.NewMemoryKeyValueStore())
-	if sf == nil {
-		t.Fatal("expected non nil pointer here")
-	}
 	if err := sf.Set(probeservices.State{}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The StateFile is like:

```Go
// StateFile is the orchestra state file. It is backed by
// a generic key-value store configured by the user.
type StateFile struct {
	Store model.KeyValueStore
	key   string
}
```

where `Store` is an interface and changes happen in `Store`.

So, we don't need to return a pointer in the constructor and we
don't need to pass around a pointer.

Part of https://github.com/ooni/probe-engine/issues/651