### PR TITLE
experiment/tor: allow for testing private bridges

### DIFF
--- a/experiment/tor/tor.go
+++ b/experiment/tor/tor.go
@@ -136,15 +136,15 @@ func (tk *TestKeys) fillToplevelKeys() {
 
 type measurer struct {
 	config             Config
-	fetchTorTargets    func(ctx context.Context, clnt model.ExperimentOrchestraClient) (map[string]model.TorTarget, error)
+	fetchTorTargets    func(ctx context.Context, clnt model.ExperimentOrchestraClient, cc string) (map[string]model.TorTarget, error)
 	newOrchestraClient func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error)
 }
 
 func newMeasurer(config Config) *measurer {
 	return &measurer{
 		config: config,
-		fetchTorTargets: func(ctx context.Context, clnt model.ExperimentOrchestraClient) (map[string]model.TorTarget, error) {
-			return clnt.FetchTorTargets(ctx)
+		fetchTorTargets: func(ctx context.Context, clnt model.ExperimentOrchestraClient, cc string) (map[string]model.TorTarget, error) {
+			return clnt.FetchTorTargets(ctx, cc)
 		},
 		newOrchestraClient: func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
 			return sess.NewOrchestraClient(ctx)
@@ -188,7 +188,7 @@ func (m *measurer) gimmeTargets(
 	if err != nil {
 		return nil, err
 	}
-	return m.fetchTorTargets(ctx, clnt)
+	return m.fetchTorTargets(ctx, clnt, sess.ProbeCC())
 }
 
 // keytarget contains a key and the related target

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -56,7 +56,7 @@ func TestUnitMeasurerMeasureFetchTorTargetsError(t *testing.T) {
 	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
 		return new(probeservices.Client), nil
 	}
-	measurer.fetchTorTargets = func(ctx context.Context, clnt model.ExperimentOrchestraClient) (map[string]model.TorTarget, error) {
+	measurer.fetchTorTargets = func(ctx context.Context, clnt model.ExperimentOrchestraClient, cc string) (map[string]model.TorTarget, error) {
 		return nil, expected
 	}
 	err := measurer.Run(
@@ -77,7 +77,7 @@ func TestUnitMeasurerMeasureFetchTorTargetsEmptyList(t *testing.T) {
 	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
 		return new(probeservices.Client), nil
 	}
-	measurer.fetchTorTargets = func(ctx context.Context, clnt model.ExperimentOrchestraClient) (map[string]model.TorTarget, error) {
+	measurer.fetchTorTargets = func(ctx context.Context, clnt model.ExperimentOrchestraClient, cc string) (map[string]model.TorTarget, error) {
 		return nil, nil
 	}
 	measurement := new(model.Measurement)
@@ -99,11 +99,13 @@ func TestUnitMeasurerMeasureFetchTorTargetsEmptyList(t *testing.T) {
 }
 
 func TestUnitMeasurerMeasureGood(t *testing.T) {
+	// This test mocks orchestra to return a nil list of targets, so the code runs
+	// but we don't perform any actualy network actions.
 	measurer := newMeasurer(Config{})
 	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
 		return new(probeservices.Client), nil
 	}
-	measurer.fetchTorTargets = func(ctx context.Context, clnt model.ExperimentOrchestraClient) (map[string]model.TorTarget, error) {
+	measurer.fetchTorTargets = func(ctx context.Context, clnt model.ExperimentOrchestraClient, cc string) (map[string]model.TorTarget, error) {
 		return nil, nil
 	}
 	err := measurer.Run(

--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -178,7 +178,7 @@ func (c ExperimentOrchestraClient) FetchPsiphonConfig(
 
 // FetchTorTargets implements ExperimentOrchestraClient.TorTargets
 func (c ExperimentOrchestraClient) FetchTorTargets(
-	ctx context.Context) (map[string]model.TorTarget, error) {
+	ctx context.Context, cc string) (map[string]model.TorTarget, error) {
 	return c.MockableFetchTorTargetsResult, c.MockableFetchTorTargetsErr
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -362,7 +362,7 @@ type URLListConfig struct {
 // a client for querying the OONI orchestra API.
 type ExperimentOrchestraClient interface {
 	FetchPsiphonConfig(ctx context.Context) ([]byte, error)
-	FetchTorTargets(ctx context.Context) (map[string]TorTarget, error)
+	FetchTorTargets(ctx context.Context, cc string) (map[string]TorTarget, error)
 	FetchURLList(ctx context.Context, config URLListConfig) ([]URLInfo, error)
 }
 

--- a/probeservices/tor.go
+++ b/probeservices/tor.go
@@ -3,18 +3,22 @@ package probeservices
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/ooni/probe-engine/model"
 )
 
 // FetchTorTargets returns the targets for the tor experiment.
-func (c Client) FetchTorTargets(ctx context.Context) (result map[string]model.TorTarget, err error) {
+func (c Client) FetchTorTargets(ctx context.Context, cc string) (result map[string]model.TorTarget, err error) {
 	_, auth, err := c.GetCredsAndAuth()
 	if err != nil {
 		return nil, err
 	}
 	client := c.Client
 	client.Authorization = fmt.Sprintf("Bearer %s", auth.Token)
-	err = client.GetJSON(ctx, "/api/v1/test-list/tor-targets", &result)
+	query := url.Values{}
+	query.Add("country_code", cc)
+	err = client.GetJSONWithQuery(
+		ctx, "/api/v1/test-list/tor-targets", query, &result)
 	return
 }

--- a/probeservices/tor_test.go
+++ b/probeservices/tor_test.go
@@ -2,6 +2,7 @@ package probeservices_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/ooni/probe-engine/probeservices"
@@ -16,7 +17,7 @@ func TestIntegrationFetchTorTargets(t *testing.T) {
 	if err := clnt.MaybeLogin(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	data, err := clnt.FetchTorTargets(context.Background())
+	data, err := clnt.FetchTorTargets(context.Background(), "ZZ")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,11 +34,49 @@ func TestFetchTorTargetsNotRegistered(t *testing.T) {
 	if err := clnt.StateFile.Set(state); err != nil {
 		t.Fatal(err)
 	}
-	data, err := clnt.FetchTorTargets(context.Background())
+	data, err := clnt.FetchTorTargets(context.Background(), "ZZ")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
 	if data != nil {
 		t.Fatal("expected nil data here")
+	}
+}
+
+type FetchTorTargetsHTTPTransport struct {
+	Response *http.Response
+}
+
+func (clnt *FetchTorTargetsHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if req.URL.Path == "/api/v1/test-list/tor-targets" {
+		clnt.Response = resp
+	}
+	return resp, err
+}
+
+func TestFetchTorTargetsSetsQueryString(t *testing.T) {
+	clnt := newclient()
+	txp := new(FetchTorTargetsHTTPTransport)
+	clnt.HTTPClient.Transport = txp
+	if err := clnt.MaybeRegister(context.Background(), testorchestra.MetadataFixture()); err != nil {
+		t.Fatal(err)
+	}
+	if err := clnt.MaybeLogin(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := clnt.FetchTorTargets(context.Background(), "ZZ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data == nil || len(data) <= 0 {
+		t.Fatal("invalid data")
+	}
+	requestURL := txp.Response.Request.URL
+	if requestURL.Query().Get("country_code") != "ZZ" {
+		t.Fatal("invalid country code")
 	}
 }

--- a/session.go
+++ b/session.go
@@ -264,6 +264,9 @@ func (s *Session) NewOrchestraClient(ctx context.Context) (model.ExperimentOrche
 	if err := s.maybeLookupBackends(ctx); err != nil {
 		return nil, err
 	}
+	if err := s.maybeLookupLocation(ctx); err != nil {
+		return nil, err
+	}
 	if s.selectedProbeServiceHook != nil {
 		s.selectedProbeServiceHook(s.selectedProbeService)
 	}


### PR DESCRIPTION
1. make sure we pass `country_code=$CC` to the orchestra API https://github.com/ooni/probe-engine/issues/629

2. add functional test to ensure the output is scrubbed in such case https://github.com/ooni/probe-engine/issues/721