### PR TITLE
doh: use same user-agent used for measurements

### DIFF
--- a/netx/resolver/dnsoverhttps.go
+++ b/netx/resolver/dnsoverhttps.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/ooni/probe-engine/internal/httpheader"
 )
 
 // DNSOverHTTPS is a DNS over HTTPS RoundTripper. Requests are submitted over
@@ -27,6 +29,7 @@ func (t DNSOverHTTPS) RoundTrip(ctx context.Context, query []byte) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("user-agent", httpheader.RandomUserAgent())
 	req.Header.Set("content-type", "application/dns-message")
 	var resp *http.Response
 	resp, err = t.Do(req.WithContext(ctx))


### PR DESCRIPTION
No need to announce us as being OONI.

Part of https://github.com/ooni/probe-engine/issues/716