### PR TITLE
urlgetter: implement FailOnHTTPError

### DIFF
--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -69,12 +69,6 @@ func (tk *TestKeys) Update(v urlgetter.MultiOutput) {
 		tk.TelegramWebFailure = v.TestKeys.Failure
 		return
 	}
-	if v.TestKeys.HTTPResponseStatus != 200 {
-		failureString := "http_request_failed" // MK uses it
-		tk.TelegramWebFailure = &failureString
-		tk.TelegramWebStatus = "blocked"
-		return
-	}
 	title := `<title>Telegram Web</title>`
 	if strings.Contains(v.TestKeys.HTTPResponseBody, title) == false {
 		failureString := "telegram_missing_title_error"
@@ -85,19 +79,28 @@ func (tk *TestKeys) Update(v urlgetter.MultiOutput) {
 	return
 }
 
-type measurer struct {
-	config Config
+// Measurer performs the measurement
+type Measurer struct {
+	// Config contains the experiment settings. If empty we
+	// will be using default settings.
+	Config Config
+
+	// Getter is an optional getter to be used for testing.
+	Getter urlgetter.MultiGetter
 }
 
-func (m measurer) ExperimentName() string {
+// ExperimentName implements ExperimentMeasurer.ExperimentName
+func (m Measurer) ExperimentName() string {
 	return testName
 }
 
-func (m measurer) ExperimentVersion() string {
+// ExperimentVersion implements ExperimentMeasurer.ExperimentVersion
+func (m Measurer) ExperimentVersion() string {
 	return testVersion
 }
 
-func (m measurer) Run(ctx context.Context, sess model.ExperimentSession,
+// Run implements ExperimentMeasurer.Run
+func (m Measurer) Run(ctx context.Context, sess model.ExperimentSession,
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks) error {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
@@ -115,10 +118,10 @@ func (m measurer) Run(ctx context.Context, sess model.ExperimentSession,
 		{Target: "http://149.154.167.91:443/", Config: urlgetter.Config{Method: "POST"}},
 		{Target: "http://149.154.171.5:443/", Config: urlgetter.Config{Method: "POST"}},
 
-		{Target: "http://web.telegram.org/", Config: urlgetter.Config{Method: "GET"}},
-		{Target: "https://web.telegram.org/", Config: urlgetter.Config{Method: "GET"}},
+		{Target: "http://web.telegram.org/", Config: urlgetter.Config{FailOnHTTPError: true}},
+		{Target: "https://web.telegram.org/", Config: urlgetter.Config{FailOnHTTPError: true}},
 	}
-	multi := urlgetter.Multi{Begin: time.Now(), Session: sess}
+	multi := urlgetter.Multi{Begin: time.Now(), Getter: m.Getter, Session: sess}
 	testkeys := NewTestKeys()
 	testkeys.Agent = "redirect"
 	measurement.TestKeys = testkeys
@@ -130,5 +133,5 @@ func (m measurer) Run(ctx context.Context, sess model.ExperimentSession,
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return measurer{config: config}
+	return Measurer{Config: config}
 }

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
+	"github.com/ooni/probe-engine/atomicx"
 	"github.com/ooni/probe-engine/experiment/handler"
 	"github.com/ooni/probe-engine/experiment/telegram"
 	"github.com/ooni/probe-engine/experiment/urlgetter"
@@ -261,32 +262,44 @@ func TestUpdateWebWithMixedResults(t *testing.T) {
 	}
 }
 
-func TestUpdateWithBadRequest(t *testing.T) {
-	tk := telegram.NewTestKeys()
-	tk.Update(urlgetter.MultiOutput{
-		Input: urlgetter.MultiInput{
-			Config: urlgetter.Config{Method: "GET"},
-			Target: "http://web.telegram.org/",
+func TestWeConfigureWebChecksToFailOnHTTPError(t *testing.T) {
+	called := atomicx.NewInt64()
+	failOnErrorHTTPS := atomicx.NewInt64()
+	failOnErrorHTTP := atomicx.NewInt64()
+	measurer := telegram.Measurer{
+		Config: telegram.Config{},
+		Getter: func(ctx context.Context, g urlgetter.Getter) (urlgetter.TestKeys, error) {
+			called.Add(1)
+			switch g.Target {
+			case "https://web.telegram.org/":
+				if g.Config.FailOnHTTPError {
+					failOnErrorHTTPS.Add(1)
+				}
+			case "http://web.telegram.org/":
+				if g.Config.FailOnHTTPError {
+					failOnErrorHTTP.Add(1)
+				}
+			}
+			return urlgetter.DefaultMultiGetter(ctx, g)
 		},
-		TestKeys: urlgetter.TestKeys{
-			HTTPResponseStatus: 400,
-		},
-	})
-	tk.Update(urlgetter.MultiOutput{
-		Input: urlgetter.MultiInput{
-			Config: urlgetter.Config{Method: "GET"},
-			Target: "https://web.telegram.org/",
-		},
-		TestKeys: urlgetter.TestKeys{
-			HTTPResponseBody:   `<title>Telegram Web</title>`,
-			HTTPResponseStatus: 200,
-		},
-	})
-	if tk.TelegramWebStatus != "blocked" {
-		t.Fatal("TelegramWebStatus should be blocked")
 	}
-	if *tk.TelegramWebFailure != "http_request_failed" {
-		t.Fatal("invalid TelegramWebFailure")
+	ctx := context.Background()
+	sess := &mockable.ExperimentSession{
+		MockableLogger: log.Log,
+	}
+	measurement := new(model.Measurement)
+	callbacks := handler.NewPrinterCallbacks(log.Log)
+	if err := measurer.Run(ctx, sess, measurement, callbacks); err != nil {
+		t.Fatal(err)
+	}
+	if called.Load() < 1 {
+		t.Fatal("not called")
+	}
+	if failOnErrorHTTPS.Load() != 1 {
+		t.Fatal("not configured fail on error for HTTPS")
+	}
+	if failOnErrorHTTP.Load() != 1 {
+		t.Fatal("not configured fail on error for HTTP")
 	}
 }
 

--- a/experiment/urlgetter/multi.go
+++ b/experiment/urlgetter/multi.go
@@ -32,8 +32,8 @@ type MultiOutput struct {
 // MultiGetter allows to override the behaviour of Multi for testing purposes.
 type MultiGetter func(ctx context.Context, g Getter) (TestKeys, error)
 
-// defaultMultiGetter is the default MultiGetter
-func defaultMultiGetter(ctx context.Context, g Getter) (TestKeys, error) {
+// DefaultMultiGetter is the default MultiGetter
+func DefaultMultiGetter(ctx context.Context, g Getter) (TestKeys, error) {
 	return g.Get(ctx)
 }
 
@@ -125,7 +125,7 @@ func (m Multi) do(ctx context.Context, in <-chan MultiInput, out chan<- MultiOut
 		}
 		fn := m.Getter
 		if fn == nil {
-			fn = defaultMultiGetter
+			fn = DefaultMultiGetter
 		}
 		tk, err := fn(ctx, g)
 		out <- MultiOutput{Input: input, Err: err, TestKeys: tk}

--- a/experiment/urlgetter/runner.go
+++ b/experiment/urlgetter/runner.go
@@ -13,7 +13,17 @@ import (
 	"github.com/ooni/probe-engine/internal/httpheader"
 	"github.com/ooni/probe-engine/internal/runtimex"
 	"github.com/ooni/probe-engine/netx/httptransport"
+	"github.com/ooni/probe-engine/netx/modelx"
 )
+
+const httpRequestFailed = "http_request_failed"
+
+// ErrHTTPRequestFailed indicates that the HTTP request failed.
+var ErrHTTPRequestFailed = &modelx.ErrWrapper{
+	Failure:    httpRequestFailed,
+	Operation:  modelx.TopLevelOperation,
+	WrappedErr: errors.New(httpRequestFailed),
+}
 
 // The Runner job is to run a single measurement
 type Runner struct {
@@ -73,8 +83,16 @@ func (r Runner) httpGet(ctx context.Context, url string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	return err
+	if _, err = io.Copy(ioutil.Discard, resp.Body); err != nil {
+		return err
+	}
+	// Implementation note: we shall check for this error once we have read the
+	// whole body. Even though we discard the body, we want to know whether we
+	// see any error when reading the body before inspecting the HTTP status code.
+	if resp.StatusCode >= 400 && r.Config.FailOnHTTPError {
+		return ErrHTTPRequestFailed
+	}
+	return nil
 }
 
 func (r Runner) dnsLookup(ctx context.Context, hostname string) error {

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -18,6 +18,7 @@ const (
 // Config contains the experiment's configuration.
 type Config struct {
 	DNSCache          string `ooni:"Add 'DOMAIN IP...' to cache"`
+	FailOnHTTPError   bool   `ooni:"Fail HTTP request if status code is 400 or above"`
 	HTTPHost          string `ooni:"Force using specific HTTP Host header"`
 	Method            string `ooni:"Force HTTP method different than GET"`
 	NoFollowRedirects bool   `ooni:"Disable following redirects"`


### PR DESCRIPTION
In some cases, we want to fail if we see an HTTP status code >= 400.

This is certainly the case when we're doing plain text HTTP.

Both the Telegram implementation and WhatsApp can benefit from that
functionality, when connecting to the web interface.

Thus, I've factored the code out of the Telegram implementation
and I have moved it inside the urlgetter package.

Part of https://github.com/ooni/probe-engine/issues/55