### PR TITLE
sniblocking: rewrite using urlgetter

### DIFF
--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -115,9 +115,11 @@ func (m *measurer) measureone(
 	case <-time.After(sleeptime):
 	case <-ctx.Done():
 		s := modelx.FailureInterrupted
+		failedop := modelx.TopLevelOperation
 		return Subresult{
 			TestKeys: urlgetter.TestKeys{
-				Failure: &s,
+				FailedOperation: &failedop,
+				Failure:         &s,
 			},
 			THAddress: thaddr,
 			SNI:       sni,

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -130,6 +130,8 @@ func (m *measurer) measureone(
 		Session: sess,
 		Target:  fmt.Sprintf("tlshandshake://%s", thaddr),
 	}
+	// Ignoring the error because g.Get() sets the tk.Failure field
+	// to be the OONI equivalent of the error that occurred.
 	tk, _ := g.Get(ctx)
 	// assemble and publish the results
 	smk := Subresult{

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -114,7 +114,7 @@ func (m *measurer) measureone(
 	select {
 	case <-time.After(sleeptime):
 	case <-ctx.Done():
-		s := modelx.FailureGenericTimeoutError
+		s := modelx.FailureInterrupted
 		return Subresult{
 			TestKeys: urlgetter.TestKeys{
 				Failure: &s,

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -119,7 +119,8 @@ func (m *measurer) measureone(
 			TestKeys: urlgetter.TestKeys{
 				Failure: &s,
 			},
-			SNI: sni,
+			THAddress: thaddr,
+			SNI:       sni,
 		}
 	}
 	// perform the measurement

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/archival"
 	"github.com/ooni/probe-engine/netx/modelx"
 )
 
@@ -36,16 +35,10 @@ type Config struct {
 // Subresult contains the keys of a single measurement
 // that targets either the target or the control.
 type Subresult struct {
-	Agent         string                     `json:"agent"`
-	Cached        bool                       `json:"-"`
-	Failure       *string                    `json:"failure"`
-	NetworkEvents []archival.NetworkEvent    `json:"network_events"`
-	Queries       []archival.DNSQueryEntry   `json:"queries"`
-	Requests      []archival.RequestEntry    `json:"requests"`
-	SNI           string                     `json:"sni"`
-	TCPConnect    []archival.TCPConnectEntry `json:"tcp_connect"`
-	THAddress     string                     `json:"th_address"`
-	TLSHandshakes []archival.TLSHandshake    `json:"tls_handshakes"`
+	urlgetter.TestKeys
+	Cached    bool   `json:"-"`
+	SNI       string `json:"sni"`
+	THAddress string `json:"th_address"`
 }
 
 // TestKeys contains sniblocking test keys.
@@ -123,8 +116,10 @@ func (m *measurer) measureone(
 	case <-ctx.Done():
 		s := modelx.FailureGenericTimeoutError
 		return Subresult{
-			Failure: &s,
-			SNI:     sni,
+			TestKeys: urlgetter.TestKeys{
+				Failure: &s,
+			},
+			SNI: sni,
 		}
 	}
 	// perform the measurement
@@ -137,15 +132,9 @@ func (m *measurer) measureone(
 	tk, _ := g.Get(ctx)
 	// assemble and publish the results
 	smk := Subresult{
-		Agent:         "redirect",
-		Failure:       tk.Failure,
-		NetworkEvents: tk.NetworkEvents,
-		Queries:       tk.Queries,
-		Requests:      tk.Requests,
-		SNI:           sni,
-		TCPConnect:    tk.TCPConnect,
-		THAddress:     thaddr,
-		TLSHandshakes: tk.TLSHandshakes,
+		SNI:       sni,
+		THAddress: thaddr,
+		TestKeys:  tk,
 	}
 	return smk
 }

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -201,7 +201,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	if result.FailedOperation != nil {
 		t.Fatal("not the expected FailedOperation")
 	}
-	if result.Failure == nil || *result.Failure != modelx.FailureGenericTimeoutError {
+	if result.Failure == nil || *result.Failure != modelx.FailureInterrupted {
 		t.Fatal("not the expected failure")
 	}
 	if result.NetworkEvents != nil {

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/apex/log"
 	"github.com/ooni/probe-engine/experiment/handler"
 	"github.com/ooni/probe-engine/internal/mockable"
-	"github.com/ooni/probe-engine/internal/netxlogger"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/modelx"
 )
@@ -106,7 +105,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "sni_blocking" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.0.5" {
+	if measurer.ExperimentVersion() != "0.1.0" {
 		t.Fatal("unexpected version")
 	}
 }
@@ -184,7 +183,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	cancel() // immediately cancel the context
 	result := new(measurer).measureone(
 		ctx,
-		netxlogger.NewHandler(log.Log),
+		&mockable.ExperimentSession{MockableLogger: log.Log},
 		time.Now(),
 		"kernel.org",
 		"example.com:443",
@@ -200,7 +199,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 func TestUnitMeasureoneSuccess(t *testing.T) {
 	result := new(measurer).measureone(
 		context.Background(),
-		netxlogger.NewHandler(log.Log),
+		&mockable.ExperimentSession{MockableLogger: log.Log},
 		time.Now(),
 		"kernel.org",
 		"example.com:443",
@@ -220,7 +219,7 @@ func TestUnitMeasureonewithcacheWorks(t *testing.T) {
 		measurer.measureonewithcache(
 			context.Background(),
 			output,
-			netxlogger.NewHandler(log.Log),
+			&mockable.ExperimentSession{MockableLogger: log.Log},
 			time.Now(),
 			"kernel.org",
 			"example.com:443",

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -2,6 +2,7 @@ package sniblocking
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,9 +189,6 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 		"kernel.org",
 		"example.com:443",
 	)
-	if *result.Failure != modelx.FailureGenericTimeoutError {
-		t.Fatal("unexpected failure")
-	}
 	if result.Agent != "" {
 		t.Fatal("not the expected Agent")
 	}
@@ -231,6 +229,58 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 		t.Fatal("unexpected SNI")
 	}
 	if result.THAddress != "example.com:443" {
+		t.Fatal("unexpected THAddress")
+	}
+}
+
+func TestUnitMeasureoneWithPreMeasurementFailure(t *testing.T) {
+	result := new(measurer).measureone(
+		context.Background(),
+		&mockable.ExperimentSession{MockableLogger: log.Log},
+		time.Now(),
+		"kernel.org",
+		"example.com:443\t\t\t", // cause URL parse error
+	)
+	if result.Agent != "redirect" {
+		t.Fatal("not the expected Agent")
+	}
+	if result.BootstrapTime != 0.0 {
+		t.Fatal("not the expected BootstrapTime")
+	}
+	if result.DNSCache != nil {
+		t.Fatal("not the expected DNSCache")
+	}
+	if result.FailedOperation == nil || *result.FailedOperation != "top_level" {
+		t.Fatal("not the expected FailedOperation")
+	}
+	if result.Failure == nil || !strings.Contains(*result.Failure, "invalid target URL") {
+		t.Fatal("not the expected failure")
+	}
+	if result.NetworkEvents != nil {
+		t.Fatal("not the expected NetworkEvents")
+	}
+	if result.Queries != nil {
+		t.Fatal("not the expected Queries")
+	}
+	if result.Requests != nil {
+		t.Fatal("not the expected Requests")
+	}
+	if result.SOCKSProxy != "" {
+		t.Fatal("not the expected SOCKSProxy")
+	}
+	if result.TCPConnect != nil {
+		t.Fatal("not the expected TCPConnect")
+	}
+	if result.TLSHandshakes != nil {
+		t.Fatal("not the expected TLSHandshakes")
+	}
+	if result.Tunnel != "" {
+		t.Fatal("not the expected Tunnel")
+	}
+	if result.SNI != "kernel.org" {
+		t.Fatal("unexpected SNI")
+	}
+	if result.THAddress != "example.com:443\t\t\t" {
 		t.Fatal("unexpected THAddress")
 	}
 }

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -191,8 +191,47 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	if *result.Failure != modelx.FailureGenericTimeoutError {
 		t.Fatal("unexpected failure")
 	}
+	if result.Agent != "" {
+		t.Fatal("not the expected Agent")
+	}
+	if result.BootstrapTime != 0.0 {
+		t.Fatal("not the expected BootstrapTime")
+	}
+	if result.DNSCache != nil {
+		t.Fatal("not the expected DNSCache")
+	}
+	if result.FailedOperation != nil {
+		t.Fatal("not the expected FailedOperation")
+	}
+	if result.Failure == nil || *result.Failure != modelx.FailureGenericTimeoutError {
+		t.Fatal("not the expected failure")
+	}
+	if result.NetworkEvents != nil {
+		t.Fatal("not the expected NetworkEvents")
+	}
+	if result.Queries != nil {
+		t.Fatal("not the expected Queries")
+	}
+	if result.Requests != nil {
+		t.Fatal("not the expected Requests")
+	}
+	if result.SOCKSProxy != "" {
+		t.Fatal("not the expected SOCKSProxy")
+	}
+	if result.TCPConnect != nil {
+		t.Fatal("not the expected TCPConnect")
+	}
+	if result.TLSHandshakes != nil {
+		t.Fatal("not the expected TLSHandshakes")
+	}
+	if result.Tunnel != "" {
+		t.Fatal("not the expected Tunnel")
+	}
 	if result.SNI != "kernel.org" {
 		t.Fatal("unexpected SNI")
+	}
+	if result.THAddress != "example.com:443" {
+		t.Fatal("unexpected THAddress")
 	}
 }
 
@@ -204,11 +243,47 @@ func TestUnitMeasureoneSuccess(t *testing.T) {
 		"kernel.org",
 		"example.com:443",
 	)
-	if *result.Failure != modelx.FailureSSLInvalidHostname {
+	if result.Agent != "redirect" {
+		t.Fatal("not the expected Agent")
+	}
+	if result.BootstrapTime != 0.0 {
+		t.Fatal("not the expected BootstrapTime")
+	}
+	if result.DNSCache != nil {
+		t.Fatal("not the expected DNSCache")
+	}
+	if result.FailedOperation == nil || *result.FailedOperation != modelx.TLSHandshakeOperation {
+		t.Fatal("not the expected FailedOperation")
+	}
+	if result.Failure == nil || *result.Failure != modelx.FailureSSLInvalidHostname {
 		t.Fatal("unexpected failure")
+	}
+	if len(result.NetworkEvents) < 1 {
+		t.Fatal("not the expected NetworkEvents")
+	}
+	if len(result.Queries) < 1 {
+		t.Fatal("not the expected Queries")
+	}
+	if result.Requests != nil {
+		t.Fatal("not the expected Requests")
+	}
+	if result.SOCKSProxy != "" {
+		t.Fatal("not the expected SOCKSProxy")
+	}
+	if len(result.TCPConnect) < 1 {
+		t.Fatal("not the expected TCPConnect")
+	}
+	if len(result.TLSHandshakes) < 1 {
+		t.Fatal("not the expected TLSHandshakes")
+	}
+	if result.Tunnel != "" {
+		t.Fatal("not the expected Tunnel")
 	}
 	if result.SNI != "kernel.org" {
 		t.Fatal("unexpected SNI")
+	}
+	if result.THAddress != "example.com:443" {
+		t.Fatal("unexpected THAddress")
 	}
 }
 

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -198,7 +198,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	if result.DNSCache != nil {
 		t.Fatal("not the expected DNSCache")
 	}
-	if result.FailedOperation != nil {
+	if result.FailedOperation == nil || *result.FailedOperation != modelx.TopLevelOperation {
 		t.Fatal("not the expected FailedOperation")
 	}
 	if result.Failure == nil || *result.Failure != modelx.FailureInterrupted {

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -42,8 +42,8 @@ type TestKeys struct {
 	NetworkEvents   []archival.NetworkEvent    `json:"network_events"`
 	Queries         []archival.DNSQueryEntry   `json:"queries"`
 	Requests        []archival.RequestEntry    `json:"requests"`
-	TCPConnect      []archival.TCPConnectEntry `json:"tcp_connect"`
 	SOCKSProxy      string                     `json:"socksproxy,omitempty"`
+	TCPConnect      []archival.TCPConnectEntry `json:"tcp_connect"`
 	TLSHandshakes   []archival.TLSHandshake    `json:"tls_handshakes"`
 	Tunnel          string                     `json:"tunnel,omitempty"`
 


### PR DESCRIPTION
A more substantial rewrite would have been possible. But let's proceed
piecemeal and, for now, just stop depending on the old netx.

This was the objective and we achieved it.

When we'll tackle the task of improving testing, we'll also refactor
the tests and see if we can also simplify sniblocking further.

Part of https://github.com/ooni/probe-engine/issues/684