### PR TITLE
fix(selfcensor.go): add timeout for default net.Dialer

### DIFF
--- a/netx/selfcensor/selfcensor.go
+++ b/netx/selfcensor/selfcensor.go
@@ -29,6 +29,7 @@ import (
 	"log"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/ooni/probe-engine/atomicx"
 )
@@ -148,8 +149,11 @@ func (r SystemResolver) Address() string {
 // not censor anything unless you call selfcensor.Enable().
 type SystemDialer struct{}
 
-// defaultDialer is the dialer we use by default
-var defaultDialer = new(net.Dialer)
+// defaultNetDialer is the dialer we use by default
+var defaultNetDialer = &net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 30 * time.Second,
+}
 
 // DialContext implements Dialer.DialContext
 func (d SystemDialer) DialContext(
@@ -173,7 +177,7 @@ func (d SystemDialer) DialContext(
 			}
 		}
 		if spec.BlockedFingerprints != nil {
-			conn, err := defaultDialer.DialContext(ctx, network, address)
+			conn, err := defaultNetDialer.DialContext(ctx, network, address)
 			if err != nil {
 				return nil, err
 			}
@@ -182,7 +186,7 @@ func (d SystemDialer) DialContext(
 		}
 		// FALLTHROUGH
 	}
-	return defaultDialer.DialContext(ctx, network, address)
+	return defaultNetDialer.DialContext(ctx, network, address)
 }
 
 type connWrapper struct {

--- a/netx/selfcensor/selfcensor.go
+++ b/netx/selfcensor/selfcensor.go
@@ -149,7 +149,8 @@ func (r SystemResolver) Address() string {
 // not censor anything unless you call selfcensor.Enable().
 type SystemDialer struct{}
 
-// defaultNetDialer is the dialer we use by default
+// defaultNetDialer is the dialer we use by default. The values are the
+// same values used by golang's net/http DefaultTransport.
 var defaultNetDialer = &net.Dialer{
 	Timeout:   30 * time.Second,
 	KeepAlive: 30 * time.Second,


### PR DESCRIPTION
While there use a more clear name for this variable.

Closes https://github.com/ooni/probe-engine/issues/764