### PR TITLE
selfcensor: expose a Dialer that others can reuse

### DIFF
--- a/netx/selfcensor/selfcensor.go
+++ b/netx/selfcensor/selfcensor.go
@@ -156,6 +156,10 @@ var defaultNetDialer = &net.Dialer{
 	KeepAlive: 30 * time.Second,
 }
 
+// DefaultDialer is the dialer you should use in code that wants
+// to take advantage of selfcensor capabilities.
+var DefaultDialer = SystemDialer{}
+
 // DialContext implements Dialer.DialContext
 func (d SystemDialer) DialContext(
 	ctx context.Context, network, address string) (net.Conn, error) {


### PR DESCRIPTION
This will allow HHFM to use a Dialer for which self censorship
works, which in turn enables quick testing.

Part of https://github.com/ooni/probe-engine/issues/763