### PR TITLE
DoH: better timeouts and TRR2-like implementation

### DIFF
--- a/internal/sessionresolver/sessionresolver.go
+++ b/internal/sessionresolver/sessionresolver.go
@@ -42,11 +42,10 @@ func (r *Resolver) CloseIdleConnections() {
 
 // LookupHost implements Resolver.LookupHost
 func (r *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
-	// We doing this like Firefox trr 2 mode. See here:
+	// Algorithm similar to Firefox TRR2 mode. See:
 	// https://wiki.mozilla.org/Trusted_Recursive_Resolver#DNS-over-HTTPS_Prefs_in_Firefox
-	// And here: network.trr.request_timeout_ms
-	// But we use a higher timeout than Firefox to be safe and use DoH more
-	// often if possible
+	// We use a higher timeout than Firefox's timeout (1.5s) to be on the safe side
+	// and therefore see to use DoH more often.
 	trr2, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
 	addrs, err := r.Primary.LookupHost(trr2, hostname)

--- a/netx/resolver/dnsoverhttps.go
+++ b/netx/resolver/dnsoverhttps.go
@@ -26,7 +26,7 @@ func NewDNSOverHTTPS(client *http.Client, URL string) DNSOverHTTPS {
 
 // RoundTrip implements RoundTripper.RoundTrip.
 func (t DNSOverHTTPS) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 	req, err := http.NewRequest("POST", t.URL, bytes.NewReader(query))
 	if err != nil {

--- a/netx/selfcensor/selfcensor.go
+++ b/netx/selfcensor/selfcensor.go
@@ -152,8 +152,8 @@ type SystemDialer struct{}
 // defaultNetDialer is the dialer we use by default. The values are the
 // same values used by golang's net/http DefaultTransport.
 var defaultNetDialer = &net.Dialer{
-	Timeout:   30 * time.Second,
-	KeepAlive: 30 * time.Second,
+	Timeout:   15 * time.Second,
+	KeepAlive: 15 * time.Second,
 }
 
 // DefaultDialer is the dialer you should use in code that wants

--- a/netx/selfcensor/selfcensor.go
+++ b/netx/selfcensor/selfcensor.go
@@ -149,8 +149,7 @@ func (r SystemResolver) Address() string {
 // not censor anything unless you call selfcensor.Enable().
 type SystemDialer struct{}
 
-// defaultNetDialer is the dialer we use by default. The values are the
-// same values used by golang's net/http DefaultTransport.
+// defaultNetDialer is the dialer we use by default.
 var defaultNetDialer = &net.Dialer{
 	Timeout:   15 * time.Second,
 	KeepAlive: 15 * time.Second,


### PR DESCRIPTION
Let us use 15 seconds as timeout for connecting. Let us give DoH 45 seconds to resolve by default. This means, if there are timeouts, we can attempt with three IP addresses. At the same time, implement something like TRR2 for the session resolver such that we fallback to using the system resolver quite quickly if DoH doesn't work.