### PR TITLE
cmd/miniooni/main.go: print log message in case of panic

### DIFF
--- a/cmd/miniooni/main.go
+++ b/cmd/miniooni/main.go
@@ -2,15 +2,15 @@
 package main
 
 import (
-	"os"
+	"log"
 
 	"github.com/ooni/probe-engine/libminiooni"
 )
 
 func main() {
 	defer func() {
-		if recover() != nil {
-			os.Exit(1)
+		if s := recover(); s != nil {
+			log.Fatal(s)
 		}
 	}()
 	libminiooni.Main()


### PR DESCRIPTION
Makes it much more obvious that something went wrong beyond just
inspecting the exit code and noticing is nonzero.

Part of https://github.com/ooni/probe-engine/issues/763