### PR TITLE
Rewrite Web Connectivity in Go (1/n)

### DIFF
--- a/experiment/webconnectivity/analyze.go
+++ b/experiment/webconnectivity/analyze.go
@@ -1,0 +1,7 @@
+package webconnectivity
+
+// Analyze performs follow-up analysis on the webconnectivity measurement by
+// comparing the measurement (tk.TestKeys) and the control (tk.Control).
+func Analyze(tk *TestKeys) {
+	// TODO(bassosimone): implement
+}

--- a/experiment/webconnectivity/control.go
+++ b/experiment/webconnectivity/control.go
@@ -1,0 +1,113 @@
+package webconnectivity
+
+import (
+	"context"
+	"net"
+	"strconv"
+
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/geoiplookup/mmdblookup"
+	"github.com/ooni/probe-engine/internal/httpx"
+	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/errorx"
+	"github.com/ooni/probe-engine/netx/modelx"
+)
+
+// ControlRequest is the request that we send to the control
+type ControlRequest struct {
+	HTTPRequest        string              `json:"http_request"`
+	HTTPRequestHeaders map[string][]string `json:"http_request_headers"`
+	TCPConnect         []string            `json:"tcp_connect"`
+}
+
+// NewControlRequest creates a new control request from the result
+// obtained by measuring the target URL and the target URL.
+func NewControlRequest(
+	target model.MeasurementTarget, result urlgetter.TestKeys) (out ControlRequest) {
+	out.HTTPRequest = string(target)
+	out.HTTPRequestHeaders = make(map[string][]string)
+	if len(result.Requests) >= 1 {
+		// Only these headers are accepted by the control service. We use the
+		// canonical canonicalisation, which is what Go enforces.
+		for _, key := range []string{"User-Agent", "Accept", "Accept-Language"} {
+			// We never set multi line headers so using the map instead of the list
+			// is totally fine and saves us some extra lines of code.
+			if value, ok := result.Requests[0].Request.Headers[key]; ok {
+				out.HTTPRequestHeaders[key] = []string{value.Value}
+			}
+		}
+	}
+	// Just in case we have multiple endpoints/attempts, reduce them:
+	epnts := make(map[string]int)
+	for _, entry := range result.TCPConnect {
+		epnts[net.JoinHostPort(entry.IP, strconv.Itoa(entry.Port))]++
+	}
+	for key := range epnts {
+		out.TCPConnect = append(out.TCPConnect, key)
+	}
+	return
+}
+
+// ControlTCPConnectResult is the result of the TCP connect
+// attempt performed by the control vantage point.
+type ControlTCPConnectResult struct {
+	Status  bool    `json:"status"`
+	Failure *string `json:"failure"`
+}
+
+// ControlHTTPRequestResult is the result of the HTTP request
+// performed by the control vantage point.
+type ControlHTTPRequestResult struct {
+	BodyLength int64             `json:"body_length"`
+	Failure    *string           `json:"failure"`
+	Title      string            `json:"title"`
+	Headers    map[string]string `json:"headers"`
+	StatusCode int64             `json:"status_code"`
+}
+
+// ControlDNSResult is the result of the DNS lookup
+// performed by the control vantage point.
+type ControlDNSResult struct {
+	Failure *string  `json:"failure"`
+	Addrs   []string `json:"addrs"`
+	ASNs    []int64  `json:"x_asns"` // not in spec
+}
+
+// ControlResponse is the response from the control service.
+type ControlResponse struct {
+	TCPConnect  map[string]ControlTCPConnectResult `json:"tcp_connect"`
+	HTTPRequest ControlHTTPRequestResult           `json:"http_request"`
+	DNS         ControlDNSResult                   `json:"dns"`
+}
+
+// Control performs the control request and returns the response.
+func Control(
+	ctx context.Context, sess model.ExperimentSession,
+	thAddr string, creq ControlRequest) (out ControlResponse, err error) {
+	clnt := httpx.Client{
+		BaseURL:    thAddr,
+		HTTPClient: sess.DefaultHTTPClient(),
+		Logger:     sess.Logger(),
+	}
+	// make sure error is wrapped
+	err = errorx.SafeErrWrapperBuilder{
+		Error:     clnt.PostJSON(ctx, "/", creq, &out),
+		Operation: modelx.TopLevelOperation,
+	}.MaybeBuild()
+	(&out.DNS).FillASNs(sess)
+	return
+}
+
+// FillASNs fills the ASNs array of ControlDNSResult. For each Addr inside
+// of the ControlDNSResult structure, we obtain the corresponding ASN.
+//
+// This is very useful to know what ASNs were the IP addresses returned by
+// the control according to the probe's database.
+func (dns *ControlDNSResult) FillASNs(sess model.ExperimentSession) {
+	for _, ip := range dns.Addrs {
+		// TODO(bassosimone): this would be more efficient if we'd open just
+		// once the database and then reuse it for every address.
+		asn, _, _ := mmdblookup.ASN(sess.ASNDatabasePath(), ip)
+		dns.ASNs = append(dns.ASNs, int64(asn))
+	}
+}

--- a/experiment/webconnectivity/measure.go
+++ b/experiment/webconnectivity/measure.go
@@ -1,0 +1,20 @@
+package webconnectivity
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/model"
+)
+
+// Measure performs the measurement given the context, the current
+// measurement session, and the measurement target.
+func Measure(
+	ctx context.Context, sess model.ExperimentSession,
+	target model.MeasurementTarget) (result urlgetter.TestKeys) {
+	g := urlgetter.Getter{Session: sess, Target: string(target)}
+	// Ignoring the error because g.Get() sets the tk.Failure field
+	// to be the OONI equivalent of the error that occurred.
+	result, _ = g.Get(ctx)
+	return
+}

--- a/experiment/webconnectivity/webconnectivity.go
+++ b/experiment/webconnectivity/webconnectivity.go
@@ -24,8 +24,13 @@ type Config struct{}
 
 // TestKeys contains webconnectivity test keys.
 type TestKeys struct {
+	// measurement
 	urlgetter.TestKeys
-	ClientResolver string          `json:"client_resolver"`
+
+	// contextual information
+	ClientResolver string `json:"client_resolver"`
+
+	// control
 	ControlFailure *string         `json:"control_failure"`
 	ControlRequest ControlRequest  `json:"x_control_request"` // not in the spec
 	Control        ControlResponse `json:"control"`

--- a/experiment/webconnectivity/webconnectivity.go
+++ b/experiment/webconnectivity/webconnectivity.go
@@ -1,0 +1,110 @@
+// Package webconnectivity implements OONI's Web Connectivity experiment.
+//
+// See https://github.com/ooni/spec/blob/master/nettests/ts-017-web-connectivity.md
+package webconnectivity
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/model"
+	"github.com/ooni/probe-engine/netx/archival"
+)
+
+const (
+	testName    = "web_connectivity"
+	testVersion = "0.1.0"
+)
+
+// Config contains the experiment config.
+type Config struct{}
+
+// TestKeys contains webconnectivity test keys.
+type TestKeys struct {
+	urlgetter.TestKeys
+	ClientResolver string          `json:"client_resolver"`
+	ControlFailure *string         `json:"control_failure"`
+	ControlRequest ControlRequest  `json:"x_control_request"` // not in the spec
+	Control        ControlResponse `json:"control"`
+}
+
+// Measurer performs the measurement.
+type Measurer struct {
+	Config Config
+}
+
+// NewExperimentMeasurer creates a new ExperimentMeasurer.
+func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
+	return Measurer{Config: config}
+}
+
+// ExperimentName implements ExperimentMeasurer.ExperExperimentName.
+func (m Measurer) ExperimentName() string {
+	return testName
+}
+
+// ExperimentVersion implements ExperimentMeasurer.ExperExperimentVersion.
+func (m Measurer) ExperimentVersion() string {
+	return testVersion
+}
+
+var (
+	// ErrNoAvailableTestHelpers is emitted when there are no available test helpers.
+	ErrNoAvailableTestHelpers = errors.New("no available helpers")
+
+	// ErrNoInput indicates that no input was provided
+	ErrNoInput = errors.New("no input provided")
+
+	// ErrUnsupportedInput indicates that the input URL scheme is unsupported.
+	ErrUnsupportedInput = errors.New("unsupported input scheme")
+)
+
+// Run implements ExperimentMeasurer.Run.
+func (m Measurer) Run(
+	ctx context.Context,
+	sess model.ExperimentSession,
+	measurement *model.Measurement,
+	callbacks model.ExperimentCallbacks,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	urlgetter.RegisterExtensions(measurement)
+	tk := new(TestKeys)
+	measurement.TestKeys = tk
+	tk.ClientResolver = sess.ResolverIP()
+	if measurement.Input == "" {
+		return ErrNoInput
+	}
+	if strings.HasPrefix(string(measurement.Input), "http://") != true &&
+		strings.HasPrefix(string(measurement.Input), "https://") != true {
+		return ErrUnsupportedInput
+	}
+	// 1. find test helper
+	testhelpers, _ := sess.GetTestHelpersByName("web-connectivity")
+	var testhelper *model.Service
+	for _, th := range testhelpers {
+		if th.Type == "https" {
+			testhelper = &th
+			break
+		}
+	}
+	if testhelper == nil {
+		return ErrNoAvailableTestHelpers
+	}
+	measurement.TestHelpers = map[string]interface{}{
+		"backend": testhelper,
+	}
+	// 2. perform the measurement
+	tk.TestKeys = Measure(ctx, sess, measurement.Input)
+	// 3. contact the control
+	tk.ControlRequest = NewControlRequest(measurement.Input, tk.TestKeys)
+	var err error
+	tk.Control, err = Control(ctx, sess, testhelper.Address, tk.ControlRequest)
+	tk.ControlFailure = archival.NewFailure(err)
+	// 4. compare measurement to control
+	Analyze(tk)
+	return nil
+}

--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -29,6 +29,7 @@ type ExperimentSession struct {
 	MockableProbeIP              string
 	MockableProbeNetworkName     string
 	MockableProxyURL             *url.URL
+	MockableResolverIP           string
 	MockableSoftwareName         string
 	MockableSoftwareVersion      string
 	MockableTempDir              string
@@ -120,6 +121,11 @@ func (sess *ExperimentSession) ProbeNetworkName() string {
 // ProxyURL implements ExperimentSession.ProxyURL
 func (sess *ExperimentSession) ProxyURL() *url.URL {
 	return sess.MockableProxyURL
+}
+
+// ResolverIP implements ExperimentSession.ResolverIP
+func (sess *ExperimentSession) ResolverIP() string {
+	return sess.MockableResolverIP
 }
 
 // SoftwareName implements ExperimentSession.SoftwareName

--- a/model/model.go
+++ b/model/model.go
@@ -381,6 +381,7 @@ type ExperimentSession interface {
 	ProbeIP() string
 	ProbeNetworkName() string
 	ProxyURL() *url.URL
+	ResolverIP() string
 	SoftwareName() string
 	SoftwareVersion() string
 	TempDir() string


### PR DESCRIPTION
This diff implements the basic machinery. We perform the measurement
and the control measurement. We'll write tests next.

For now, we still use MK for Web Connectivity. We will not switch to the
new implementation until it's feature complete and tested.

Part of https://github.com/ooni/probe-engine/issues/776.