### PR TITLE
internal/httpheader: stop claiming headers are random

### DIFF
--- a/experiment/hhfm/hhfm.go
+++ b/experiment/hhfm/hhfm.go
@@ -122,12 +122,12 @@ func (m Measurer) Run(
 		return err
 	}
 	headers := map[string]string{
-		randx.ChangeCapitalization("Accept"):          httpheader.RandomAccept(),
+		randx.ChangeCapitalization("Accept"):          httpheader.Accept(),
 		randx.ChangeCapitalization("Accept-Charset"):  "ISO-8859-1,utf-8;q=0.7,*;q=0.3",
 		randx.ChangeCapitalization("Accept-Encoding"): "gzip,deflate,sdch",
-		randx.ChangeCapitalization("Accept-Language"): httpheader.RandomAcceptLanguage(),
+		randx.ChangeCapitalization("Accept-Language"): httpheader.AcceptLanguage(),
 		randx.ChangeCapitalization("Host"):            randx.Letters(15) + ".com",
-		randx.ChangeCapitalization("User-Agent"):      httpheader.RandomUserAgent(),
+		randx.ChangeCapitalization("User-Agent"):      httpheader.UserAgent(),
 	}
 	for key, value := range headers {
 		// Implementation note: Golang will normalize the header names. We will use

--- a/experiment/tor/tor.go
+++ b/experiment/tor/tor.go
@@ -372,15 +372,15 @@ func (rc *resultsCollector) defaultFlexibleConnect(
 		}
 		const snapshotsize = 1 << 8 // no need to include all in report
 		r := oonitemplates.HTTPDo(ctx, oonitemplates.HTTPDoConfig{
-			Accept:                  httpheader.RandomAccept(),
-			AcceptLanguage:          httpheader.RandomAcceptLanguage(),
+			Accept:                  httpheader.Accept(),
+			AcceptLanguage:          httpheader.AcceptLanguage(),
 			Beginning:               rc.measurement.MeasurementStartTimeSaved,
 			MaxEventsBodySnapSize:   snapshotsize,
 			MaxResponseBodySnapSize: snapshotsize,
 			Handler:                 netxlogger.NewHandler(logger),
 			Method:                  "GET",
 			URL:                     url.String(),
-			UserAgent:               httpheader.RandomUserAgent(),
+			UserAgent:               httpheader.UserAgent(),
 		})
 		tk, err = r.TestKeys, r.Error
 	case "or_port", "or_port_dirauth":

--- a/experiment/urlgetter/runner.go
+++ b/experiment/urlgetter/runner.go
@@ -56,7 +56,7 @@ func (r Runner) Run(ctx context.Context) error {
 // returns httpheader.RandomUserAgent().
 func MaybeRandomUserAgent(ua string) string {
 	if ua == "" {
-		ua = httpheader.RandomUserAgent()
+		ua = httpheader.UserAgent()
 	}
 	return ua
 }
@@ -66,8 +66,8 @@ func (r Runner) httpGet(ctx context.Context, url string) error {
 	req, err := http.NewRequest(r.Config.Method, url, nil)
 	runtimex.PanicOnError(err, "http.NewRequest failed")
 	req = req.WithContext(ctx)
-	req.Header.Set("Accept", httpheader.RandomAccept())
-	req.Header.Set("Accept-Language", httpheader.RandomAcceptLanguage())
+	req.Header.Set("Accept", httpheader.Accept())
+	req.Header.Set("Accept-Language", httpheader.AcceptLanguage())
 	req.Header.Set("User-Agent", MaybeRandomUserAgent(r.Config.UserAgent))
 	if r.Config.HTTPHost != "" {
 		req.Host = r.Config.HTTPHost

--- a/experiment/urlgetter/runner_test.go
+++ b/experiment/urlgetter/runner_test.go
@@ -261,7 +261,7 @@ func TestRunnerWeCanForceUserAgent(t *testing.T) {
 }
 
 func TestRunnerDefaultUserAgent(t *testing.T) {
-	expected := httpheader.RandomUserAgent()
+	expected := httpheader.UserAgent()
 	found := atomicx.NewInt64()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("User-Agent") == expected {

--- a/internal/httpheader/accept.go
+++ b/internal/httpheader/accept.go
@@ -1,8 +1,6 @@
 package httpheader
 
-// RandomAccept returns a random Accept header.
-func RandomAccept() string {
-	// This is the same that is returned by MK. We have #147 to
-	// ensure that headers are randomized, if needed.
+// Accept returns the Accept header used for measuring.
+func Accept() string {
 	return "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 }

--- a/internal/httpheader/acceptlanguage.go
+++ b/internal/httpheader/acceptlanguage.go
@@ -1,8 +1,6 @@
 package httpheader
 
-// RandomAcceptLanguage returns a random Accept-Language header
-func RandomAcceptLanguage() string {
-	// This is the same that is returned by MK. We have #147 to
-	// ensure that headers are randomized, if needed.
+// AcceptLanguage returns the Accept-Language header used for measuring.
+func AcceptLanguage() string {
 	return "en-US;q=0.8,en;q=0.5"
 }

--- a/internal/httpheader/useragent.go
+++ b/internal/httpheader/useragent.go
@@ -1,7 +1,7 @@
 // Package httpheader contains code to set common HTTP headers.
 package httpheader
 
-// UserAgent returns the User-Agent used for measuring.
+// UserAgent returns the User-Agent header used for measuring.
 func UserAgent() string {
 	// 14.9% as of Jun 25, 2020 according to https://techblog.willshouse.com/2012/01/03/most-common-user-agents/
 	const ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"

--- a/internal/httpheader/useragent.go
+++ b/internal/httpheader/useragent.go
@@ -1,11 +1,8 @@
 // Package httpheader contains code to set common HTTP headers.
 package httpheader
 
-// RandomUserAgent returns a random User-Agent
-func RandomUserAgent() string {
-	// TODO(bassosimone): this user-agent solution is temporary and we
-	// should instead select one among many user agents. See #147.
-	//
+// UserAgent returns the User-Agent used for measuring.
+func UserAgent() string {
 	// 14.9% as of Jun 25, 2020 according to https://techblog.willshouse.com/2012/01/03/most-common-user-agents/
 	const ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
 	return ua

--- a/netx/resolver/dnsoverhttps.go
+++ b/netx/resolver/dnsoverhttps.go
@@ -32,7 +32,7 @@ func (t DNSOverHTTPS) RoundTrip(ctx context.Context, query []byte) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("user-agent", httpheader.RandomUserAgent())
+	req.Header.Set("user-agent", httpheader.UserAgent())
 	req.Header.Set("content-type", "application/dns-message")
 	var resp *http.Response
 	resp, err = t.Do(req.WithContext(ctx))

--- a/netx/resolver/dnsoverhttps_test.go
+++ b/netx/resolver/dnsoverhttps_test.go
@@ -122,7 +122,7 @@ func TestUnitDNSOverHTTPSClientSetsUserAgent(t *testing.T) {
 	var correct bool
 	txp := resolver.DNSOverHTTPS{
 		Do: func(req *http.Request) (*http.Response, error) {
-			correct = req.Header.Get("User-Agent") == httpheader.RandomUserAgent()
+			correct = req.Header.Get("User-Agent") == httpheader.UserAgent()
 			return nil, expected
 		},
 		URL: "https://doh.powerdns.org/",

--- a/session.go
+++ b/session.go
@@ -466,7 +466,7 @@ func (s *Session) lookupProbeIP(ctx context.Context) (string, error) {
 	return (&iplookup.Client{
 		HTTPClient: s.DefaultHTTPClient(),
 		Logger:     s.logger,
-		UserAgent:  httpheader.RandomUserAgent(), // no need to identify as OONI
+		UserAgent:  httpheader.UserAgent(), // no need to identify as OONI
 	}).Do(ctx)
 }
 


### PR DESCRIPTION
Life is already too complicated that adding a level of randomness here
is possibly only going to confuse TLS MITM detection.

Play it simple and use always same headers.

Part of https://github.com/ooni/probe-engine/issues/776