### PR TITLE
QA/webconnectivity: control failure w/ HTTP website

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -80,6 +80,7 @@ def webconnectivity_transparent_http_proxy(ooni_exe, outfile):
     assert tk["dns_experiment_failure"] == None
     assert tk["dns_consistency"] == "consistent"
     assert tk["control_failure"] == None
+    assert tk["http_experiment_failure"] == None
     assert tk["body_length_match"] == True
     assert tk["body_proportion"] == 1
     assert tk["status_code_match"] == True
@@ -105,6 +106,7 @@ def webconnectivity_dns_hijacking(ooni_exe, outfile):
     assert tk["dns_experiment_failure"] == None
     assert tk["dns_consistency"] == "inconsistent"
     assert tk["control_failure"] == None
+    assert tk["http_experiment_failure"] == None
     assert tk["body_length_match"] == True
     assert tk["body_proportion"] == 1
     assert tk["status_code_match"] == True
@@ -112,6 +114,31 @@ def webconnectivity_dns_hijacking(ooni_exe, outfile):
     assert tk["title_match"] == True
     assert tk["blocking"] == False
     assert tk["accessible"] == True
+
+def webconnectivity_control_unreachable_http(ooni_exe, outfile):
+    """ Test case where the control is unreachable and we're using the
+        plaintext HTTP protocol rather than HTTPS """
+    args = []
+    args.append("-iptables-reset-keyword")
+    args.append("wcth.ooni.io")
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i http://example.org web_connectivity",
+        "webconnectivity_control_unreachable_http",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == None
+    assert tk["control_failure"] == "connection_reset"
+    assert tk["http_experiment_failure"] == None
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    assert tk["blocking"] == None
+    assert tk["accessible"] == None
 
 
 def main():
@@ -122,6 +149,7 @@ def main():
     tests = [
         webconnectivity_transparent_http_proxy,
         webconnectivity_dns_hijacking,
+        webconnectivity_control_unreachable_http,
     ]
     for test in tests:
         test(ooni_exe, outfile)

--- a/experiment/webconnectivity/dnsanalysis.go
+++ b/experiment/webconnectivity/dnsanalysis.go
@@ -10,7 +10,7 @@ import (
 // DNSAnalysisResult contains the results of analysing comparing
 // the measurement and the control DNS results.
 type DNSAnalysisResult struct {
-	DNSConsistency string `json:"dns_consistency"`
+	DNSConsistency *string `json:"dns_consistency"`
 }
 
 // DNSNameError is the error returned by the control on NXDOMAIN
@@ -32,11 +32,11 @@ var (
 func DNSAnalysis(URL *url.URL, measurement DNSLookupResult,
 	control ControlResponse) (out DNSAnalysisResult) {
 	// 0. start assuming it's not consistent
-	out.DNSConsistency = DNSInconsistent
+	out.DNSConsistency = &DNSInconsistent
 	// 1. flip to consistent if we're targeting an IP address because the
 	// control will actually return dns_name_error in this case.
 	if net.ParseIP(URL.Hostname()) != nil {
-		out.DNSConsistency = DNSConsistent
+		out.DNSConsistency = &DNSConsistent
 		return
 	}
 	// 2. flip to consistent if the failures are compatible
@@ -45,7 +45,7 @@ func DNSAnalysis(URL *url.URL, measurement DNSLookupResult,
 		case DNSNameError: // the control returns this on NXDOMAIN error
 			switch *measurement.Failure {
 			case modelx.FailureDNSNXDOMAINError:
-				out.DNSConsistency = DNSConsistent
+				out.DNSConsistency = &DNSConsistent
 			}
 		}
 		return
@@ -74,7 +74,7 @@ func DNSAnalysis(URL *url.URL, measurement DNSLookupResult,
 	for key, value := range asnmap {
 		// zero means that ASN lookup failed
 		if key != 0 && (value&inBoth) == inBoth {
-			out.DNSConsistency = DNSConsistent
+			out.DNSConsistency = &DNSConsistent
 			return
 		}
 	}
@@ -90,7 +90,7 @@ func DNSAnalysis(URL *url.URL, measurement DNSLookupResult,
 	for key, value := range ipmap {
 		// just in case an empty string slipped through
 		if key != "" && (value&inBoth) == inBoth {
-			out.DNSConsistency = DNSConsistent
+			out.DNSConsistency = &DNSConsistent
 			return
 		}
 	}

--- a/experiment/webconnectivity/dnsanalysis_test.go
+++ b/experiment/webconnectivity/dnsanalysis_test.go
@@ -36,7 +36,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSConsistent,
+			DNSConsistency: &webconnectivity.DNSConsistent,
 		},
 	}, {
 		name: "when the failures are not compatible",
@@ -54,7 +54,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSInconsistent,
+			DNSConsistency: &webconnectivity.DNSInconsistent,
 		},
 	}, {
 		name: "when the failures are compatible",
@@ -72,7 +72,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSConsistent,
+			DNSConsistency: &webconnectivity.DNSConsistent,
 		},
 	}, {
 		name: "when the ASNs are equal",
@@ -93,7 +93,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSConsistent,
+			DNSConsistency: &webconnectivity.DNSConsistent,
 		},
 	}, {
 		name: "when the ASNs overlap",
@@ -114,7 +114,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSConsistent,
+			DNSConsistency: &webconnectivity.DNSConsistent,
 		},
 	}, {
 		name: "when the ASNs do not overlap",
@@ -135,7 +135,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSInconsistent,
+			DNSConsistency: &webconnectivity.DNSInconsistent,
 		},
 	}, {
 		name: "when ASNs lookup fails but IPs overlap",
@@ -157,7 +157,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSConsistent,
+			DNSConsistency: &webconnectivity.DNSConsistent,
 		},
 	}, {
 		name: "when ASNs lookup fails and IPs do not overlap",
@@ -179,7 +179,7 @@ func TestDNSAnalysis(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.DNSAnalysisResult{
-			DNSConsistency: webconnectivity.DNSInconsistent,
+			DNSConsistency: &webconnectivity.DNSInconsistent,
 		},
 	}}
 	for _, tt := range tests {

--- a/experiment/webconnectivity/httpanalysis.go
+++ b/experiment/webconnectivity/httpanalysis.go
@@ -1,48 +1,32 @@
 package webconnectivity
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
 
 	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/experiment/webconnectivity/internal"
 	"github.com/ooni/probe-engine/model"
 )
 
 // HTTPAnalysisResult contains the results of the analysis performed on the
 // client. We obtain it by comparing the measurement and the control.
 type HTTPAnalysisResult struct {
-	BodyLengthMatch *bool    `json:"body_length_match"`
-	BodyProportion  *float64 `json:"body_proportion"`
-	StatusCodeMatch *bool    `json:"status_code_match"`
-	HeadersMatch    *bool    `json:"headers_match"`
-	TitleMatch      *bool    `json:"title_match"`
-}
-
-func boolPointerToString(v *bool) (out string) {
-	out = "nil"
-	if v != nil {
-		out = fmt.Sprintf("%+v", *v)
-	}
-	return
-}
-
-func float64PointerToString(v *float64) (out string) {
-	out = "nil"
-	if v != nil {
-		out = fmt.Sprintf("%+v", *v)
-	}
-	return
+	BodyLengthMatch *bool   `json:"body_length_match"`
+	BodyProportion  float64 `json:"body_proportion"`
+	StatusCodeMatch *bool   `json:"status_code_match"`
+	HeadersMatch    *bool   `json:"headers_match"`
+	TitleMatch      *bool   `json:"title_match"`
 }
 
 // Log logs the results of the analysis
 func (har HTTPAnalysisResult) Log(logger model.Logger) {
-	logger.Infof("BodyLengthMatch: %+v", boolPointerToString(har.BodyLengthMatch))
-	logger.Infof("BodyProportion: %+v", float64PointerToString(har.BodyProportion))
-	logger.Infof("StatusCodeMatch: %+v", boolPointerToString(har.StatusCodeMatch))
-	logger.Infof("HeadersMatch: %+v", boolPointerToString(har.HeadersMatch))
-	logger.Infof("TitleMatch: %+v", boolPointerToString(har.TitleMatch))
+	logger.Infof("BodyLengthMatch: %+v", internal.BoolPointerToString(har.BodyLengthMatch))
+	logger.Infof("BodyProportion: %+v", har.BodyProportion)
+	logger.Infof("StatusCodeMatch: %+v", internal.BoolPointerToString(har.StatusCodeMatch))
+	logger.Infof("HeadersMatch: %+v", internal.BoolPointerToString(har.HeadersMatch))
+	logger.Infof("TitleMatch: %+v", internal.BoolPointerToString(har.TitleMatch))
 }
 
 // HTTPAnalysis performs follow-up analysis on the webconnectivity measurement by
@@ -60,7 +44,7 @@ func HTTPAnalysis(tk urlgetter.TestKeys, ctrl ControlResponse) (out HTTPAnalysis
 // the two bodies. This check may return nil, nil when such a
 // comparison would actually not be applicable.
 func HTTPBodyLengthChecks(
-	tk urlgetter.TestKeys, ctrl ControlResponse) (match *bool, percentage *float64) {
+	tk urlgetter.TestKeys, ctrl ControlResponse) (match *bool, proportion float64) {
 	control := ctrl.HTTPRequest.BodyLength
 	if control <= 0 {
 		return
@@ -77,7 +61,6 @@ func HTTPBodyLengthChecks(
 		return
 	}
 	const bodyProportionFactor = 0.7
-	var proportion float64
 	if measurement >= control {
 		proportion = float64(control) / float64(measurement)
 	} else {
@@ -85,7 +68,6 @@ func HTTPBodyLengthChecks(
 	}
 	v := proportion > bodyProportionFactor
 	match = &v
-	percentage = &proportion
 	return
 }
 

--- a/experiment/webconnectivity/httpanalysis_test.go
+++ b/experiment/webconnectivity/httpanalysis_test.go
@@ -23,7 +23,7 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 		name        string
 		args        args
 		lengthMatch *bool
-		proportion  *float64
+		proportion  float64
 	}{{
 		name:        "nothing",
 		args:        args{},
@@ -89,7 +89,7 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			},
 		},
 		lengthMatch: &trueValue,
-		proportion:  (func() *float64 { v := 0.75; return &v })(),
+		proportion:  0.75,
 	}, {
 		name: "match with bigger measurement",
 		args: args{
@@ -109,7 +109,7 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			},
 		},
 		lengthMatch: &trueValue,
-		proportion:  (func() *float64 { v := 0.75; return &v })(),
+		proportion:  0.75,
 	}, {
 		name: "not match with bigger control",
 		args: args{
@@ -129,7 +129,7 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			},
 		},
 		lengthMatch: &falseValue,
-		proportion:  (func() *float64 { v := 0.5; return &v })(),
+		proportion:  0.5,
 	}, {
 		name: "match with bigger measurement",
 		args: args{
@@ -149,7 +149,7 @@ func TestHTTPBodyLengthChecks(t *testing.T) {
 			},
 		},
 		lengthMatch: &falseValue,
-		proportion:  (func() *float64 { v := 0.5; return &v })(),
+		proportion:  0.5,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/experiment/webconnectivity/internal/internal.go
+++ b/experiment/webconnectivity/internal/internal.go
@@ -1,0 +1,23 @@
+// Package internal contains internal code.
+package internal
+
+import "fmt"
+
+// StringPointerToString converts a string pointer to a string. When the
+// pointer is null, we return the "nil" string.
+func StringPointerToString(v *string) (out string) {
+	out = "nil"
+	if v != nil {
+		out = fmt.Sprintf("%+v", *v)
+	}
+	return
+}
+
+// BoolPointerToString is like StringPointerToString but for bool.
+func BoolPointerToString(v *bool) (out string) {
+	out = "nil"
+	if v != nil {
+		out = fmt.Sprintf("%+v", *v)
+	}
+	return
+}

--- a/experiment/webconnectivity/internal/internal_test.go
+++ b/experiment/webconnectivity/internal/internal_test.go
@@ -1,0 +1,31 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/ooni/probe-engine/experiment/webconnectivity/internal"
+)
+
+func TestStringPointerToString(t *testing.T) {
+	s := "ANTANI"
+	if internal.StringPointerToString(&s) != s {
+		t.Fatal("unexpected result")
+	}
+	if internal.StringPointerToString(nil) != "nil" {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestBoolPointerToString(t *testing.T) {
+	v := true
+	if internal.BoolPointerToString(&v) != "true" {
+		t.Fatal("unexpected result")
+	}
+	v = false
+	if internal.BoolPointerToString(&v) != "false" {
+		t.Fatal("unexpected result")
+	}
+	if internal.BoolPointerToString(nil) != "nil" {
+		t.Fatal("unexpected result")
+	}
+}

--- a/experiment/webconnectivity/summary_test.go
+++ b/experiment/webconnectivity/summary_test.go
@@ -71,7 +71,7 @@ func TestSummarize(t *testing.T) {
 			tk: &webconnectivity.TestKeys{
 				DNSExperimentFailure: &probeNXDOMAIN,
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: webconnectivity.DNSConsistent,
+					DNSConsistency: &webconnectivity.DNSConsistent,
 				},
 			},
 		},
@@ -85,7 +85,7 @@ func TestSummarize(t *testing.T) {
 		args: args{
 			tk: &webconnectivity.TestKeys{
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: webconnectivity.DNSConsistent,
+					DNSConsistency: &webconnectivity.DNSConsistent,
 				},
 				TCPConnectAttempts:  7,
 				TCPConnectSuccesses: 0,
@@ -101,7 +101,7 @@ func TestSummarize(t *testing.T) {
 		args: args{
 			tk: &webconnectivity.TestKeys{
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: webconnectivity.DNSInconsistent,
+					DNSConsistency: &webconnectivity.DNSInconsistent,
 				},
 				TCPConnectAttempts:  7,
 				TCPConnectSuccesses: 0,
@@ -117,7 +117,10 @@ func TestSummarize(t *testing.T) {
 		args: args{
 			tk: &webconnectivity.TestKeys{
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: "ANTANI",
+					DNSConsistency: func() *string {
+						s := "ANTANI"
+						return &s
+					}(),
 				},
 				TCPConnectAttempts:  7,
 				TCPConnectSuccesses: 0,
@@ -271,7 +274,7 @@ func TestSummarize(t *testing.T) {
 		args: args{
 			tk: &webconnectivity.TestKeys{
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: webconnectivity.DNSInconsistent,
+					DNSConsistency: &webconnectivity.DNSInconsistent,
 				},
 				Requests: []archival.RequestEntry{{
 					Failure: &probeSSLUnknownAuth,
@@ -288,7 +291,7 @@ func TestSummarize(t *testing.T) {
 		args: args{
 			tk: &webconnectivity.TestKeys{
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: webconnectivity.DNSInconsistent,
+					DNSConsistency: &webconnectivity.DNSInconsistent,
 				},
 				Requests: []archival.RequestEntry{{
 					Failure: &probeSSLUnknownAuth,
@@ -358,7 +361,7 @@ func TestSummarize(t *testing.T) {
 				},
 				Requests: []archival.RequestEntry{{}},
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: webconnectivity.DNSInconsistent,
+					DNSConsistency: &webconnectivity.DNSInconsistent,
 				},
 			},
 		},
@@ -377,7 +380,7 @@ func TestSummarize(t *testing.T) {
 				},
 				Requests: []archival.RequestEntry{{}},
 				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
-					DNSConsistency: webconnectivity.DNSConsistent,
+					DNSConsistency: &webconnectivity.DNSConsistent,
 				},
 			},
 		},

--- a/experiment/webconnectivity/webconnectivity.go
+++ b/experiment/webconnectivity/webconnectivity.go
@@ -144,7 +144,9 @@ func (m Measurer) Run(
 	})
 	tk.ControlFailure = archival.NewFailure(err)
 	// 4. analyze DNS results
-	tk.DNSAnalysisResult = DNSAnalysis(URL, dnsResult, tk.Control)
+	if tk.ControlFailure == nil {
+		tk.DNSAnalysisResult = DNSAnalysis(URL, dnsResult, tk.Control)
+	}
 	sess.Logger().Infof("DNS analysis result: %+v", tk.DNSAnalysisResult)
 	// 5. perform TCP/TLS connects
 	connectsResult := Connects(ctx, ConnectsConfig{


### PR DESCRIPTION
We already know that probe-engine does better than MK when there is a control
failure and the website is using HTTPS and we can access it.

MK would flag such case as failed measurement, where instead probe-engine
would flag such case as success.

What we can instead test here is what happens if the same happens but we're
accessing a website using HTTP rather than HTTPS.

This QA test allowed us to discover the following issues:

1. MK always sets the body proportion to zero, even when performing such a
comparison is not actually possible, so do the same also in probe-engine even
though probably using `null` would be a more consistent result

2. MK sets the DNSConsistency field only when the control succeded and we
should do the same rather than flagging the DNS as consistent

This diff includes both the diff adding the new QA check and the required fixes
in probe-engine required to address the two above issues.

Part of https://github.com/ooni/probe-engine/issues/810