### PR TITLE
QA/webconnectivity: TCP/IP blocking w/ inconsistent DNS

### DIFF
--- a/QA/common.py
+++ b/QA/common.py
@@ -5,6 +5,7 @@ import json
 import os
 import shlex
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -59,3 +60,13 @@ def check_maybe_binary_value(value):
         and value["format"] == "base64"
         and isinstance(value["data"], str)
     )
+
+
+def with_free_port(func):
+    """ This function executes |func| passing it a port number on localhost
+        which is bound but not listening for new connections """
+    # See <https://stackoverflow.com/a/45690594>
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        func(sock.getsockname()[1])

--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -162,6 +162,40 @@ def webconnectivity_tcpip_blocking_with_consistent_dns(ooni_exe, outfile):
     assert tk["accessible"] == False
 
 
+def webconnectivity_tcpip_blocking_with_inconsistent_dns(ooni_exe, outfile):
+    """ Test case where there's TCP/IP blocking w/ inconsistent DNS """
+
+    def runner(port):
+        args = [
+            "-dns-proxy-hijack",
+            "nexa.polito.it",
+            "-iptables-hijack-dns-to",
+            "127.0.0.1:53",
+            "-iptables-hijack-http-to",
+            "127.0.0.1:{}".format(port),
+        ]
+        tk = execute_jafar_and_return_validated_test_keys(
+            ooni_exe,
+            outfile,
+            "-i http://nexa.polito.it web_connectivity",
+            "webconnectivity_tcpip_blocking_with_inconsistent_dns",
+            args,
+        )
+        assert tk["dns_experiment_failure"] == None
+        assert tk["dns_consistency"] == "inconsistent"
+        assert tk["control_failure"] == None
+        assert tk["http_experiment_failure"] == "connection_refused"
+        assert tk["body_length_match"] == None
+        assert tk["body_proportion"] == 0
+        assert tk["status_code_match"] == None
+        assert tk["headers_match"] == None
+        assert tk["title_match"] == None
+        assert tk["blocking"] == "dns"
+        assert tk["accessible"] == False
+
+    common.with_free_port(runner)
+
+
 def main():
     if len(sys.argv) != 2:
         sys.exit("usage: %s /path/to/ooniprobelegacy-like/binary" % sys.argv[0])
@@ -173,6 +207,7 @@ def main():
         webconnectivity_control_unreachable_http,
         webconnectivity_nonexistent_domain,
         webconnectivity_tcpip_blocking_with_consistent_dns,
+        webconnectivity_tcpip_blocking_with_inconsistent_dns,
     ]
     for test in tests:
         test(ooni_exe, outfile)

--- a/experiment/webconnectivity/webconnectivity.go
+++ b/experiment/webconnectivity/webconnectivity.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ooni/probe-engine/experiment/webconnectivity/internal"
 	"github.com/ooni/probe-engine/internal/httpheader"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
@@ -147,7 +148,8 @@ func (m Measurer) Run(
 	if tk.ControlFailure == nil {
 		tk.DNSAnalysisResult = DNSAnalysis(URL, dnsResult, tk.Control)
 	}
-	sess.Logger().Infof("DNS analysis result: %+v", tk.DNSAnalysisResult)
+	sess.Logger().Infof("DNS analysis result: %+v", internal.StringPointerToString(
+		tk.DNSAnalysisResult.DNSConsistency))
 	// 5. perform TCP/TLS connects
 	connectsResult := Connects(ctx, ConnectsConfig{
 		Session:       sess,


### PR DESCRIPTION
We open a listening port on localhost but we don't listen to such
port. We redirect HTTP to such port. So connect fails.

We also hijack the DNS such that the target host is localhost.

While there, fix printing the DNS consistency check result.

I have manually checked we match MK's behaviour.