### PR TITLE
QA/webconnectivity: connection refused in redirect chain

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -196,6 +196,36 @@ def webconnectivity_tcpip_blocking_with_inconsistent_dns(ooni_exe, outfile):
     common.with_free_port(runner)
 
 
+def webconnectivity_http_connection_refused_with_consistent_dns(ooni_exe, outfile):
+    """ Test case where there's TCP/IP blocking w/ consistent DNS that occurs
+        while we're following the chain of redirects. """
+    # We use a bit.ly link redirecting to nexa.polito.it. We block the IP address
+    # used by nexa.polito.it. So the error should happen in the redirect chain.
+    ip = socket.gethostbyname("nexa.polito.it")
+    args = [
+        "-iptables-reset-ip",
+        ip,
+    ]
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i https://bit.ly/3h9EJR3 web_connectivity",
+        "webconnectivity_tcpip_blocking_with_consistent_dns",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == "consistent"
+    assert tk["control_failure"] == None
+    assert tk["http_experiment_failure"] == "connection_refused"
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    assert tk["blocking"] == "http-failure"
+    assert tk["accessible"] == False
+
+
 def main():
     if len(sys.argv) != 2:
         sys.exit("usage: %s /path/to/ooniprobelegacy-like/binary" % sys.argv[0])
@@ -208,6 +238,7 @@ def main():
         webconnectivity_nonexistent_domain,
         webconnectivity_tcpip_blocking_with_consistent_dns,
         webconnectivity_tcpip_blocking_with_inconsistent_dns,
+        webconnectivity_http_connection_refused_with_consistent_dns,
     ]
     for test in tests:
         test(ooni_exe, outfile)

--- a/experiment/webconnectivity/summary.go
+++ b/experiment/webconnectivity/summary.go
@@ -129,8 +129,9 @@ func Summarize(tk *TestKeys) (out Summary) {
 		switch *tk.Requests[0].Failure {
 		case modelx.FailureConnectionRefused:
 			// This is possibly because a subsequent connection to some
-			// other endpoint has been blocked. So tcp-ip.
-			out.BlockingReason = &tcpIP
+			// other endpoint has been blocked. We call this http-failure
+			// because this is what MK would actually do.
+			out.BlockingReason = &httpFailure
 			out.Accessible = &inaccessible
 		case modelx.FailureConnectionReset:
 			// We don't currently support TLS failures and we don't have a

--- a/experiment/webconnectivity/summary_test.go
+++ b/experiment/webconnectivity/summary_test.go
@@ -167,8 +167,8 @@ func TestSummarize(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.Summary{
-			BlockingReason: &tcpIP,
-			Blocking:       &tcpIP,
+			BlockingReason: &httpFailure,
+			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
 		},
 	}, {


### PR DESCRIPTION
Make sure we do the same MK would do in this case.

Part of https://github.com/ooni/probe-engine/issues/810.