### PR TITLE
QA/webconnectivity: do like MK when domain is NXDOMAIN

### DIFF
--- a/experiment/webconnectivity/summary.go
+++ b/experiment/webconnectivity/summary.go
@@ -93,6 +93,11 @@ func Summarize(tk *TestKeys) (out Summary) {
 	if tk.DNSExperimentFailure != nil &&
 		*tk.DNSExperimentFailure == modelx.FailureDNSNXDOMAINError &&
 		tk.DNSConsistency != nil && *tk.DNSConsistency == DNSConsistent {
+		// TODO(bassosimone): MK flags this as accessible. This result is debateable. We
+		// are doing what MK does. But we most likely want to make it better later.
+		//
+		// See <https://github.com/ooni/probe-engine/issues/579>.
+		out.Accessible = &accessible
 		return
 	}
 	// If we tried to connect more than once and never succeded and we were

--- a/experiment/webconnectivity/summary_test.go
+++ b/experiment/webconnectivity/summary_test.go
@@ -77,8 +77,8 @@ func TestSummarize(t *testing.T) {
 		},
 		wantOut: webconnectivity.Summary{
 			BlockingReason: nil,
-			Blocking:       nilstring,
-			Accessible:     nil,
+			Blocking:       false,
+			Accessible:     &trueValue,
 		},
 	}, {
 		name: "with TCP total failure and consistent DNS",


### PR DESCRIPTION
This impacts on https://github.com/ooni/probe-engine/issues/579.

Part of https://github.com/ooni/probe-engine/issues/810.