### PR TITLE
QA/webconnectivity: timeout error in redirect chain

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -334,6 +334,40 @@ def webconnectivity_http_eof_error_with_consistent_dns(ooni_exe, outfile):
     assert tk["accessible"] == False
 
 
+def webconnectivity_http_generic_timeout_error_with_consistent_dns(ooni_exe, outfile):
+    """ Test case where there's a redirection and the redirected request cannot
+        continue because a generic_timeout_error error occurs. """
+    # We use a bit.ly link redirecting to nexa.polito.it. We block the HTTP request
+    # for nexa.polito.it using the cleartext bad proxy. So the error should happen in
+    # the redirect chain and should be timeout.
+    args = [
+        "-iptables-hijack-dns-to",
+        "127.0.0.1:53",
+        "-dns-proxy-hijack",
+        "nexa.polito.it",
+        "-iptables-drop-keyword",
+        "Host: nexa",
+    ]
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i https://bit.ly/3h9EJR3 web_connectivity",
+        "webconnectivity_http_generic_timeout_error_with_consistent_dns",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == "consistent"
+    assert tk["control_failure"] == None
+    assert tk["http_experiment_failure"] == "generic_timeout_error"
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    assert tk["blocking"] == "http-failure"
+    assert tk["accessible"] == False
+
+
 def main():
     if len(sys.argv) != 2:
         sys.exit("usage: %s /path/to/ooniprobelegacy-like/binary" % sys.argv[0])
@@ -350,6 +384,7 @@ def main():
         webconnectivity_http_connection_reset_with_consistent_dns,
         webconnectivity_http_nxdomain_with_consistent_dns,
         webconnectivity_http_eof_error_with_consistent_dns,
+        webconnectivity_http_generic_timeout_error_with_consistent_dns,
     ]
     for test in tests:
         test(ooni_exe, outfile)

--- a/experiment/webconnectivity/summary.go
+++ b/experiment/webconnectivity/summary.go
@@ -156,9 +156,8 @@ func Summarize(tk *TestKeys) (out Summary) {
 			out.Accessible = &inaccessible
 		case modelx.FailureGenericTimeoutError:
 			// Alas, here we don't know whether it's connect or whether it's
-			// perhaps the TLS handshake. Yet, there is some common ground here
-			// that suddenly all our packets are discared at TCP/IP level.
-			out.BlockingReason = &tcpIP
+			// perhaps the TLS handshake. So use the same classification used by MK.
+			out.BlockingReason = &httpFailure
 			out.Accessible = &inaccessible
 		case modelx.FailureSSLInvalidHostname,
 			modelx.FailureSSLInvalidCertificate,

--- a/experiment/webconnectivity/summary_test.go
+++ b/experiment/webconnectivity/summary_test.go
@@ -223,8 +223,8 @@ func TestSummarize(t *testing.T) {
 			},
 		},
 		wantOut: webconnectivity.Summary{
-			BlockingReason: &tcpIP,
-			Blocking:       &tcpIP,
+			BlockingReason: &httpFailure,
+			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
 		},
 	}, {

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -938,7 +938,7 @@ func TestNewFailure(t *testing.T) {
 			return &s
 		}(),
 	}, {
-		name: "when error is wrapped and failure is notmeaningful",
+		name: "when error is wrapped and failure is not meaningful",
 		args: args{
 			err: &modelx.ErrWrapper{},
 		},
@@ -947,7 +947,14 @@ func TestNewFailure(t *testing.T) {
 			return &s
 		}(),
 	}, {
-		name: "otherwise",
+		name: "when error is not wrapped but wrappable",
+		args: args{err: io.EOF},
+		want: func() *string {
+			s := "eof_error"
+			return &s
+		}(),
+	}, {
+		name: "when the error is not wrapped and not wrappable",
 		args: args{
 			err: errors.New("use of closed socket 127.0.0.1:8080->10.0.0.1:22"),
 		},


### PR DESCRIPTION
Again, likely doing the redirect chain is not necessary. But it makes
things more interesting, because we are testing stuff that happens after
the initial DNS, TCP, etc. checks performed by Web Connectivity.

Part of https://github.com/ooni/probe-engine/issues/810