### PR TITLE
QA/webconnectivity: several checks for TLS failures

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -140,7 +140,7 @@ def webconnectivity_dns_hijacking(ooni_exe, outfile):
     assert tk["accessible"] == True
 
 
-def webconnectivity_control_unreachable_http(ooni_exe, outfile):
+def webconnectivity_control_unreachable_and_using_http(ooni_exe, outfile):
     """ Test case where the control is unreachable and we're using the
         plaintext HTTP protocol rather than HTTPS """
     args = []
@@ -150,7 +150,7 @@ def webconnectivity_control_unreachable_http(ooni_exe, outfile):
         ooni_exe,
         outfile,
         "-i http://example.org web_connectivity",
-        "webconnectivity_control_unreachable_http",
+        "webconnectivity_control_unreachable_and_using_http",
         args,
     )
     assert tk["dns_experiment_failure"] == None
@@ -559,6 +559,150 @@ def webconnectivity_http_diff_with_consistent_dns(ooni_exe, outfile):
     assert tk["accessible"] == False
 
 
+def webconnectivity_https_expired_certificate(ooni_exe, outfile):
+    """ Test case where the domain's certificate is expired """
+    args = []
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i https://expired.badssl.com/ web_connectivity",
+        "webconnectivity_https_expired_certificate",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == "consistent"
+    assert tk["control_failure"] == None
+    if "miniooni" in ooni_exe:
+        assert tk["http_experiment_failure"] == "ssl_invalid_certificate"
+    else:
+        assert "certificate verify failed" in tk["http_experiment_failure"]
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    # The following strikes me as a measurement_kit bug. We are saying
+    # that all is good with a domain where actually we don't know why the
+    # control is failed and that is clearly not accessible according to
+    # our measurement of the domain (certificate expired).
+    #
+    # See <https://github.com/ooni/probe-engine/issues/858>.
+    if "miniooni" in ooni_exe:
+        assert tk["blocking"] == None
+        assert tk["accessible"] == None
+    else:
+        assert tk["blocking"] == False
+        assert tk["accessible"] == True
+
+
+def webconnectivity_https_wrong_host(ooni_exe, outfile):
+    """ Test case where the hostname is wrong for the certificate """
+    args = []
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i https://wrong.host.badssl.com/ web_connectivity",
+        "webconnectivity_https_wrong_host",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == "consistent"
+    assert tk["control_failure"] == None
+    if "miniooni" in ooni_exe:
+        assert tk["http_experiment_failure"] == "ssl_invalid_hostname"
+    else:
+        assert "certificate verify failed" in tk["http_experiment_failure"]
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    # The following strikes me as a measurement_kit bug. We are saying
+    # that all is good with a domain where actually we don't know why the
+    # control is failed and that is clearly not accessible according to
+    # our measurement of the domain (wrong host for certificate).
+    #
+    # See <https://github.com/ooni/probe-engine/issues/858>.
+    if "miniooni" in ooni_exe:
+        assert tk["blocking"] == None
+        assert tk["accessible"] == None
+    else:
+        assert tk["blocking"] == False
+        assert tk["accessible"] == True
+
+
+def webconnectivity_https_self_signed(ooni_exe, outfile):
+    """ Test case where the certificate is self signed """
+    args = []
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i https://self-signed.badssl.com/ web_connectivity",
+        "webconnectivity_https_self_signed",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == "consistent"
+    assert tk["control_failure"] == None
+    if "miniooni" in ooni_exe:
+        assert tk["http_experiment_failure"] == "ssl_unknown_authority"
+    else:
+        assert "certificate verify failed" in tk["http_experiment_failure"]
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    # The following strikes me as a measurement_kit bug. We are saying
+    # that all is good with a domain where actually we don't know why the
+    # control is failed and that is clearly not accessible according to
+    # our measurement of the domain (self signed certificate).
+    #
+    # See <https://github.com/ooni/probe-engine/issues/858>.
+    if "miniooni" in ooni_exe:
+        assert tk["blocking"] == None
+        assert tk["accessible"] == None
+    else:
+        assert tk["blocking"] == False
+        assert tk["accessible"] == True
+
+
+def webconnectivity_https_untrusted_root(ooni_exe, outfile):
+    """ Test case where the certificate has an untrusted root """
+    args = []
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i https://untrusted-root.badssl.com/ web_connectivity",
+        "webconnectivity_https_untrusted_root",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == "consistent"
+    assert tk["control_failure"] == None
+    if "miniooni" in ooni_exe:
+        assert tk["http_experiment_failure"] == "ssl_unknown_authority"
+    else:
+        assert "certificate verify failed" in tk["http_experiment_failure"]
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    # The following strikes me as a measurement_kit bug. We are saying
+    # that all is good with a domain where actually we don't know why the
+    # control is failed and that is clearly not accessible according to
+    # our measurement of the domain (untrusted root certificate).
+    #
+    # See <https://github.com/ooni/probe-engine/issues/858>.
+    if "miniooni" in ooni_exe:
+        assert tk["blocking"] == None
+        assert tk["accessible"] == None
+    else:
+        assert tk["blocking"] == False
+        assert tk["accessible"] == True
+
+
 def main():
     if len(sys.argv) != 2:
         sys.exit("usage: %s /path/to/ooniprobelegacy-like/binary" % sys.argv[0])
@@ -569,7 +713,7 @@ def main():
         webconnectivity_http_ok_with_control_failure,
         webconnectivity_transparent_http_proxy,
         webconnectivity_dns_hijacking,
-        webconnectivity_control_unreachable_http,
+        webconnectivity_control_unreachable_and_using_http,
         webconnectivity_nonexistent_domain,
         webconnectivity_tcpip_blocking_with_consistent_dns,
         webconnectivity_tcpip_blocking_with_inconsistent_dns,
@@ -583,6 +727,10 @@ def main():
         webconnectivity_https_successful_website,
         webconnectivity_http_diff_with_inconsistent_dns,
         webconnectivity_http_diff_with_consistent_dns,
+        webconnectivity_https_expired_certificate,
+        webconnectivity_https_wrong_host,
+        webconnectivity_https_self_signed,
+        webconnectivity_https_untrusted_root,
     ]
     for test in tests:
         test(ooni_exe, outfile)


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/852

Related to https://github.com/ooni/probe-engine/issues/858