### PR TITLE
QA/webconnectivity: censorship using NXDOMAIN

### DIFF
--- a/experiment/webconnectivity/summary.go
+++ b/experiment/webconnectivity/summary.go
@@ -100,6 +100,13 @@ func Summarize(tk *TestKeys) (out Summary) {
 		out.Accessible = &accessible
 		return
 	}
+	// Otherwise, if DNS failed with NXDOMAIN, it's DNS based blocking.
+	if tk.DNSExperimentFailure != nil &&
+		*tk.DNSExperimentFailure == modelx.FailureDNSNXDOMAINError {
+		out.Accessible = &inaccessible
+		out.BlockingReason = &dns
+		return
+	}
 	// If we tried to connect more than once and never succeded and we were
 	// able to measure DNS consistency, then we can conclude something.
 	if tk.TCPConnectAttempts > 0 && tk.TCPConnectSuccesses <= 0 && tk.DNSConsistency != nil {

--- a/experiment/webconnectivity/summary_test.go
+++ b/experiment/webconnectivity/summary_test.go
@@ -81,6 +81,21 @@ func TestSummarize(t *testing.T) {
 			Accessible:     &trueValue,
 		},
 	}, {
+		name: "with NXDOMAIN measured only by the probe",
+		args: args{
+			tk: &webconnectivity.TestKeys{
+				DNSExperimentFailure: &probeNXDOMAIN,
+				DNSAnalysisResult: webconnectivity.DNSAnalysisResult{
+					DNSConsistency: &webconnectivity.DNSInconsistent,
+				},
+			},
+		},
+		wantOut: webconnectivity.Summary{
+			BlockingReason: &dns,
+			Blocking:       &dns,
+			Accessible:     &falseValue,
+		},
+	}, {
 		name: "with TCP total failure and consistent DNS",
 		args: args{
 			tk: &webconnectivity.TestKeys{


### PR DESCRIPTION
When working on this, notice that we were not correctly handling this
specific case, handle it and add also a test for that.

While there, notice that MK is not handling this case correctly and
file an issue for that: https://github.com/measurement-kit/measurement-kit/issues/1931

Part of https://github.com/ooni/probe-engine/issues/852