### PR TITLE
QA/webconnectivity: repair flaky test

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -512,7 +512,7 @@ def webconnectivity_http_diff_with_inconsistent_dns(ooni_exe, outfile):
         "-iptables-hijack-dns-to",
         "127.0.0.1:53",
         "-dns-proxy-hijack",
-        "neverssl",
+        "example.org",
         "-http-proxy-block",
         "example.org",
     ]

--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -466,7 +466,7 @@ def webconnectivity_http_successful_website(ooni_exe, outfile):
     tk = execute_jafar_and_return_validated_test_keys(
         ooni_exe,
         outfile,
-        "-i http://neverssl.com/ web_connectivity",
+        "-i http://example.org/ web_connectivity",
         "webconnectivity_http_successful_website",
         args,
     )

--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -71,7 +71,7 @@ def webconnectivity_http_ok_with_control_failure(ooni_exe, outfile):
     tk = execute_jafar_and_return_validated_test_keys(
         ooni_exe,
         outfile,
-        "-i http://neverssl.com/ web_connectivity",
+        "-i http://example.org/ web_connectivity",
         "webconnectivity_http_ok_with_control_failure",
         args,
     )
@@ -514,12 +514,12 @@ def webconnectivity_http_diff_with_inconsistent_dns(ooni_exe, outfile):
         "-dns-proxy-hijack",
         "neverssl",
         "-http-proxy-block",
-        "neverssl.com",
+        "example.org",
     ]
     tk = execute_jafar_and_return_validated_test_keys(
         ooni_exe,
         outfile,
-        "-i http://neverssl.com/ web_connectivity",
+        "-i http://example.org/ web_connectivity",
         "webconnectivity_http_diff_with_inconsistent_dns",
         args,
     )
@@ -542,12 +542,12 @@ def webconnectivity_http_diff_with_consistent_dns(ooni_exe, outfile):
         "-iptables-hijack-http-to",
         "127.0.0.1:80",
         "-http-proxy-block",
-        "neverssl.com",
+        "example.org",
     ]
     tk = execute_jafar_and_return_validated_test_keys(
         ooni_exe,
         outfile,
-        "-i http://neverssl.com/ web_connectivity",
+        "-i http://example.org/ web_connectivity",
         "webconnectivity_http_diff_with_consistent_dns",
         args,
     )


### PR DESCRIPTION
It seems using neverssl.com isn't working well as a target for us
when running inside of github actions as documented in
https://github.com/ooni/probe-engine/issues/861.

For this reason, let us try with example.org as target instead.