### PR TITLE
QA/webconnectivity: introduce status flags

### DIFF
--- a/QA/webconnectivity.py
+++ b/QA/webconnectivity.py
@@ -32,6 +32,15 @@ def execute_jafar_and_return_validated_test_keys(
     return tk
 
 
+def assert_status_flags_are(ooni_exe, tk, desired):
+    """ Checks whether the status flags are what we expect them to
+        be when we're running miniooni. This check only makes sense
+        with miniooni b/c status flags are a miniooni extension. """
+    if "miniooni" not in ooni_exe:
+        return
+    assert tk["x_status"] == desired
+
+
 def webconnectivity_https_ok_with_control_failure(ooni_exe, outfile):
     """ Successful HTTPS measurement but control failure. """
     args = [
@@ -60,6 +69,7 @@ def webconnectivity_https_ok_with_control_failure(ooni_exe, outfile):
     else:
         assert tk["blocking"] == None
         assert tk["accessible"] == None
+    assert_status_flags_are(ooni_exe, tk, 1)
 
 
 def webconnectivity_http_ok_with_control_failure(ooni_exe, outfile):
@@ -86,6 +96,7 @@ def webconnectivity_http_ok_with_control_failure(ooni_exe, outfile):
     assert tk["title_match"] == None
     assert tk["blocking"] == None
     assert tk["accessible"] == None
+    assert_status_flags_are(ooni_exe, tk, 8)
 
 
 def webconnectivity_transparent_http_proxy(ooni_exe, outfile):
@@ -111,6 +122,7 @@ def webconnectivity_transparent_http_proxy(ooni_exe, outfile):
     assert tk["title_match"] == True
     assert tk["blocking"] == False
     assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 1)
 
 
 def webconnectivity_dns_hijacking(ooni_exe, outfile):
@@ -138,6 +150,7 @@ def webconnectivity_dns_hijacking(ooni_exe, outfile):
     assert tk["title_match"] == True
     assert tk["blocking"] == False
     assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 1)
 
 
 def webconnectivity_control_unreachable_and_using_http(ooni_exe, outfile):
@@ -164,6 +177,7 @@ def webconnectivity_control_unreachable_and_using_http(ooni_exe, outfile):
     assert tk["title_match"] == None
     assert tk["blocking"] == None
     assert tk["accessible"] == None
+    assert_status_flags_are(ooni_exe, tk, 8)
 
 
 def webconnectivity_nonexistent_domain(ooni_exe, outfile):
@@ -205,6 +219,7 @@ def webconnectivity_nonexistent_domain(ooni_exe, outfile):
     assert tk["title_match"] == None
     assert tk["blocking"] == False
     assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 2052)
 
 
 def webconnectivity_tcpip_blocking_with_consistent_dns(ooni_exe, outfile):
@@ -232,6 +247,7 @@ def webconnectivity_tcpip_blocking_with_consistent_dns(ooni_exe, outfile):
     assert tk["title_match"] == None
     assert tk["blocking"] == "tcp_ip"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 4224)
 
 
 def webconnectivity_tcpip_blocking_with_inconsistent_dns(ooni_exe, outfile):
@@ -264,6 +280,7 @@ def webconnectivity_tcpip_blocking_with_inconsistent_dns(ooni_exe, outfile):
         assert tk["title_match"] == None
         assert tk["blocking"] == "dns"
         assert tk["accessible"] == False
+        assert_status_flags_are(ooni_exe, tk, 4256)
 
     common.with_free_port(runner)
 
@@ -296,6 +313,7 @@ def webconnectivity_http_connection_refused_with_consistent_dns(ooni_exe, outfil
     assert tk["title_match"] == None
     assert tk["blocking"] == "http-failure"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 8320)
 
 
 def webconnectivity_http_connection_reset_with_consistent_dns(ooni_exe, outfile):
@@ -325,6 +343,7 @@ def webconnectivity_http_connection_reset_with_consistent_dns(ooni_exe, outfile)
     assert tk["title_match"] == None
     assert tk["blocking"] == "http-failure"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 8448)
 
 
 def webconnectivity_http_nxdomain_with_consistent_dns(ooni_exe, outfile):
@@ -359,6 +378,7 @@ def webconnectivity_http_nxdomain_with_consistent_dns(ooni_exe, outfile):
     assert tk["title_match"] == None
     assert tk["blocking"] == "dns"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 8224)
 
 
 def webconnectivity_http_eof_error_with_consistent_dns(ooni_exe, outfile):
@@ -393,6 +413,7 @@ def webconnectivity_http_eof_error_with_consistent_dns(ooni_exe, outfile):
     assert tk["title_match"] == None
     assert tk["blocking"] == "http-failure"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 8448)
 
 
 def webconnectivity_http_generic_timeout_error_with_consistent_dns(ooni_exe, outfile):
@@ -427,6 +448,7 @@ def webconnectivity_http_generic_timeout_error_with_consistent_dns(ooni_exe, out
     assert tk["title_match"] == None
     assert tk["blocking"] == "http-failure"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 8704)
 
 
 def webconnectivity_http_connection_reset_with_inconsistent_dns(ooni_exe, outfile):
@@ -458,6 +480,7 @@ def webconnectivity_http_connection_reset_with_inconsistent_dns(ooni_exe, outfil
     assert tk["title_match"] == None
     assert tk["blocking"] == "dns"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 8480)
 
 
 def webconnectivity_http_successful_website(ooni_exe, outfile):
@@ -481,6 +504,7 @@ def webconnectivity_http_successful_website(ooni_exe, outfile):
     assert tk["title_match"] == True
     assert tk["blocking"] == False
     assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 2)
 
 
 def webconnectivity_https_successful_website(ooni_exe, outfile):
@@ -504,6 +528,7 @@ def webconnectivity_https_successful_website(ooni_exe, outfile):
     assert tk["title_match"] == True
     assert tk["blocking"] == False
     assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 1)
 
 
 def webconnectivity_http_diff_with_inconsistent_dns(ooni_exe, outfile):
@@ -534,6 +559,7 @@ def webconnectivity_http_diff_with_inconsistent_dns(ooni_exe, outfile):
     assert tk["title_match"] == False
     assert tk["blocking"] == "dns"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 96)
 
 
 def webconnectivity_http_diff_with_consistent_dns(ooni_exe, outfile):
@@ -562,6 +588,7 @@ def webconnectivity_http_diff_with_consistent_dns(ooni_exe, outfile):
     assert tk["title_match"] == False
     assert tk["blocking"] == "http-diff"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 64)
 
 
 def webconnectivity_https_expired_certificate(ooni_exe, outfile):
@@ -598,6 +625,7 @@ def webconnectivity_https_expired_certificate(ooni_exe, outfile):
     else:
         assert tk["blocking"] == False
         assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 16)
 
 
 def webconnectivity_https_wrong_host(ooni_exe, outfile):
@@ -634,6 +662,7 @@ def webconnectivity_https_wrong_host(ooni_exe, outfile):
     else:
         assert tk["blocking"] == False
         assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 16)
 
 
 def webconnectivity_https_self_signed(ooni_exe, outfile):
@@ -670,6 +699,7 @@ def webconnectivity_https_self_signed(ooni_exe, outfile):
     else:
         assert tk["blocking"] == False
         assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 16)
 
 
 def webconnectivity_https_untrusted_root(ooni_exe, outfile):
@@ -706,6 +736,7 @@ def webconnectivity_https_untrusted_root(ooni_exe, outfile):
     else:
         assert tk["blocking"] == False
         assert tk["accessible"] == True
+    assert_status_flags_are(ooni_exe, tk, 16)
 
 
 def webconnectivity_dns_blocking_nxdomain(ooni_exe, outfile):
@@ -744,6 +775,44 @@ def webconnectivity_dns_blocking_nxdomain(ooni_exe, outfile):
     assert tk["title_match"] == None
     assert tk["blocking"] == "dns"
     assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 2080)
+
+
+def webconnectivity_https_unknown_authority_with_inconsistent_dns(ooni_exe, outfile):
+    """ Test case where the DNS is sending us towards a website where
+        we're served an invalid certificate """
+    args = [
+        "-iptables-hijack-dns-to",
+        "127.0.0.1:53",
+        "-dns-proxy-hijack",
+        "example.org",
+        "-bad-proxy-address-tls",
+        "127.0.0.1:443",
+        "-tls-proxy-address",
+        "127.0.0.1:4114",
+    ]
+    tk = execute_jafar_and_return_validated_test_keys(
+        ooni_exe,
+        outfile,
+        "-i https://example.org/ web_connectivity",
+        "webconnectivity_https_unknown_authority_with_inconsistent_dns",
+        args,
+    )
+    assert tk["dns_experiment_failure"] == None
+    assert tk["dns_consistency"] == "inconsistent"
+    assert tk["control_failure"] == None
+    if "miniooni" in ooni_exe:
+        assert tk["http_experiment_failure"] == "ssl_unknown_authority"
+    else:
+        assert "certificate verify failed" in tk["http_experiment_failure"]
+    assert tk["body_length_match"] == None
+    assert tk["body_proportion"] == 0
+    assert tk["status_code_match"] == None
+    assert tk["headers_match"] == None
+    assert tk["title_match"] == None
+    assert tk["blocking"] == "dns"
+    assert tk["accessible"] == False
+    assert_status_flags_are(ooni_exe, tk, 9248)
 
 
 def main():
@@ -775,6 +844,7 @@ def main():
         webconnectivity_https_self_signed,
         webconnectivity_https_untrusted_root,
         webconnectivity_dns_blocking_nxdomain,
+        webconnectivity_https_unknown_authority_with_inconsistent_dns,
     ]
     for test in tests:
         test(ooni_exe, outfile)

--- a/experiment/webconnectivity/summary_test.go
+++ b/experiment/webconnectivity/summary_test.go
@@ -52,6 +52,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       false,
 			Accessible:     &trueValue,
+			Status:         webconnectivity.StatusSuccessSecure,
 		},
 	}, {
 		name: "with failure in contacting the control",
@@ -64,6 +65,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       nilstring,
 			Accessible:     nil,
+			Status:         webconnectivity.StatusAnomalyControlUnreachable,
 		},
 	}, {
 		name: "with non-existing website",
@@ -79,6 +81,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       false,
 			Accessible:     &trueValue,
+			Status: webconnectivity.StatusSuccessNXDOMAIN |
+				webconnectivity.StatusExperimentDNS,
 		},
 	}, {
 		name: "with NXDOMAIN measured only by the probe",
@@ -94,6 +98,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &dns,
 			Blocking:       &dns,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusAnomalyDNS |
+				webconnectivity.StatusExperimentDNS,
 		},
 	}, {
 		name: "with TCP total failure and consistent DNS",
@@ -110,6 +116,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &tcpIP,
 			Blocking:       &tcpIP,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusAnomalyConnect |
+				webconnectivity.StatusExperimentConnect,
 		},
 	}, {
 		name: "with TCP total failure and inconsistent DNS",
@@ -126,6 +134,9 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &dns,
 			Blocking:       &dns,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusAnomalyConnect |
+				webconnectivity.StatusExperimentConnect |
+				webconnectivity.StatusAnomalyDNS,
 		},
 	}, {
 		name: "with TCP total failure and unexpected DNS consistency",
@@ -145,6 +156,9 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       nilstring,
 			Accessible:     nil,
+			Status: webconnectivity.StatusAnomalyConnect |
+				webconnectivity.StatusExperimentConnect |
+				webconnectivity.StatusAnomalyUnknown,
 		},
 	}, {
 		name: "with failed control HTTP request",
@@ -161,6 +175,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       nilstring,
 			Accessible:     nil,
+			Status:         webconnectivity.StatusAnomalyControlFailure,
 		},
 	}, {
 		name: "with less that one request entry",
@@ -171,6 +186,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       nilstring,
 			Accessible:     nil,
+			Status:         webconnectivity.StatusBugNoRequests,
 		},
 	}, {
 		name: "with connection refused",
@@ -185,6 +201,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyConnect,
 		},
 	}, {
 		name: "with connection reset",
@@ -199,6 +217,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyReadWrite,
 		},
 	}, {
 		name: "with NXDOMAIN",
@@ -213,6 +233,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &dns,
 			Blocking:       &dns,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyDNS,
 		},
 	}, {
 		name: "with EOF",
@@ -227,6 +249,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyReadWrite,
 		},
 	}, {
 		name: "with timeout",
@@ -241,6 +265,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyUnknown,
 		},
 	}, {
 		name: "with SSL invalid hostname",
@@ -255,6 +281,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyTLSHandshake,
 		},
 	}, {
 		name: "with SSL invalid cert",
@@ -269,6 +297,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyTLSHandshake,
 		},
 	}, {
 		name: "with SSL unknown auth",
@@ -283,6 +313,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyTLSHandshake,
 		},
 	}, {
 		name: "with SSL unknown auth _and_ untrustworthy DNS",
@@ -300,6 +332,9 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &dns,
 			Blocking:       &dns,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyTLSHandshake |
+				webconnectivity.StatusAnomalyDNS,
 		},
 	}, {
 		name: "with SSL unknown auth _and_ untrustworthy DNS _and_ a longer chain",
@@ -317,6 +352,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpFailure,
 			Blocking:       &httpFailure,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusExperimentHTTP |
+				webconnectivity.StatusAnomalyTLSHandshake,
 		},
 	}, {
 		name: "with status code and body length matching",
@@ -333,6 +370,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       falseValue,
 			Accessible:     &trueValue,
+			Status:         webconnectivity.StatusSuccessCleartext,
 		},
 	}, {
 		name: "with status code and headers matching",
@@ -349,6 +387,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       falseValue,
 			Accessible:     &trueValue,
+			Status:         webconnectivity.StatusSuccessCleartext,
 		},
 	}, {
 		name: "with status code and title matching",
@@ -365,6 +404,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: nil,
 			Blocking:       falseValue,
 			Accessible:     &trueValue,
+			Status:         webconnectivity.StatusSuccessCleartext,
 		},
 	}, {
 		name: "with suspect http-diff and inconsistent DNS",
@@ -384,6 +424,8 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &dns,
 			Blocking:       &dns,
 			Accessible:     &falseValue,
+			Status: webconnectivity.StatusAnomalyHTTPDiff |
+				webconnectivity.StatusAnomalyDNS,
 		},
 	}, {
 		name: "with suspect http-diff and consistent DNS",
@@ -403,6 +445,7 @@ func TestSummarize(t *testing.T) {
 			BlockingReason: &httpDiff,
 			Blocking:       &httpDiff,
 			Accessible:     &falseValue,
+			Status:         webconnectivity.StatusAnomalyHTTPDiff,
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
The status flags allow us to measure in a more precise way why and how
we flag a measurement as such. The flags are currently marked as an
experimental feature. I see them as a tool to:

1. make sure we can assert more precisely in tests why a specific
censorship condition led to a specific result

2. see quite clearly what are the places in which our understanding
of what went wrong is not very precise

After this last round of QA, I have covered most of the error conditions
specified in summary.go, and verified that the behavior that we are
implementing now is consistent with MK in such cases.

Therefore, with the merging of this diff, we will be reaching the point
where https://github.com/ooni/probe-engine/issues/852 is done.