### PR TITLE
.github/workflows/golang.yml: re-enable `-race`

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - uses: actions/checkout@v2
-      - run: go test -tags shaping -v -coverprofile=probe-engine.cov -coverpkg=./... ./...
+      - run: go test -race -tags shaping -v -coverprofile=probe-engine.cov -coverpkg=./... ./...
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: probe-engine.cov


### PR DESCRIPTION
Let's see whether we can run tests using the race detector.

This should now be possible.

For historical context see https://github.com/ooni/probe-engine/issues/486.