### PR TITLE
urlgetter: set default timeout when run from command line

### DIFF
--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -5,6 +5,7 @@ package urlgetter
 
 import (
 	"context"
+	"time"
 
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
@@ -80,6 +81,12 @@ func (m measurer) Run(
 	ctx context.Context, sess model.ExperimentSession,
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
 ) error {
+	// When using the urlgetter experiment directly, there is a nonconfigurable
+	// default timeout that applies. When urlgetter is used as a library, it's
+	// instead the responsibility of the user of urlgetter to set timeouts. Note
+	// that this code is indeed only called when using urlgetter directly.
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
 	RegisterExtensions(measurement)
 	g := Getter{
 		Config:  m.Config,

--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -12,7 +12,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -350,10 +352,16 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 		// Tests that do not expect input internally require an empty input to run
 		currentOptions.Inputs = append(currentOptions.Inputs, "")
 	}
+	intregexp := regexp.MustCompile("^[0-9]+$")
 	for key, value := range extraOptions {
 		if value == "true" || value == "false" {
 			err := builder.SetOptionBool(key, value == "true")
 			fatalOnError(err, "cannot set boolean option")
+		} else if intregexp.MatchString(value) {
+			number, err := strconv.ParseInt(value, 10, 64)
+			fatalOnError(err, "cannot parse integer option")
+			err = builder.SetOptionInt(key, number)
+			fatalOnError(err, "cannot set integer option")
 		} else {
 			err := builder.SetOptionString(key, value)
 			fatalOnError(err, "cannot set string option")


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/655