### PR TITLE
geoiplookup: simplify and rename geolocate

### DIFF
--- a/experiment/webconnectivity/control.go
+++ b/experiment/webconnectivity/control.go
@@ -3,7 +3,7 @@ package webconnectivity
 import (
 	"context"
 
-	"github.com/ooni/probe-engine/geoiplookup/mmdblookup"
+	"github.com/ooni/probe-engine/geolocate"
 	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/errorx"
@@ -79,7 +79,7 @@ func (dns *ControlDNSResult) FillASNs(sess model.ExperimentSession) {
 	for _, ip := range dns.Addrs {
 		// TODO(bassosimone): this would be more efficient if we'd open just
 		// once the database and then reuse it for every address.
-		asn, _, _ := mmdblookup.ASN(sess.ASNDatabasePath(), ip)
+		asn, _, _ := geolocate.LookupASN(sess.ASNDatabasePath(), ip)
 		dns.ASNs = append(dns.ASNs, int64(asn))
 	}
 }

--- a/geolocate/README.md
+++ b/geolocate/README.md
@@ -1,0 +1,4 @@
+# Package github.com/ooni/probe-engine/geolocate
+
+Package geolocate implements IP lookup, resolver lookup, and GeoIP
+location of an OONI Probe instance.

--- a/geolocate/avast.go
+++ b/geolocate/avast.go
@@ -1,5 +1,6 @@
-// Package avast lookups the IP using avast.
-package avast
+// Package geolocate implements IP lookup, resolver lookup, and GeoIP
+// location an OONI Probe instance.
+package geolocate
 
 import (
 	"context"
@@ -9,18 +10,19 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-type response struct {
+// AvastResponse is the response returned by Avast IP lookup services.
+type AvastResponse struct {
 	IP string `json:"ip"`
 }
 
-// Do performs the IP lookup.
-func Do(
+// AvastIPLookup performs the IP lookup using Avast services.
+func AvastIPLookup(
 	ctx context.Context,
 	httpClient *http.Client,
 	logger model.Logger,
 	userAgent string,
 ) (string, error) {
-	var v response
+	var v AvastResponse
 	err := (httpx.Client{
 		BaseURL:    "https://ip-info.ff.avast.com",
 		HTTPClient: httpClient,

--- a/geolocate/invalid_test.go
+++ b/geolocate/invalid_test.go
@@ -1,5 +1,4 @@
-// Package invalid returns an invalid IP.
-package invalid
+package geolocate
 
 import (
 	"context"
@@ -8,8 +7,8 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-// Do performs the IP lookup.
-func Do(
+// InvalidIPLookup is an IP lookup that always returns an invalid IP.
+func InvalidIPLookup(
 	ctx context.Context,
 	httpClient *http.Client,
 	logger model.Logger,

--- a/geolocate/iplookup.go
+++ b/geolocate/iplookup.go
@@ -1,5 +1,4 @@
-// Package iplookup implements probe IP lookup.
-package iplookup
+package geolocate
 
 import (
 	"context"
@@ -11,8 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/probe-engine/geoiplookup/iplookup/avast"
-	"github.com/ooni/probe-engine/geoiplookup/iplookup/ubuntu"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -31,19 +28,19 @@ var (
 	methods = []method{
 		{
 			name: "avast",
-			fn:   avast.Do,
+			fn:   AvastIPLookup,
 		},
 		{
 			name: "ubuntu",
-			fn:   ubuntu.Do,
+			fn:   UbuntuIPLookup,
 		},
 	}
 
 	once sync.Once
 )
 
-// Client is an iplookup client
-type Client struct {
+// IPLookupClient is an iplookup client
+type IPLookupClient struct {
 	// HTTPClient is the HTTP client to use
 	HTTPClient *http.Client
 
@@ -65,7 +62,7 @@ func makeSlice() []method {
 }
 
 // DoWithCustomFunc performs the IP lookup with a custom function.
-func (c *Client) DoWithCustomFunc(
+func (c *IPLookupClient) DoWithCustomFunc(
 	ctx context.Context, fn LookupFunc,
 ) (string, error) {
 	ip, err := fn(ctx, c.HTTPClient, c.Logger, c.UserAgent)
@@ -80,7 +77,7 @@ func (c *Client) DoWithCustomFunc(
 }
 
 // Do performs the IP lookup.
-func (c *Client) Do(ctx context.Context) (ip string, err error) {
+func (c *IPLookupClient) Do(ctx context.Context) (ip string, err error) {
 	for _, method := range makeSlice() {
 		c.Logger.Debugf("iplookup: using %s", method.name)
 		ip, err = c.DoWithCustomFunc(ctx, method.fn)

--- a/geolocate/iplookup_test.go
+++ b/geolocate/iplookup_test.go
@@ -1,4 +1,4 @@
-package iplookup_test
+package geolocate_test
 
 import (
 	"context"
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-engine/geoiplookup/iplookup"
-	"github.com/ooni/probe-engine/geoiplookup/iplookup/invalid"
+	"github.com/ooni/probe-engine/geolocate"
 	"github.com/ooni/probe-engine/model"
 )
 
-func TestIntegration(t *testing.T) {
+func TestIPLookupIntegration(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
-	ip, err := (&iplookup.Client{
+	ip, err := (&geolocate.IPLookupClient{
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,
 		UserAgent:  "ooniprobe-engine/0.1.0",
@@ -24,11 +23,11 @@ func TestIntegration(t *testing.T) {
 	t.Log(ip)
 }
 
-func TestAllFailed(t *testing.T) {
+func TestIPLookupAllFailed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel to cause Do() to fail
 	log.SetLevel(log.DebugLevel)
-	ip, err := (&iplookup.Client{
+	ip, err := (&geolocate.IPLookupClient{
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,
 		UserAgent:  "ooniprobe-engine/0.1.0",
@@ -41,14 +40,14 @@ func TestAllFailed(t *testing.T) {
 	}
 }
 
-func TestInvalidIP(t *testing.T) {
+func TestIPLookupInvalidIP(t *testing.T) {
 	ctx := context.Background()
 	log.SetLevel(log.DebugLevel)
-	ip, err := (&iplookup.Client{
+	ip, err := (&geolocate.IPLookupClient{
 		HTTPClient: http.DefaultClient,
 		Logger:     log.Log,
 		UserAgent:  "ooniprobe-engine/0.1.0",
-	}).DoWithCustomFunc(ctx, invalid.Do)
+	}).DoWithCustomFunc(ctx, geolocate.InvalidIPLookup)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/geolocate/mmdblookup.go
+++ b/geolocate/mmdblookup.go
@@ -1,5 +1,4 @@
-// Package mmdblookup performs probe ASN, CC, NetworkName lookups.
-package mmdblookup
+package geolocate
 
 import (
 	"net"
@@ -8,11 +7,11 @@ import (
 	"github.com/oschwald/geoip2-golang"
 )
 
-// ASN maps the ip to the probe ASN and org using the
+// LookupASN maps the ip to the probe ASN and org using the
 // MMDB database located at path, or returns an error. In case
 // the IP is not valid, this function will fail with an error
 // complaining that geoip2 was passed a nil IP.
-func ASN(path, ip string) (asn uint, org string, err error) {
+func LookupASN(path, ip string) (asn uint, org string, err error) {
 	asn, org = model.DefaultProbeASN, model.DefaultProbeNetworkName
 	db, err := geoip2.Open(path)
 	if err != nil {
@@ -30,8 +29,8 @@ func ASN(path, ip string) (asn uint, org string, err error) {
 	return
 }
 
-// CC is like LookupASN but for the country code.
-func CC(path, ip string) (cc string, err error) {
+// LookupCC is like LookupASN but for the country code.
+func LookupCC(path, ip string) (cc string, err error) {
 	cc = model.DefaultProbeCC
 	db, err := geoip2.Open(path)
 	if err != nil {

--- a/geolocate/mmdblookup_test.go
+++ b/geolocate/mmdblookup_test.go
@@ -1,4 +1,4 @@
-package mmdblookup_test
+package geolocate_test
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/ooni/probe-engine/geoiplookup/mmdblookup"
+	"github.com/ooni/probe-engine/geolocate"
 	"github.com/ooni/probe-engine/internal/resources"
 	"github.com/ooni/probe-engine/model"
 )
@@ -29,9 +29,9 @@ func maybeFetchResources(t *testing.T) {
 	}
 }
 
-func TestLookupProbeASN(t *testing.T) {
+func TestLookupASN(t *testing.T) {
 	maybeFetchResources(t)
-	asn, org, err := mmdblookup.ASN(asnDBPath, ipAddr)
+	asn, org, err := geolocate.LookupASN(asnDBPath, ipAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,9 +39,9 @@ func TestLookupProbeASN(t *testing.T) {
 	t.Log(org)
 }
 
-func TestLookupProbeASNInvalidFile(t *testing.T) {
+func TestLookupASNInvalidFile(t *testing.T) {
 	maybeFetchResources(t)
-	asn, org, err := mmdblookup.ASN("/nonexistent", ipAddr)
+	asn, org, err := geolocate.LookupASN("/nonexistent", ipAddr)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -53,9 +53,9 @@ func TestLookupProbeASNInvalidFile(t *testing.T) {
 	}
 }
 
-func TestLookupProbeASNInvalidIP(t *testing.T) {
+func TestLookupASNInvalidIP(t *testing.T) {
 	maybeFetchResources(t)
-	asn, org, err := mmdblookup.ASN(asnDBPath, "xxx")
+	asn, org, err := geolocate.LookupASN(asnDBPath, "xxx")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -67,18 +67,18 @@ func TestLookupProbeASNInvalidIP(t *testing.T) {
 	}
 }
 
-func TestLookupProbeCC(t *testing.T) {
+func TestLookupCC(t *testing.T) {
 	maybeFetchResources(t)
-	cc, err := mmdblookup.CC(countryDBPath, ipAddr)
+	cc, err := geolocate.LookupCC(countryDBPath, ipAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(cc)
 }
 
-func TestLookupProbeCCInvalidFile(t *testing.T) {
+func TestLookupCCInvalidFile(t *testing.T) {
 	maybeFetchResources(t)
-	cc, err := mmdblookup.CC("/nonexistent", ipAddr)
+	cc, err := geolocate.LookupCC("/nonexistent", ipAddr)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
@@ -87,9 +87,9 @@ func TestLookupProbeCCInvalidFile(t *testing.T) {
 	}
 }
 
-func TestLookupProbeCCInvalidIP(t *testing.T) {
+func TestLookupCCInvalidIP(t *testing.T) {
 	maybeFetchResources(t)
-	cc, err := mmdblookup.CC(asnDBPath, "xxx")
+	cc, err := geolocate.LookupCC(asnDBPath, "xxx")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/geolocate/resolverlookup.go
+++ b/geolocate/resolverlookup.go
@@ -1,5 +1,4 @@
-// Package resolverlookup discovers the resolver's IP
-package resolverlookup
+package geolocate
 
 import (
 	"context"
@@ -12,8 +11,8 @@ type HostLookupper interface {
 	LookupHost(ctx context.Context, host string) (addrs []string, err error)
 }
 
-// All returns all resolver IPs
-func All(ctx context.Context, resolver HostLookupper) (ips []string, err error) {
+// LookupAllResolverIPs returns all resolver IPs
+func LookupAllResolverIPs(ctx context.Context, resolver HostLookupper) (ips []string, err error) {
 	if resolver == nil {
 		resolver = &net.Resolver{}
 	}
@@ -21,10 +20,10 @@ func All(ctx context.Context, resolver HostLookupper) (ips []string, err error) 
 	return
 }
 
-// First returns the first resolver IP
-func First(ctx context.Context, resolver HostLookupper) (ip string, err error) {
+// LookupFirstResolverIP returns the first resolver IP
+func LookupFirstResolverIP(ctx context.Context, resolver HostLookupper) (ip string, err error) {
 	var ips []string
-	ips, err = All(ctx, resolver)
+	ips, err = LookupAllResolverIPs(ctx, resolver)
 	if err == nil && len(ips) < 1 {
 		err = errors.New("No IP address returned")
 		return

--- a/geolocate/resolverlookup_test.go
+++ b/geolocate/resolverlookup_test.go
@@ -1,14 +1,14 @@
-package resolverlookup_test
+package geolocate_test
 
 import (
 	"context"
 	"testing"
 
-	"github.com/ooni/probe-engine/geoiplookup/resolverlookup"
+	"github.com/ooni/probe-engine/geolocate"
 )
 
 func TestResolverLookupAll(t *testing.T) {
-	addrs, err := resolverlookup.All(context.Background(), nil)
+	addrs, err := geolocate.LookupAllResolverIPs(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,7 +18,7 @@ func TestResolverLookupAll(t *testing.T) {
 }
 
 func TestResolverLookupFirstSuccess(t *testing.T) {
-	addr, err := resolverlookup.First(context.Background(), nil)
+	addr, err := geolocate.LookupFirstResolverIP(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func (*brokenHostLookupper) LookupHost(
 
 func TestResolverLookupFirstFailure(t *testing.T) {
 	resolver := &brokenHostLookupper{}
-	addr, err := resolverlookup.First(context.Background(), resolver)
+	addr, err := geolocate.LookupFirstResolverIP(context.Background(), resolver)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/geolocate/ubuntu.go
+++ b/geolocate/ubuntu.go
@@ -1,5 +1,4 @@
-// Package ubuntu lookups the IP using Ubuntu.
-package ubuntu
+package geolocate
 
 import (
 	"context"
@@ -10,13 +9,14 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-type response struct {
+// UbuntuResponse is the response by Ubuntu IP lookup services.
+type UbuntuResponse struct {
 	XMLName xml.Name `xml:"Response"`
 	IP      string   `xml:"Ip"`
 }
 
-// Do performs the IP lookup.
-func Do(
+// UbuntuIPLookup performs the IP lookup using Ubuntu services.
+func UbuntuIPLookup(
 	ctx context.Context,
 	httpClient *http.Client,
 	logger model.Logger,
@@ -32,7 +32,7 @@ func Do(
 		return model.DefaultProbeIP, err
 	}
 	logger.Debugf("ubuntu: body: %s", string(data))
-	var v response
+	var v UbuntuResponse
 	err = xml.Unmarshal(data, &v)
 	if err != nil {
 		return model.DefaultProbeIP, err

--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -16,7 +16,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/ooni/probe-engine/geoiplookup/mmdblookup"
+	"github.com/ooni/probe-engine/geolocate"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/modelx"
@@ -436,7 +436,7 @@ func (qtype dnsQueryType) ipoftype(addr string) bool {
 
 func (qtype dnsQueryType) makeanswerentry(addr string, dbpath string) DNSAnswerEntry {
 	answer := DNSAnswerEntry{AnswerType: string(qtype)}
-	asn, org, _ := mmdblookup.ASN(dbpath, addr)
+	asn, org, _ := geolocate.LookupASN(dbpath, addr)
 	answer.ASN = int64(asn)
 	answer.ASOrgName = org
 	switch qtype {

--- a/session.go
+++ b/session.go
@@ -13,9 +13,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/atomicx"
-	"github.com/ooni/probe-engine/geoiplookup/iplookup"
-	"github.com/ooni/probe-engine/geoiplookup/mmdblookup"
-	"github.com/ooni/probe-engine/geoiplookup/resolverlookup"
+	"github.com/ooni/probe-engine/geolocate"
 	"github.com/ooni/probe-engine/internal/httpheader"
 	"github.com/ooni/probe-engine/internal/kvstore"
 	"github.com/ooni/probe-engine/internal/platform"
@@ -459,11 +457,11 @@ func (s *Session) initOrchestraClient(
 }
 
 func (s *Session) lookupASN(dbPath, ip string) (uint, string, error) {
-	return mmdblookup.ASN(dbPath, ip)
+	return geolocate.LookupASN(dbPath, ip)
 }
 
 func (s *Session) lookupProbeIP(ctx context.Context) (string, error) {
-	return (&iplookup.Client{
+	return (&geolocate.IPLookupClient{
 		HTTPClient: s.DefaultHTTPClient(),
 		Logger:     s.logger,
 		UserAgent:  httpheader.UserAgent(), // no need to identify as OONI
@@ -471,11 +469,11 @@ func (s *Session) lookupProbeIP(ctx context.Context) (string, error) {
 }
 
 func (s *Session) lookupProbeCC(dbPath, probeIP string) (string, error) {
-	return mmdblookup.CC(dbPath, probeIP)
+	return geolocate.LookupCC(dbPath, probeIP)
 }
 
 func (s *Session) lookupResolverIP(ctx context.Context) (string, error) {
-	return resolverlookup.First(ctx, nil)
+	return geolocate.LookupFirstResolverIP(ctx, nil)
 }
 
 func (s *Session) maybeLookupBackends(ctx context.Context) error {


### PR DESCRIPTION
Again, simplification preparing a blog post on probe-engine
as documented in https://github.com/ooni/probe-engine/issues/746.