### PR TITLE
netx: move legacy code into the legacy folder (2/n)

### DIFF
--- a/experiment/dash/dash.go
+++ b/experiment/dash/dash.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ooni/probe-engine/internal/humanizex"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/httptransport"
-	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -182,7 +182,7 @@ func (r runner) measure(
 		// of the latest connect time. We should have one sample in most
 		// cases, because the connection should be persistent.
 		for _, ev := range r.saver.Read() {
-			if ev.Name == modelx.ConnectOperation {
+			if ev.Name == errorx.ConnectOperation {
 				connectTime = ev.Duration.Seconds()
 			}
 		}

--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ooni/probe-engine/internal/handler"
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -110,7 +110,7 @@ func TestUnitRunnerLoopMeasureFailure(t *testing.T) {
 func TestUnitRunnerLoopCollectFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := new(trace.Saver)
-	saver.Write(trace.Event{Name: modelx.ConnectOperation, Duration: 150 * time.Millisecond})
+	saver.Write(trace.Event{Name: errorx.ConnectOperation, Duration: 150 * time.Millisecond})
 	r := runner{
 		callbacks: handler.NewPrinterCallbacks(log.Log),
 		httpClient: &http.Client{
@@ -154,7 +154,7 @@ func TestUnitRunnerLoopCollectFailure(t *testing.T) {
 
 func TestUnitRunnerLoopSuccess(t *testing.T) {
 	saver := new(trace.Saver)
-	saver.Write(trace.Event{Name: modelx.ConnectOperation, Duration: 150 * time.Millisecond})
+	saver.Write(trace.Event{Name: errorx.ConnectOperation, Duration: 150 * time.Millisecond})
 	r := runner{
 		callbacks: handler.NewPrinterCallbacks(log.Log),
 		httpClient: &http.Client{

--- a/experiment/fbmessenger/fbmessenger.go
+++ b/experiment/fbmessenger/fbmessenger.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 const (
@@ -110,7 +110,7 @@ func (tk *TestKeys) ComputeEndpointStatus(v urlgetter.MultiOutput, dns, tcp **bo
 	// start where all is unknown
 	*dns, *tcp = nil, nil
 	// process DNS first
-	if v.TestKeys.FailedOperation != nil && *v.TestKeys.FailedOperation == modelx.ResolveOperation {
+	if v.TestKeys.FailedOperation != nil && *v.TestKeys.FailedOperation == errorx.ResolveOperation {
 		tk.FacebookDNSBlocking = &trueValue
 		*dns = &falseValue
 		return // we know that the DNS has failed
@@ -126,7 +126,7 @@ func (tk *TestKeys) ComputeEndpointStatus(v urlgetter.MultiOutput, dns, tcp **bo
 	}
 	*dns = &trueValue
 	// now process connect
-	if v.TestKeys.FailedOperation != nil && *v.TestKeys.FailedOperation == modelx.ConnectOperation {
+	if v.TestKeys.FailedOperation != nil && *v.TestKeys.FailedOperation == errorx.ConnectOperation {
 		tk.FacebookTCPBlocking = &trueValue
 		*tcp = &falseValue
 		return // because connect failed

--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/internal/handler"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestNewExperimentMeasurer(t *testing.T) {
@@ -152,7 +152,7 @@ func TestIntegrationWithCancelledContext(t *testing.T) {
 
 func TestComputeEndpointStatsTCPBlocking(t *testing.T) {
 	failure := io.EOF.Error()
-	operation := modelx.ConnectOperation
+	operation := errorx.ConnectOperation
 	tk := fbmessenger.TestKeys{}
 	tk.Update(urlgetter.MultiOutput{
 		Input: urlgetter.MultiInput{Target: fbmessenger.ServiceEdge},
@@ -182,7 +182,7 @@ func TestComputeEndpointStatsTCPBlocking(t *testing.T) {
 
 func TestComputeEndpointStatsDNSIsLying(t *testing.T) {
 	failure := io.EOF.Error()
-	operation := modelx.ConnectOperation
+	operation := errorx.ConnectOperation
 	tk := fbmessenger.TestKeys{}
 	tk.Update(urlgetter.MultiOutput{
 		Input: urlgetter.MultiInput{Target: fbmessenger.ServiceEdge},

--- a/experiment/hhfm/hhfm.go
+++ b/experiment/hhfm/hhfm.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ooni/probe-engine/netx/archival"
 	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/httptransport"
-	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/selfcensor"
 )
 
@@ -166,7 +165,7 @@ func (m Measurer) Run(
 	// parse response body
 	var jsonHeaders JSONHeaders
 	if err := json.Unmarshal(data, &jsonHeaders); err != nil {
-		failure := modelx.FailureJSONParseError
+		failure := errorx.FailureJSONParseError
 		tk.Failure = &failure
 		tk.Tampering.Total = true
 		return nil // measurement did not fail, we measured tampering
@@ -183,7 +182,7 @@ func Transact(txp Transport, req *http.Request,
 	// make sure that we return a wrapped error here
 	resp, data, err := transact(txp, req, callbacks)
 	err = errorx.SafeErrWrapperBuilder{
-		Error: err, Operation: modelx.TopLevelOperation}.MaybeBuild()
+		Error: err, Operation: errorx.TopLevelOperation}.MaybeBuild()
 	return resp, data, err
 }
 

--- a/experiment/hhfm/hhfm_test.go
+++ b/experiment/hhfm/hhfm_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestNewExperimentMeasurer(t *testing.T) {
@@ -152,14 +152,14 @@ func TestIntegrationCancelledContext(t *testing.T) {
 	if tk.Agent != "agent" {
 		t.Fatal("invalid Agent")
 	}
-	if *tk.Failure != modelx.FailureInterrupted {
+	if *tk.Failure != errorx.FailureInterrupted {
 		t.Fatal("invalid Failure")
 	}
 	if len(tk.Requests) != 1 {
 		t.Fatal("invalid Requests")
 	}
 	request := tk.Requests[0]
-	if *request.Failure != modelx.FailureInterrupted {
+	if *request.Failure != errorx.FailureInterrupted {
 		t.Fatal("invalid Requests[0].Failure")
 	}
 	if request.Request.Body.Value != "" {
@@ -467,7 +467,7 @@ func TestInvalidJSONBody(t *testing.T) {
 	if tk.Agent != "agent" {
 		t.Fatal("invalid Agent")
 	}
-	if *tk.Failure != modelx.FailureJSONParseError {
+	if *tk.Failure != errorx.FailureJSONParseError {
 		t.Fatal("invalid Failure")
 	}
 	if len(tk.Requests) != 1 {

--- a/experiment/hirl/hirl.go
+++ b/experiment/hirl/hirl.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ooni/probe-engine/internal/randx"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/httptransport"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 const (
@@ -293,7 +293,7 @@ func RunMethod(ctx context.Context, config RunMethodConfig) {
 		count, err := conn.Read(data)
 		if err != nil {
 			// We expect this method to terminate w/ timeout
-			if err.Error() == modelx.FailureGenericTimeoutError {
+			if err.Error() == errorx.FailureGenericTimeoutError {
 				err = nil
 			}
 			result.Err = err

--- a/experiment/hirl/hirl_test.go
+++ b/experiment/hirl/hirl_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/httptransport"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 func TestNewExperimentMeasurer(t *testing.T) {
@@ -85,7 +85,7 @@ func TestIntegrationCancelledContext(t *testing.T) {
 		t.Fatal("unexpected FailureList length")
 	}
 	for _, failure := range tk.FailureList {
-		if *failure != modelx.FailureInterrupted {
+		if *failure != errorx.FailureInterrupted {
 			t.Fatal("unexpected failure")
 		}
 	}

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 const (
@@ -64,24 +64,24 @@ func (tk *TestKeys) classify() string {
 		return classSuccessGotServerHello
 	}
 	switch *tk.Target.Failure {
-	case modelx.FailureConnectionRefused:
+	case errorx.FailureConnectionRefused:
 		return classAnomalyTestHelperUnreachable
-	case modelx.FailureConnectionReset:
+	case errorx.FailureConnectionReset:
 		return classInterferenceReset
-	case modelx.FailureDNSNXDOMAINError:
+	case errorx.FailureDNSNXDOMAINError:
 		return classAnomalyTestHelperUnreachable
-	case modelx.FailureEOFError:
+	case errorx.FailureEOFError:
 		return classInterferenceClosed
-	case modelx.FailureGenericTimeoutError:
+	case errorx.FailureGenericTimeoutError:
 		if tk.Control.Failure != nil {
 			return classAnomalyTestHelperUnreachable
 		}
 		return classAnomalyTimeout
-	case modelx.FailureSSLInvalidCertificate:
+	case errorx.FailureSSLInvalidCertificate:
 		return classInterferenceInvalidCertificate
-	case modelx.FailureSSLInvalidHostname:
+	case errorx.FailureSSLInvalidHostname:
 		return classSuccessGotServerHello
-	case modelx.FailureSSLUnknownAuthority:
+	case errorx.FailureSSLUnknownAuthority:
 		return classInterferenceUnknownAuthority
 	}
 	return classAnomalyUnexpectedFailure
@@ -117,8 +117,8 @@ func (m *Measurer) measureone(
 	select {
 	case <-time.After(sleeptime):
 	case <-ctx.Done():
-		s := modelx.FailureInterrupted
-		failedop := modelx.TopLevelOperation
+		s := errorx.FailureInterrupted
+		failedop := errorx.TopLevelOperation
 		return Subresult{
 			TestKeys: urlgetter.TestKeys{
 				FailedOperation: &failedop,

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-engine/internal/handler"
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 const (
@@ -30,64 +30,64 @@ func TestUnitTestKeysClassify(t *testing.T) {
 	})
 	t.Run("with tk.Target.Failure == connection_refused", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureConnectionRefused)
+		tk.Target.Failure = asStringPtr(errorx.FailureConnectionRefused)
 		if tk.classify() != classAnomalyTestHelperUnreachable {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == dns_nxdomain_error", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureDNSNXDOMAINError)
+		tk.Target.Failure = asStringPtr(errorx.FailureDNSNXDOMAINError)
 		if tk.classify() != classAnomalyTestHelperUnreachable {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == connection_reset", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureConnectionReset)
+		tk.Target.Failure = asStringPtr(errorx.FailureConnectionReset)
 		if tk.classify() != classInterferenceReset {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == eof_error", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureEOFError)
+		tk.Target.Failure = asStringPtr(errorx.FailureEOFError)
 		if tk.classify() != classInterferenceClosed {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == ssl_invalid_hostname", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureSSLInvalidHostname)
+		tk.Target.Failure = asStringPtr(errorx.FailureSSLInvalidHostname)
 		if tk.classify() != classSuccessGotServerHello {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == ssl_unknown_authority", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureSSLUnknownAuthority)
+		tk.Target.Failure = asStringPtr(errorx.FailureSSLUnknownAuthority)
 		if tk.classify() != classInterferenceUnknownAuthority {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == ssl_invalid_certificate", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureSSLInvalidCertificate)
+		tk.Target.Failure = asStringPtr(errorx.FailureSSLInvalidCertificate)
 		if tk.classify() != classInterferenceInvalidCertificate {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == generic_timeout_error #1", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
+		tk.Target.Failure = asStringPtr(errorx.FailureGenericTimeoutError)
 		if tk.classify() != classAnomalyTimeout {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("with tk.Target.Failure == generic_timeout_error #2", func(t *testing.T) {
 		tk := new(TestKeys)
-		tk.Target.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
-		tk.Control.Failure = asStringPtr(modelx.FailureGenericTimeoutError)
+		tk.Target.Failure = asStringPtr(errorx.FailureGenericTimeoutError)
+		tk.Control.Failure = asStringPtr(errorx.FailureGenericTimeoutError)
 		if tk.classify() != classAnomalyTestHelperUnreachable {
 			t.Fatal("unexpected result")
 		}
@@ -198,10 +198,10 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	if result.DNSCache != nil {
 		t.Fatal("not the expected DNSCache")
 	}
-	if result.FailedOperation == nil || *result.FailedOperation != modelx.TopLevelOperation {
+	if result.FailedOperation == nil || *result.FailedOperation != errorx.TopLevelOperation {
 		t.Fatal("not the expected FailedOperation")
 	}
-	if result.Failure == nil || *result.Failure != modelx.FailureInterrupted {
+	if result.Failure == nil || *result.Failure != errorx.FailureInterrupted {
 		t.Fatal("not the expected failure")
 	}
 	if result.NetworkEvents != nil {
@@ -302,10 +302,10 @@ func TestUnitMeasureoneSuccess(t *testing.T) {
 	if result.DNSCache != nil {
 		t.Fatal("not the expected DNSCache")
 	}
-	if result.FailedOperation == nil || *result.FailedOperation != modelx.TLSHandshakeOperation {
+	if result.FailedOperation == nil || *result.FailedOperation != errorx.TLSHandshakeOperation {
 		t.Fatal("not the expected FailedOperation")
 	}
-	if result.Failure == nil || *result.Failure != modelx.FailureSSLInvalidHostname {
+	if result.Failure == nil || *result.Failure != errorx.FailureSSLInvalidHostname {
 		t.Fatal("unexpected failure")
 	}
 	if len(result.NetworkEvents) < 1 {
@@ -355,7 +355,7 @@ func TestUnitMeasureonewithcacheWorks(t *testing.T) {
 		if result.Cached != expected {
 			t.Fatal("unexpected cached")
 		}
-		if *result.Failure != modelx.FailureSSLInvalidHostname {
+		if *result.Failure != errorx.FailureSSLInvalidHostname {
 			t.Fatal("unexpected failure")
 		}
 		if result.SNI != "kernel.org" {

--- a/experiment/stunreachability/stunreachability_test.go
+++ b/experiment/stunreachability/stunreachability_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/internal/handler"
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/pion/stun"
 )
 
@@ -204,7 +204,7 @@ func TestReadFailure(t *testing.T) {
 		t.Fatal("not the error we expected")
 	}
 	tk := measurement.TestKeys.(*stunreachability.TestKeys)
-	if *tk.Failure != modelx.FailureGenericTimeoutError {
+	if *tk.Failure != errorx.FailureGenericTimeoutError {
 		t.Fatal("expected different failure here")
 	}
 	if tk.Endpoint != "stun.l.google.com:19302" {

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 const (
@@ -55,7 +55,7 @@ func (tk *TestKeys) Update(v urlgetter.MultiOutput) {
 			tk.TelegramTCPBlocking = false
 			return // found successful access point connection
 		}
-		if v.TestKeys.FailedOperation == nil || *v.TestKeys.FailedOperation != modelx.ConnectOperation {
+		if v.TestKeys.FailedOperation == nil || *v.TestKeys.FailedOperation != errorx.ConnectOperation {
 			tk.TelegramTCPBlocking = false
 		}
 		return

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/probe-engine/internal/handler"
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestNewExperimentMeasurer(t *testing.T) {
@@ -86,7 +86,7 @@ func TestUpdateWithNoAccessPointsBlocking(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -117,7 +117,7 @@ func TestUpdateWithNilFailedOperation(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -129,7 +129,7 @@ func TestUpdateWithNilFailedOperation(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -151,11 +151,11 @@ func TestUpdateWithNonConnectFailedOperation(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			FailedOperation: (func() *string {
-				s := modelx.ConnectOperation
+				s := errorx.ConnectOperation
 				return &s
 			})(),
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -167,11 +167,11 @@ func TestUpdateWithNonConnectFailedOperation(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			FailedOperation: (func() *string {
-				s := modelx.HTTPRoundTripOperation
+				s := errorx.HTTPRoundTripOperation
 				return &s
 			})(),
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -193,11 +193,11 @@ func TestUpdateWithAllConnectsFailed(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			FailedOperation: (func() *string {
-				s := modelx.ConnectOperation
+				s := errorx.ConnectOperation
 				return &s
 			})(),
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -209,11 +209,11 @@ func TestUpdateWithAllConnectsFailed(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			FailedOperation: (func() *string {
-				s := modelx.ConnectOperation
+				s := errorx.ConnectOperation
 				return &s
 			})(),
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -235,11 +235,11 @@ func TestUpdateWebWithMixedResults(t *testing.T) {
 		},
 		TestKeys: urlgetter.TestKeys{
 			FailedOperation: (func() *string {
-				s := modelx.HTTPRoundTripOperation
+				s := errorx.HTTPRoundTripOperation
 				return &s
 			})(),
 			Failure: (func() *string {
-				s := modelx.FailureEOFError
+				s := errorx.FailureEOFError
 				return &s
 			})(),
 		},
@@ -257,7 +257,7 @@ func TestUpdateWebWithMixedResults(t *testing.T) {
 	if tk.TelegramWebStatus != "blocked" {
 		t.Fatal("TelegramWebStatus should be blocked")
 	}
-	if *tk.TelegramWebFailure != modelx.FailureEOFError {
+	if *tk.TelegramWebFailure != errorx.FailureEOFError {
 		t.Fatal("invalid TelegramWebFailure")
 	}
 }

--- a/experiment/tor/tor.go
+++ b/experiment/tor/tor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ooni/probe-engine/legacy/oonitemplates"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 const (
@@ -71,7 +70,7 @@ func (tr *TargetResults) fillSummary() {
 	if len(tr.TCPConnect) < 1 {
 		return
 	}
-	tr.Summary[modelx.ConnectOperation] = Summary{
+	tr.Summary[errorx.ConnectOperation] = Summary{
 		Failure: tr.TCPConnect[0].Status.Failure,
 	}
 	switch tr.TargetProtocol {

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/oonidatamodel"
 	"github.com/ooni/probe-engine/legacy/oonitemplates"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/probeservices"
 )
 
@@ -469,7 +469,7 @@ func TestUnitSummary(t *testing.T) {
 		if len(tr.Summary) != 1 {
 			t.Fatal("cannot find expected entry")
 		}
-		if *tr.Summary[modelx.ConnectOperation].Failure != failure {
+		if *tr.Summary[errorx.ConnectOperation].Failure != failure {
 			t.Fatal("invalid failure")
 		}
 	})
@@ -488,7 +488,7 @@ func TestUnitSummary(t *testing.T) {
 		if len(tr.Summary) != 2 {
 			t.Fatal("cannot find expected entry")
 		}
-		if tr.Summary[modelx.ConnectOperation].Failure != nil {
+		if tr.Summary[errorx.ConnectOperation].Failure != nil {
 			t.Fatal("invalid failure")
 		}
 		if *tr.Summary["handshake"].Failure != failure {
@@ -512,7 +512,7 @@ func TestUnitSummary(t *testing.T) {
 			if len(tr.Summary) < 1 {
 				t.Fatal("cannot find expected entry")
 			}
-			if tr.Summary[modelx.ConnectOperation].Failure != nil {
+			if tr.Summary[errorx.ConnectOperation].Failure != nil {
 				t.Fatal("invalid failure")
 			}
 			if handshake == nil {

--- a/experiment/urlgetter/getter.go
+++ b/experiment/urlgetter/getter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -46,7 +45,7 @@ func (g Getter) Get(ctx context.Context) (TestKeys, error) {
 	// hitting our httptransport that does error wrapping.
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     err,
-		Operation: modelx.TopLevelOperation,
+		Operation: errorx.TopLevelOperation,
 	}.MaybeBuild()
 	tk.FailedOperation = archival.NewFailedOperation(err)
 	tk.Failure = archival.NewFailure(err)

--- a/experiment/urlgetter/getter_test.go
+++ b/experiment/urlgetter/getter_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ooni/probe-engine/experiment/urlgetter"
 	"github.com/ooni/probe-engine/internal/mockable"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestGetterWithCancelledContextVanilla(t *testing.T) {
@@ -31,7 +31,7 @@ func TestGetterWithCancelledContextVanilla(t *testing.T) {
 	if tk.BootstrapTime != 0 {
 		t.Fatal("not the BootstrapTime we expected")
 	}
-	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
+	if tk.FailedOperation == nil || *tk.FailedOperation != errorx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
 	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
@@ -99,7 +99,7 @@ func TestGetterWithCancelledContextAndMethod(t *testing.T) {
 	if tk.BootstrapTime != 0 {
 		t.Fatal("not the BootstrapTime we expected")
 	}
-	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
+	if tk.FailedOperation == nil || *tk.FailedOperation != errorx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
 	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
@@ -169,7 +169,7 @@ func TestGetterWithCancelledContextNoFollowRedirects(t *testing.T) {
 	if tk.BootstrapTime != 0 {
 		t.Fatal("not the BootstrapTime we expected")
 	}
-	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
+	if tk.FailedOperation == nil || *tk.FailedOperation != errorx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
 	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
@@ -238,7 +238,7 @@ func TestGetterWithCancelledContextCannotStartTunnel(t *testing.T) {
 	if tk.BootstrapTime != 0 {
 		t.Fatal("not the BootstrapTime we expected")
 	}
-	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
+	if tk.FailedOperation == nil || *tk.FailedOperation != errorx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
 	if tk.Failure == nil || *tk.Failure != "eof_error" {
@@ -297,7 +297,7 @@ func TestGetterWithCancelledContextWithTunnel(t *testing.T) {
 	if tk.BootstrapTime != 10.0 {
 		t.Fatal("not the BootstrapTime we expected")
 	}
-	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
+	if tk.FailedOperation == nil || *tk.FailedOperation != errorx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
 	if tk.Failure == nil || !strings.HasSuffix(*tk.Failure, "interrupted") {
@@ -367,7 +367,7 @@ func TestGetterWithCancelledContextUnknownResolverURL(t *testing.T) {
 	if tk.BootstrapTime != 0 {
 		t.Fatal("not the BootstrapTime we expected")
 	}
-	if tk.FailedOperation == nil || *tk.FailedOperation != modelx.TopLevelOperation {
+	if tk.FailedOperation == nil || *tk.FailedOperation != errorx.TopLevelOperation {
 		t.Fatal("not the FailedOperation we expected")
 	}
 	if tk.Failure == nil || *tk.Failure != "unknown_failure: unsupported resolver scheme" {
@@ -452,7 +452,7 @@ func TestGetterIntegrationHTTPS(t *testing.T) {
 			resolveStart = true
 		case "resolve_done":
 			resolveDone = true
-		case modelx.ConnectOperation:
+		case errorx.ConnectOperation:
 			connect = true
 		case "tls_handshake_start":
 			tlsHandshakeStart = true
@@ -593,7 +593,7 @@ func TestGetterIntegrationTLSHandshake(t *testing.T) {
 			resolveStart = true
 		case "resolve_done":
 			resolveDone = true
-		case modelx.ConnectOperation:
+		case errorx.ConnectOperation:
 			connect = true
 		case "tls_handshake_start":
 			tlsHandshakeStart = true

--- a/experiment/urlgetter/runner.go
+++ b/experiment/urlgetter/runner.go
@@ -12,16 +12,16 @@ import (
 
 	"github.com/ooni/probe-engine/internal/httpheader"
 	"github.com/ooni/probe-engine/internal/runtimex"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/httptransport"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 const httpRequestFailed = "http_request_failed"
 
 // ErrHTTPRequestFailed indicates that the HTTP request failed.
-var ErrHTTPRequestFailed = &modelx.ErrWrapper{
+var ErrHTTPRequestFailed = &errorx.ErrWrapper{
 	Failure:    httpRequestFailed,
-	Operation:  modelx.TopLevelOperation,
+	Operation:  errorx.TopLevelOperation,
 	WrappedErr: errors.New(httpRequestFailed),
 }
 

--- a/experiment/webconnectivity/control.go
+++ b/experiment/webconnectivity/control.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ooni/probe-engine/internal/httpx"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 // ControlRequest is the request that we send to the control
@@ -62,7 +61,7 @@ func Control(
 	// make sure error is wrapped
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     clnt.PostJSON(ctx, "/", creq, &out),
-		Operation: modelx.TopLevelOperation,
+		Operation: errorx.TopLevelOperation,
 	}.MaybeBuild()
 	sess.Logger().Infof("control %s... %+v", creq.HTTPRequest, err)
 	(&out.DNS).FillASNs(sess)

--- a/experiment/webconnectivity/dnsanalysis.go
+++ b/experiment/webconnectivity/dnsanalysis.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"net/url"
 
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 // DNSAnalysisResult contains the results of analysing comparing
@@ -44,7 +44,7 @@ func DNSAnalysis(URL *url.URL, measurement DNSLookupResult,
 		switch *control.DNS.Failure {
 		case DNSNameError: // the control returns this on NXDOMAIN error
 			switch *measurement.Failure {
-			case modelx.FailureDNSNXDOMAINError:
+			case errorx.FailureDNSNXDOMAINError:
 				out.DNSConsistency = &DNSConsistent
 			}
 		}

--- a/experiment/webconnectivity/dnsanalysis_test.go
+++ b/experiment/webconnectivity/dnsanalysis_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-engine/experiment/webconnectivity"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestDNSAnalysis(t *testing.T) {
-	measurementFailure := modelx.FailureDNSNXDOMAINError
+	measurementFailure := errorx.FailureDNSNXDOMAINError
 	controlFailure := webconnectivity.DNSNameError
 	eofFailure := io.EOF.Error()
 	type args struct {

--- a/experiment/webconnectivity/summary.go
+++ b/experiment/webconnectivity/summary.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ooni/probe-engine/experiment/webconnectivity/internal"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 // The following set of status flags identifies in a more nuanced way the
@@ -127,7 +127,7 @@ func Summarize(tk *TestKeys) (out Summary) {
 	// If DNS failed with NXDOMAIN and the control DNS is consistent, then it
 	// means this website does not exist anymore.
 	if tk.DNSExperimentFailure != nil &&
-		*tk.DNSExperimentFailure == modelx.FailureDNSNXDOMAINError &&
+		*tk.DNSExperimentFailure == errorx.FailureDNSNXDOMAINError &&
 		tk.DNSConsistency != nil && *tk.DNSConsistency == DNSConsistent {
 		// TODO(bassosimone): MK flags this as accessible. This result is debateable. We
 		// are doing what MK does. But we most likely want to make it better later.
@@ -140,7 +140,7 @@ func Summarize(tk *TestKeys) (out Summary) {
 	// Otherwise, if DNS failed with NXDOMAIN, it's DNS based blocking.
 	// TODO(bassosimone): do we wanna include other errors here? Like timeout?
 	if tk.DNSExperimentFailure != nil &&
-		*tk.DNSExperimentFailure == modelx.FailureDNSNXDOMAINError {
+		*tk.DNSExperimentFailure == errorx.FailureDNSNXDOMAINError {
 		out.Accessible = &inaccessible
 		out.BlockingReason = &dns
 		out.Status |= StatusAnomalyDNS | StatusExperimentDNS
@@ -184,41 +184,41 @@ func Summarize(tk *TestKeys) (out Summary) {
 	if tk.Requests[0].Failure != nil {
 		out.Status |= StatusExperimentHTTP
 		switch *tk.Requests[0].Failure {
-		case modelx.FailureConnectionRefused:
+		case errorx.FailureConnectionRefused:
 			// This is possibly because a subsequent connection to some
 			// other endpoint has been blocked. We call this http-failure
 			// because this is what MK would actually do.
 			out.BlockingReason = &httpFailure
 			out.Accessible = &inaccessible
 			out.Status |= StatusAnomalyConnect
-		case modelx.FailureConnectionReset:
+		case errorx.FailureConnectionReset:
 			// We don't currently support TLS failures and we don't have a
 			// way to know if it was during TLS or later. So, for now we are
 			// going to call this error condition an http-failure.
 			out.BlockingReason = &httpFailure
 			out.Accessible = &inaccessible
 			out.Status |= StatusAnomalyReadWrite
-		case modelx.FailureDNSNXDOMAINError:
+		case errorx.FailureDNSNXDOMAINError:
 			// This is possibly because a subsequent resolution to
 			// some other domain name has been blocked.
 			out.BlockingReason = &dns
 			out.Accessible = &inaccessible
 			out.Status |= StatusAnomalyDNS
-		case modelx.FailureEOFError:
+		case errorx.FailureEOFError:
 			// We have seen this happening with TLS handshakes as well as
 			// sometimes with HTTP blocking. So http-failure.
 			out.BlockingReason = &httpFailure
 			out.Accessible = &inaccessible
 			out.Status |= StatusAnomalyReadWrite
-		case modelx.FailureGenericTimeoutError:
+		case errorx.FailureGenericTimeoutError:
 			// Alas, here we don't know whether it's connect or whether it's
 			// perhaps the TLS handshake. So use the same classification used by MK.
 			out.BlockingReason = &httpFailure
 			out.Accessible = &inaccessible
 			out.Status |= StatusAnomalyUnknown
-		case modelx.FailureSSLInvalidHostname,
-			modelx.FailureSSLInvalidCertificate,
-			modelx.FailureSSLUnknownAuthority:
+		case errorx.FailureSSLInvalidHostname,
+			errorx.FailureSSLInvalidCertificate,
+			errorx.FailureSSLUnknownAuthority:
 			// We treat these three cases equally. Misconfiguration is a bit
 			// less likely since we also checked with the control. Since there
 			// is no TLS, for now we're going to call this http-failure.

--- a/experiment/webconnectivity/summary_test.go
+++ b/experiment/webconnectivity/summary_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-engine/experiment/webconnectivity"
 	"github.com/ooni/probe-engine/netx/archival"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestSummarize(t *testing.T) {
@@ -18,14 +18,14 @@ func TestSummarize(t *testing.T) {
 		httpDiff               = "http-diff"
 		httpFailure            = "http-failure"
 		nilstring              *string
-		probeConnectionRefused = modelx.FailureConnectionRefused
-		probeConnectionReset   = modelx.FailureConnectionReset
-		probeEOFError          = modelx.FailureEOFError
-		probeNXDOMAIN          = modelx.FailureDNSNXDOMAINError
-		probeTimeout           = modelx.FailureGenericTimeoutError
-		probeSSLInvalidHost    = modelx.FailureSSLInvalidHostname
-		probeSSLInvalidCert    = modelx.FailureSSLInvalidCertificate
-		probeSSLUnknownAuth    = modelx.FailureSSLUnknownAuthority
+		probeConnectionRefused = errorx.FailureConnectionRefused
+		probeConnectionReset   = errorx.FailureConnectionReset
+		probeEOFError          = errorx.FailureEOFError
+		probeNXDOMAIN          = errorx.FailureDNSNXDOMAINError
+		probeTimeout           = errorx.FailureGenericTimeoutError
+		probeSSLInvalidHost    = errorx.FailureSSLInvalidHostname
+		probeSSLInvalidCert    = errorx.FailureSSLInvalidCertificate
+		probeSSLUnknownAuth    = errorx.FailureSSLUnknownAuthority
 		tcpIP                  = "tcp_ip"
 		trueValue              = true
 	)

--- a/experiment/webconnectivity/webconnectivity_test.go
+++ b/experiment/webconnectivity/webconnectivity_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/internal/handler"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestNewExperimentMeasurer(t *testing.T) {
@@ -69,10 +69,10 @@ func TestMeasureWithCancelledContext(t *testing.T) {
 	if tk.ClientResolver == "" || tk.ClientResolver == model.DefaultResolverIP {
 		t.Fatal("unexpected client_resolver")
 	}
-	if *tk.ControlFailure != modelx.FailureInterrupted {
+	if *tk.ControlFailure != errorx.FailureInterrupted {
 		t.Fatal("unexpected control_failure")
 	}
-	if *tk.DNSExperimentFailure != modelx.FailureInterrupted {
+	if *tk.DNSExperimentFailure != errorx.FailureInterrupted {
 		t.Fatal("unexpected dns_experiment_failure")
 	}
 	if tk.HTTPExperimentFailure != nil {

--- a/legacy/netx/dialer.go
+++ b/legacy/netx/dialer.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
-	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
+	"github.com/ooni/probe-engine/netx/dialer"
 )
 
 // Dialer performs measurements while dialing.

--- a/legacy/netx/dialer.go
+++ b/legacy/netx/dialer.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // Dialer performs measurements while dialing.

--- a/legacy/netx/handlers/handlers.go
+++ b/legacy/netx/handlers/handlers.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/ooni/probe-engine/internal/runtimex"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 type stdoutHandler struct{}

--- a/legacy/netx/handlers/handlers_test.go
+++ b/legacy/netx/handlers/handlers_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestIntegration(t *testing.T) {

--- a/legacy/netx/http.go
+++ b/legacy/netx/http.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/legacy/netx/oldhttptransport"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"golang.org/x/net/http2"
 )
 

--- a/legacy/netx/http.go
+++ b/legacy/netx/http.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
 	"github.com/ooni/probe-engine/legacy/netx/oldhttptransport"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"golang.org/x/net/http2"
 )
 
@@ -81,10 +81,10 @@ func (t *HTTPTransport) RoundTrip(
 	resp, err = t.roundTripper.RoundTrip(req)
 	// For safety wrap the error as modelx.HTTPRoundTripOperation but this
 	// will only be used if the error chain does not contain any
-	// other major operation failure. See modelx.ErrWrapper.
+	// other major operation failure. See errorx.ErrWrapper.
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     err,
-		Operation: modelx.HTTPRoundTripOperation,
+		Operation: errorx.HTTPRoundTripOperation,
 	}.MaybeBuild()
 	return resp, err
 }

--- a/legacy/netx/http_test.go
+++ b/legacy/netx/http_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func dowithclient(t *testing.T, client *netx.HTTPClient) {
@@ -148,7 +148,7 @@ func TestIntegrationHTTPTransportTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
-	if !strings.HasSuffix(err.Error(), modelx.FailureGenericTimeoutError) {
+	if !strings.HasSuffix(err.Error(), errorx.FailureGenericTimeoutError) {
 		t.Fatal("not the error we expected")
 	}
 	if resp != nil {

--- a/legacy/netx/modelx/modelx.go
+++ b/legacy/netx/modelx/modelx.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"math"
 	"net"
 	"net/http"
@@ -83,131 +82,6 @@ type Measurement struct {
 	// part of the official API of the library. The intent however is
 	// to avoid keeping something as an extension for a long time.
 	Extension *ExtensionEvent `json:",omitempty"`
-}
-
-const (
-	// FailureConnectionRefused means ECONNREFUSED.
-	FailureConnectionRefused = "connection_refused"
-
-	// FailureConnectionReset means ECONNRESET.
-	FailureConnectionReset = "connection_reset"
-
-	// FailureDNSBogonError means we detected bogon in DNS reply.
-	FailureDNSBogonError = "dns_bogon_error"
-
-	// FailureDNSNXDOMAINError means we got NXDOMAIN in DNS reply.
-	FailureDNSNXDOMAINError = "dns_nxdomain_error"
-
-	// FailureEOFError means we got unexpected EOF on connection.
-	FailureEOFError = "eof_error"
-
-	// FailureGenericTimeoutError means we got some timer has expired.
-	FailureGenericTimeoutError = "generic_timeout_error"
-
-	// FailureInterrupted means that the user interrupted us.
-	FailureInterrupted = "interrupted"
-
-	// FailureSSLInvalidHostname means we got certificate is not valid for SNI.
-	FailureSSLInvalidHostname = "ssl_invalid_hostname"
-
-	// FailureSSLUnknownAuthority means we cannot find CA validating certificate.
-	FailureSSLUnknownAuthority = "ssl_unknown_authority"
-
-	// FailureSSLInvalidCertificate means certificate experired or other
-	// sort of errors causing it to be invalid.
-	FailureSSLInvalidCertificate = "ssl_invalid_certificate"
-
-	// FailureJSONParseError indicates that we couldn't parse a JSON
-	FailureJSONParseError = "json_parse_error"
-)
-
-const (
-	// ResolveOperation is the operation where we resolve a domain name
-	ResolveOperation = "resolve"
-
-	// ConnectOperation is the operation where we do a TCP connect
-	ConnectOperation = "connect"
-
-	// TLSHandshakeOperation is the TLS handshake
-	TLSHandshakeOperation = "tls_handshake"
-
-	// HTTPRoundTripOperation is the HTTP round trip
-	HTTPRoundTripOperation = "http_round_trip"
-
-	// CloseOperation is when we close a socket
-	CloseOperation = "close"
-
-	// ReadOperation is when we read from a socket
-	ReadOperation = "read"
-
-	// WriteOperation is when we write to a socket
-	WriteOperation = "write"
-
-	// UnknownOperation is when we cannot determine the operation
-	UnknownOperation = "unknown"
-
-	// TopLevelOperation is used when the failure happens at top level. This
-	// happens for example with urlgetter with a cancelled context.
-	TopLevelOperation = "top_level"
-)
-
-// ErrWrapper is our error wrapper for Go errors. The key objective of
-// this structure is to properly set Failure, which is also returned by
-// the Error() method, so be one of the OONI defined strings.
-type ErrWrapper struct {
-	// ConnID is the connection ID, or zero if not known.
-	ConnID int64
-
-	// DialID is the dial ID, or zero if not known.
-	DialID int64
-
-	// Failure is the OONI failure string. The failure strings are
-	// loosely backward compatible with Measurement Kit.
-	//
-	// This is either one of the FailureXXX strings or any other
-	// string like `unknown_failure ...`. The latter represents an
-	// error that we have not yet mapped to a failure.
-	Failure string
-
-	// Operation is the operation that failed. If possible, it
-	// SHOULD be a _major_ operation. Major operations are:
-	//
-	// - ResolveOperation: resolving a domain name failed
-	// - ConnectOperation: connecting to an IP failed
-	// - TLSHandshakeOperation: TLS handshaking failed
-	// - HTTPRoundTripOperation: other errors during round trip
-	//
-	// Because a network connection doesn't necessarily know
-	// what is the current major operation we also have the
-	// following _minor_ operations:
-	//
-	// - CloseOperation: CLOSE failed
-	// - ReadOperation: READ failed
-	// - WriteOperation: WRITE failed
-	//
-	// If an ErrWrapper referring to a major operation is wrapping
-	// another ErrWrapper and such ErrWrapper already refers to
-	// a major operation, then the new ErrWrapper should use the
-	// child ErrWrapper major operation. Otherwise, it should use
-	// its own major operation. This way, the topmost wrapper is
-	// supposed to refer to the major operation that failed.
-	Operation string
-
-	// TransactionID is the transaction ID, or zero if not known.
-	TransactionID int64
-
-	// WrappedErr is the error that we're wrapping.
-	WrappedErr error
-}
-
-// Error returns a description of the error that occurred.
-func (e *ErrWrapper) Error() string {
-	return e.Failure
-}
-
-// Unwrap allows to access the underlying error
-func (e *ErrWrapper) Unwrap() error {
-	return e.WrappedErr
 }
 
 // CloseEvent is emitted when the CLOSE syscall returns.
@@ -758,11 +632,6 @@ type TLSDialer interface {
 	// DialTLSContext is like DialTLS but with context
 	DialTLSContext(ctx context.Context, network, address string) (net.Conn, error)
 }
-
-// ErrDNSBogon indicates that we found a bogon address. This is the
-// correct value with which to initialize MeasurementRoot.ErrDNSBogon
-// to tell this library to return an error when a bogon is found.
-var ErrDNSBogon = errors.New("dns: detected bogon address")
 
 // MeasurementRoot is the measurement root.
 //

--- a/legacy/netx/modelx/modelx_test.go
+++ b/legacy/netx/modelx/modelx_test.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestNewTLSConnectionState(t *testing.T) {
@@ -59,7 +61,7 @@ func TestMeasurementRootWithMeasurementRootPanic(t *testing.T) {
 
 func TestErrWrapperPublicAPI(t *testing.T) {
 	child := errors.New("mocked error")
-	wrapper := &ErrWrapper{
+	wrapper := &errorx.ErrWrapper{
 		Failure:    "moobar",
 		WrappedErr: child,
 	}

--- a/legacy/netx/oldhttptransport/bodytracer.go
+++ b/legacy/netx/oldhttptransport/bodytracer.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // BodyTracer performs single HTTP transactions and emits

--- a/legacy/netx/oldhttptransport/bodytracer.go
+++ b/legacy/netx/oldhttptransport/bodytracer.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 )
 
 // BodyTracer performs single HTTP transactions and emits

--- a/legacy/netx/oldhttptransport/tracetripper.go
+++ b/legacy/netx/oldhttptransport/tracetripper.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ooni/probe-engine/atomicx"
 	"github.com/ooni/probe-engine/legacy/netx/connid"
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // TraceTripper performs single HTTP transactions.

--- a/legacy/netx/oldhttptransport/tracetripper.go
+++ b/legacy/netx/oldhttptransport/tracetripper.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // TraceTripper performs single HTTP transactions.
@@ -88,7 +88,7 @@ func (t *TraceTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	var (
 		err              error
-		majorOp          = modelx.HTTPRoundTripOperation
+		majorOp          = errorx.HTTPRoundTripOperation
 		majorOpMu        sync.Mutex
 		requestBody      []byte
 		requestHeaders   = http.Header{}
@@ -108,7 +108,7 @@ func (t *TraceTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	tracer := &httptrace.ClientTrace{
 		TLSHandshakeStart: func() {
 			majorOpMu.Lock()
-			majorOp = modelx.TLSHandshakeOperation
+			majorOp = errorx.TLSHandshakeOperation
 			majorOpMu.Unlock()
 			// Event emitted by net/http when DialTLS is not
 			// configured in the http.Transport
@@ -124,7 +124,7 @@ func (t *TraceTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			// less confusing to users to see the wrapped name
 			err = errorx.SafeErrWrapperBuilder{
 				Error:         err,
-				Operation:     modelx.TLSHandshakeOperation,
+				Operation:     errorx.TLSHandshakeOperation,
 				TransactionID: tid,
 			}.MaybeBuild()
 			durationSinceBeginning := time.Now().Sub(root.Beginning)
@@ -141,7 +141,7 @@ func (t *TraceTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		},
 		GotConn: func(info httptrace.GotConnInfo) {
 			majorOpMu.Lock()
-			majorOp = modelx.HTTPRoundTripOperation
+			majorOp = errorx.HTTPRoundTripOperation
 			majorOpMu.Unlock()
 			root.Handler.OnMeasurement(modelx.Measurement{
 				HTTPConnectionReady: &modelx.HTTPConnectionReadyEvent{
@@ -188,7 +188,7 @@ func (t *TraceTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 			// less confusing to users to see the wrapped name
 			err := errorx.SafeErrWrapperBuilder{
 				Error:         info.Err,
-				Operation:     modelx.HTTPRoundTripOperation,
+				Operation:     errorx.HTTPRoundTripOperation,
 				TransactionID: tid,
 			}.MaybeBuild()
 			root.Handler.OnMeasurement(modelx.Measurement{

--- a/legacy/netx/oldhttptransport/tracetripper_test.go
+++ b/legacy/netx/oldhttptransport/tracetripper_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestIntegrationTraceTripperSuccess(t *testing.T) {

--- a/legacy/netx/resolver.go
+++ b/legacy/netx/resolver.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
-	"github.com/ooni/probe-engine/legacy/netx/resolver"
+	"github.com/ooni/probe-engine/netx/resolver"
 	newresolver "github.com/ooni/probe-engine/netx/resolver"
 )
 

--- a/legacy/netx/resolver.go
+++ b/legacy/netx/resolver.go
@@ -10,8 +10,9 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
-	"github.com/ooni/probe-engine/netx/modelx"
-	"github.com/ooni/probe-engine/netx/resolver"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/resolver"
+	newresolver "github.com/ooni/probe-engine/netx/resolver"
 )
 
 var (
@@ -142,37 +143,37 @@ func (r chainWrapperResolver) Address() string {
 // ChainResolvers chains a primary and a secondary resolver such that
 // we can fallback to the secondary if primary is broken.
 func ChainResolvers(primary, secondary modelx.DNSResolver) modelx.DNSResolver {
-	return resolver.ChainResolver{
+	return newresolver.ChainResolver{
 		Primary:   chainWrapperResolver{DNSResolver: primary},
 		Secondary: chainWrapperResolver{DNSResolver: secondary},
 	}
 }
 
-func resolverWrapResolver(r resolver.Resolver) resolver.EmitterResolver {
-	return resolver.EmitterResolver{Resolver: resolver.ErrorWrapperResolver{Resolver: r}}
+func resolverWrapResolver(r newresolver.Resolver) resolver.EmitterResolver {
+	return resolver.EmitterResolver{Resolver: newresolver.ErrorWrapperResolver{Resolver: r}}
 }
 
-func resolverWrapTransport(txp resolver.RoundTripper) resolver.EmitterResolver {
-	return resolverWrapResolver(resolver.NewSerialResolver(
+func resolverWrapTransport(txp newresolver.RoundTripper) resolver.EmitterResolver {
+	return resolverWrapResolver(newresolver.NewSerialResolver(
 		resolver.EmitterTransport{RoundTripper: txp}))
 }
 
 func newResolverSystem() resolver.EmitterResolver {
-	return resolverWrapResolver(resolver.SystemResolver{})
+	return resolverWrapResolver(newresolver.SystemResolver{})
 }
 
-func newResolverUDP(dialer resolver.Dialer, address string) resolver.EmitterResolver {
-	return resolverWrapTransport(resolver.NewDNSOverUDP(dialer, address))
+func newResolverUDP(dialer newresolver.Dialer, address string) resolver.EmitterResolver {
+	return resolverWrapTransport(newresolver.NewDNSOverUDP(dialer, address))
 }
 
-func newResolverTCP(dial resolver.DialContextFunc, address string) resolver.EmitterResolver {
-	return resolverWrapTransport(resolver.NewDNSOverTCP(dial, address))
+func newResolverTCP(dial newresolver.DialContextFunc, address string) resolver.EmitterResolver {
+	return resolverWrapTransport(newresolver.NewDNSOverTCP(dial, address))
 }
 
-func newResolverTLS(dial resolver.DialContextFunc, address string) resolver.EmitterResolver {
-	return resolverWrapTransport(resolver.NewDNSOverTLS(dial, address))
+func newResolverTLS(dial newresolver.DialContextFunc, address string) resolver.EmitterResolver {
+	return resolverWrapTransport(newresolver.NewDNSOverTLS(dial, address))
 }
 
 func newResolverHTTPS(client *http.Client, address string) resolver.EmitterResolver {
-	return resolverWrapTransport(resolver.NewDNSOverHTTPS(client, address))
+	return resolverWrapTransport(newresolver.NewDNSOverHTTPS(client, address))
 }

--- a/legacy/netx/resolver_internal_test.go
+++ b/legacy/netx/resolver_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func NewHTTPClientForDoH(beginning time.Time, handler modelx.Handler) *http.Client {

--- a/legacy/netxlogger/netxlogger.go
+++ b/legacy/netxlogger/netxlogger.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/ooni/probe-engine/internal/tlsx"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // Logger is the interface we expect from a logger

--- a/legacy/netxlogger/netxlogger_test.go
+++ b/legacy/netxlogger/netxlogger_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/discard"
 	"github.com/ooni/probe-engine/legacy/netx"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestIntegration(t *testing.T) {

--- a/legacy/oonidatamodel/oonidatamodel.go
+++ b/legacy/oonidatamodel/oonidatamodel.go
@@ -19,7 +19,8 @@ import (
 	"github.com/ooni/probe-engine/internal/tlsx"
 	"github.com/ooni/probe-engine/legacy/oonitemplates"
 	"github.com/ooni/probe-engine/model"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // ExtSpec describes a data format extension
@@ -434,7 +435,7 @@ func NewNetworkEventsList(results oonitemplates.Results) NetworkEventsList {
 				ConnID:        in.Connect.ConnID,
 				DialID:        in.Connect.DialID,
 				Failure:       makeFailure(in.Connect.Error),
-				Operation:     modelx.ConnectOperation,
+				Operation:     errorx.ConnectOperation,
 				Proto:         protocolName[in.Connect.ConnID >= 0],
 				T:             in.Connect.DurationSinceBeginning.Seconds(),
 				TransactionID: in.Connect.TransactionID,
@@ -445,7 +446,7 @@ func NewNetworkEventsList(results oonitemplates.Results) NetworkEventsList {
 			out = append(out, &NetworkEvent{
 				ConnID:    in.Read.ConnID,
 				Failure:   makeFailure(in.Read.Error),
-				Operation: modelx.ReadOperation,
+				Operation: errorx.ReadOperation,
 				NumBytes:  in.Read.NumBytes,
 				Proto:     protocolName[in.Read.ConnID >= 0],
 				T:         in.Read.DurationSinceBeginning.Seconds(),
@@ -456,7 +457,7 @@ func NewNetworkEventsList(results oonitemplates.Results) NetworkEventsList {
 			out = append(out, &NetworkEvent{
 				ConnID:    in.Write.ConnID,
 				Failure:   makeFailure(in.Write.Error),
-				Operation: modelx.WriteOperation,
+				Operation: errorx.WriteOperation,
 				NumBytes:  in.Write.NumBytes,
 				Proto:     protocolName[in.Write.ConnID >= 0],
 				T:         in.Write.DurationSinceBeginning.Seconds(),

--- a/legacy/oonidatamodel/oonidatamodel.go
+++ b/legacy/oonidatamodel/oonidatamodel.go
@@ -17,10 +17,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/ooni/probe-engine/internal/tlsx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/legacy/oonitemplates"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // ExtSpec describes a data format extension

--- a/legacy/oonidatamodel/oonidatamodel_test.go
+++ b/legacy/oonidatamodel/oonidatamodel_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/legacy/oonitemplates"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestUnitNewTCPConnectListEmpty(t *testing.T) {

--- a/legacy/oonidatamodel/oonidatamodel_test.go
+++ b/legacy/oonidatamodel/oonidatamodel_test.go
@@ -11,7 +11,8 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/oonitemplates"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestUnitNewTCPConnectListEmpty(t *testing.T) {
@@ -66,7 +67,7 @@ func TestUnitNewTCPConnectListFailure(t *testing.T) {
 		Connects: []*modelx.ConnectEvent{
 			{
 				RemoteAddress: "8.8.8.8:53",
-				Error:         errors.New(modelx.FailureConnectionReset),
+				Error:         errors.New(errorx.FailureConnectionReset),
 			},
 		},
 	})
@@ -79,7 +80,7 @@ func TestUnitNewTCPConnectListFailure(t *testing.T) {
 	if out[0].Port != 53 {
 		t.Fatal("unexpected out[0].Port")
 	}
-	if *out[0].Status.Failure != modelx.FailureConnectionReset {
+	if *out[0].Status.Failure != errorx.FailureConnectionReset {
 		t.Fatal("unexpected out[0].Failure")
 	}
 	if out[0].Status.Success != false {
@@ -92,7 +93,7 @@ func TestUnitNewTCPConnectListInvalidInput(t *testing.T) {
 		Connects: []*modelx.ConnectEvent{
 			{
 				RemoteAddress: "8.8.8.8",
-				Error:         errors.New(modelx.FailureConnectionReset),
+				Error:         errors.New(errorx.FailureConnectionReset),
 			},
 		},
 	})
@@ -105,7 +106,7 @@ func TestUnitNewTCPConnectListInvalidInput(t *testing.T) {
 	if out[0].Port != 0 {
 		t.Fatal("unexpected out[0].Port")
 	}
-	if *out[0].Status.Failure != modelx.FailureConnectionReset {
+	if *out[0].Status.Failure != errorx.FailureConnectionReset {
 		t.Fatal("unexpected out[0].Failure")
 	}
 	if out[0].Status.Success != false {
@@ -648,7 +649,7 @@ func TestUnitNewDNSQueriesListSuccess(t *testing.T) {
 				TransportNetwork: "system",
 			},
 			{
-				Error:            errors.New(modelx.FailureDNSNXDOMAINError),
+				Error:            errors.New(errorx.FailureDNSNXDOMAINError),
 				Hostname:         "dns.googlex",
 				TransportNetwork: "system",
 			},
@@ -767,7 +768,7 @@ func dnscheckbad(e DNSQueryEntry) error {
 	if e.Engine != "system" {
 		return errors.New("invalid engine")
 	}
-	if *e.Failure != modelx.FailureDNSNXDOMAINError {
+	if *e.Failure != errorx.FailureDNSNXDOMAINError {
 		return errors.New("invalid failure")
 	}
 	if e.Hostname != "dns.googlex" {
@@ -863,7 +864,7 @@ func TestUnitNewNetworkEventsListGood(t *testing.T) {
 	if out[0].NumBytes != 0 {
 		t.Fatal("wrong out[0].NumBytes")
 	}
-	if out[0].Operation != modelx.ConnectOperation {
+	if out[0].Operation != errorx.ConnectOperation {
 		t.Fatal("wrong out[0].Operation")
 	}
 	if out[0].Proto != "tcp" {
@@ -888,7 +889,7 @@ func TestUnitNewNetworkEventsListGood(t *testing.T) {
 	if out[1].NumBytes != 1789 {
 		t.Fatal("wrong out[1].NumBytes")
 	}
-	if out[1].Operation != modelx.ReadOperation {
+	if out[1].Operation != errorx.ReadOperation {
 		t.Fatal("wrong out[1].Operation")
 	}
 	if out[1].Proto != "tcp" {
@@ -913,7 +914,7 @@ func TestUnitNewNetworkEventsListGood(t *testing.T) {
 	if out[2].NumBytes != 17714 {
 		t.Fatal("wrong out[2].NumBytes")
 	}
-	if out[2].Operation != modelx.WriteOperation {
+	if out[2].Operation != errorx.WriteOperation {
 		t.Fatal("wrong out[2].Operation")
 	}
 	if out[2].Proto != "tcp" {
@@ -973,7 +974,7 @@ func TestUnitNewNetworkEventsListGoodUDPAndErrors(t *testing.T) {
 	if out[0].NumBytes != 0 {
 		t.Fatal("wrong out[0].NumBytes")
 	}
-	if out[0].Operation != modelx.ConnectOperation {
+	if out[0].Operation != errorx.ConnectOperation {
 		t.Fatal("wrong out[0].Operation")
 	}
 	if out[0].Proto != "udp" {
@@ -998,7 +999,7 @@ func TestUnitNewNetworkEventsListGoodUDPAndErrors(t *testing.T) {
 	if out[1].NumBytes != 1789 {
 		t.Fatal("wrong out[1].NumBytes")
 	}
-	if out[1].Operation != modelx.ReadOperation {
+	if out[1].Operation != errorx.ReadOperation {
 		t.Fatal("wrong out[1].Operation")
 	}
 	if out[1].Proto != "udp" {
@@ -1023,7 +1024,7 @@ func TestUnitNewNetworkEventsListGoodUDPAndErrors(t *testing.T) {
 	if out[2].NumBytes != 17714 {
 		t.Fatal("wrong out[2].NumBytes")
 	}
-	if out[2].Operation != modelx.WriteOperation {
+	if out[2].Operation != errorx.WriteOperation {
 		t.Fatal("wrong out[2].Operation")
 	}
 	if out[2].Proto != "udp" {

--- a/legacy/oonitemplates/oonitemplates.go
+++ b/legacy/oonitemplates/oonitemplates.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ooni/probe-engine/internal/runtimex"
 	"github.com/ooni/probe-engine/legacy/netx"
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"gitlab.com/yawning/obfs4.git/transports"
 	obfs4base "gitlab.com/yawning/obfs4.git/transports/base"
 )

--- a/legacy/oonitemplates/oonitemplates_test.go
+++ b/legacy/oonitemplates/oonitemplates_test.go
@@ -10,7 +10,8 @@ import (
 	"time"
 
 	goptlib "git.torproject.org/pluggable-transports/goptlib.git"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"gitlab.com/yawning/obfs4.git/transports"
 	obfs4base "gitlab.com/yawning/obfs4.git/transports/base"
 )
@@ -54,7 +55,7 @@ func TestIntegrationDNSLookupCancellation(t *testing.T) {
 	if results.Error == nil {
 		t.Fatal("expected an error here")
 	}
-	if results.Error.Error() != modelx.FailureGenericTimeoutError {
+	if results.Error.Error() != errorx.FailureGenericTimeoutError {
 		t.Fatal("not the error we expected")
 	}
 	if len(results.Addresses) > 0 {
@@ -169,7 +170,7 @@ func TestIntegrationTLSConnectCancellation(t *testing.T) {
 	if results.Error == nil {
 		t.Fatal("expected an error here")
 	}
-	if results.Error.Error() != modelx.FailureGenericTimeoutError {
+	if results.Error.Error() != errorx.FailureGenericTimeoutError {
 		t.Fatal("not the error we expected")
 	}
 }

--- a/legacy/oonitemplates/oonitemplates_test.go
+++ b/legacy/oonitemplates/oonitemplates_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	goptlib "git.torproject.org/pluggable-transports/goptlib.git"
-	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"gitlab.com/yawning/obfs4.git/transports"
 	obfs4base "gitlab.com/yawning/obfs4.git/transports/base"
 )

--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ooni/probe-engine/geolocate"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -84,7 +83,7 @@ type TCPConnectEntry struct {
 func NewTCPConnectList(begin time.Time, events []trace.Event) []TCPConnectEntry {
 	var out []TCPConnectEntry
 	for _, event := range events {
-		if event.Name != modelx.ConnectOperation {
+		if event.Name != errorx.ConnectOperation {
 			continue
 		}
 		// We assume Go is passing us legit data structures
@@ -113,9 +112,9 @@ func NewFailure(err error) *string {
 	// in which this happen is with context deadline for HTTP.
 	err = errorx.SafeErrWrapperBuilder{
 		Error:     err,
-		Operation: modelx.TopLevelOperation,
+		Operation: errorx.TopLevelOperation,
 	}.MaybeBuild()
-	errWrapper := err.(*modelx.ErrWrapper)
+	errWrapper := err.(*errorx.ErrWrapper)
 	s := errWrapper.Failure
 	if s == "" {
 		s = "unknown_failure: errWrapper.Failure is empty"
@@ -129,8 +128,8 @@ func NewFailedOperation(err error) *string {
 		return nil
 	}
 	var (
-		errWrapper *modelx.ErrWrapper
-		s          = modelx.UnknownOperation
+		errWrapper *errorx.ErrWrapper
+		s          = errorx.UnknownOperation
 	)
 	if errors.As(err, &errWrapper) && errWrapper.Operation != "" {
 		s = errWrapper.Operation
@@ -476,7 +475,7 @@ type NetworkEvent struct {
 func NewNetworkEventsList(begin time.Time, events []trace.Event) []NetworkEvent {
 	var out []NetworkEvent
 	for _, ev := range events {
-		if ev.Name == modelx.ConnectOperation {
+		if ev.Name == errorx.ConnectOperation {
 			out = append(out, NetworkEvent{
 				Address:   ev.Address,
 				Failure:   NewFailure(ev.Err),
@@ -486,7 +485,7 @@ func NewNetworkEventsList(begin time.Time, events []trace.Event) []NetworkEvent 
 			})
 			continue
 		}
-		if ev.Name == modelx.ReadOperation {
+		if ev.Name == errorx.ReadOperation {
 			out = append(out, NetworkEvent{
 				Failure:   NewFailure(ev.Err),
 				Operation: ev.Name,
@@ -495,7 +494,7 @@ func NewNetworkEventsList(begin time.Time, events []trace.Event) []NetworkEvent 
 			})
 			continue
 		}
-		if ev.Name == modelx.WriteOperation {
+		if ev.Name == errorx.WriteOperation {
 			out = append(out, NetworkEvent{
 				Failure:   NewFailure(ev.Err),
 				Operation: ev.Name,

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/trace"
 	"github.com/ooni/probe-engine/resources"
 )
@@ -49,14 +49,14 @@ func TestNewTCPConnectList(t *testing.T) {
 			}, {
 				Address:  "8.8.8.8:853",
 				Duration: 30 * time.Millisecond,
-				Name:     modelx.ConnectOperation,
+				Name:     errorx.ConnectOperation,
 				Proto:    "tcp",
 				Time:     begin.Add(130 * time.Millisecond),
 			}, {
 				Address:  "8.8.4.4:53",
 				Duration: 50 * time.Millisecond,
 				Err:      io.EOF,
-				Name:     modelx.ConnectOperation,
+				Name:     errorx.ConnectOperation,
 				Proto:    "tcp",
 				Time:     begin.Add(180 * time.Millisecond),
 			}},
@@ -320,14 +320,14 @@ func TestNewDNSQueriesList(t *testing.T) {
 			}, {
 				Address:  "8.8.8.8:853",
 				Duration: 30 * time.Millisecond,
-				Name:     modelx.ConnectOperation,
+				Name:     errorx.ConnectOperation,
 				Proto:    "tcp",
 				Time:     begin.Add(130 * time.Millisecond),
 			}, {
 				Address:  "8.8.4.4:53",
 				Duration: 50 * time.Millisecond,
 				Err:      io.EOF,
-				Name:     modelx.ConnectOperation,
+				Name:     errorx.ConnectOperation,
 				Proto:    "tcp",
 				Time:     begin.Add(180 * time.Millisecond),
 			}},
@@ -394,7 +394,7 @@ func TestNewDNSQueriesList(t *testing.T) {
 		args: args{
 			begin: begin,
 			events: []trace.Event{{
-				Err:      &modelx.ErrWrapper{Failure: modelx.FailureDNSNXDOMAINError},
+				Err:      &errorx.ErrWrapper{Failure: errorx.FailureDNSNXDOMAINError},
 				Hostname: "dns.google.com",
 				Name:     "resolve_done",
 				Time:     begin.Add(200 * time.Millisecond),
@@ -404,14 +404,14 @@ func TestNewDNSQueriesList(t *testing.T) {
 		want: []archival.DNSQueryEntry{{
 			Answers: nil,
 			Failure: archival.NewFailure(
-				&modelx.ErrWrapper{Failure: modelx.FailureDNSNXDOMAINError}),
+				&errorx.ErrWrapper{Failure: errorx.FailureDNSNXDOMAINError}),
 			Hostname:  "dns.google.com",
 			QueryType: "A",
 			T:         0.2,
 		}, {
 			Answers: nil,
 			Failure: archival.NewFailure(
-				&modelx.ErrWrapper{Failure: modelx.FailureDNSNXDOMAINError}),
+				&errorx.ErrWrapper{Failure: errorx.FailureDNSNXDOMAINError}),
 			Hostname:  "dns.google.com",
 			QueryType: "AAAA",
 			T:         0.2,
@@ -449,23 +449,23 @@ func TestNewNetworkEventsList(t *testing.T) {
 		args: args{
 			begin: begin,
 			events: []trace.Event{{
-				Name:    modelx.ConnectOperation,
+				Name:    errorx.ConnectOperation,
 				Address: "8.8.8.8:853",
 				Err:     io.EOF,
 				Proto:   "tcp",
 				Time:    begin.Add(7 * time.Millisecond),
 			}, {
-				Name:     modelx.ReadOperation,
+				Name:     errorx.ReadOperation,
 				Err:      context.Canceled,
 				NumBytes: 7117,
 				Time:     begin.Add(11 * time.Millisecond),
 			}, {
-				Name:     modelx.WriteOperation,
+				Name:     errorx.WriteOperation,
 				Err:      websocket.ErrBadHandshake,
 				NumBytes: 4114,
 				Time:     begin.Add(14 * time.Millisecond),
 			}, {
-				Name: modelx.CloseOperation,
+				Name: errorx.CloseOperation,
 				Err:  websocket.ErrReadLimit,
 				Time: begin.Add(17 * time.Millisecond),
 			}},
@@ -473,22 +473,22 @@ func TestNewNetworkEventsList(t *testing.T) {
 		want: []archival.NetworkEvent{{
 			Address:   "8.8.8.8:853",
 			Failure:   archival.NewFailure(io.EOF),
-			Operation: modelx.ConnectOperation,
+			Operation: errorx.ConnectOperation,
 			Proto:     "tcp",
 			T:         0.007,
 		}, {
 			Failure:   archival.NewFailure(context.Canceled),
 			NumBytes:  7117,
-			Operation: modelx.ReadOperation,
+			Operation: errorx.ReadOperation,
 			T:         0.011,
 		}, {
 			Failure:   archival.NewFailure(websocket.ErrBadHandshake),
 			NumBytes:  4114,
-			Operation: modelx.WriteOperation,
+			Operation: errorx.WriteOperation,
 			T:         0.014,
 		}, {
 			Failure:   archival.NewFailure(websocket.ErrReadLimit),
-			Operation: modelx.CloseOperation,
+			Operation: errorx.CloseOperation,
 			T:         0.017,
 		}},
 	}}
@@ -523,7 +523,7 @@ func TestNewTLSHandshakesList(t *testing.T) {
 		args: args{
 			begin: begin,
 			events: []trace.Event{{
-				Name: modelx.CloseOperation,
+				Name: errorx.CloseOperation,
 				Err:  websocket.ErrReadLimit,
 				Time: begin.Add(17 * time.Millisecond),
 			}, {
@@ -929,18 +929,18 @@ func TestNewFailure(t *testing.T) {
 	}, {
 		name: "when error is wrapped and failure meaningful",
 		args: args{
-			err: &modelx.ErrWrapper{
-				Failure: modelx.FailureConnectionRefused,
+			err: &errorx.ErrWrapper{
+				Failure: errorx.FailureConnectionRefused,
 			},
 		},
 		want: func() *string {
-			s := modelx.FailureConnectionRefused
+			s := errorx.FailureConnectionRefused
 			return &s
 		}(),
 	}, {
 		name: "when error is wrapped and failure is not meaningful",
 		args: args{
-			err: &modelx.ErrWrapper{},
+			err: &errorx.ErrWrapper{},
 		},
 		want: func() *string {
 			s := "unknown_failure: errWrapper.Failure is empty"
@@ -1009,24 +1009,24 @@ func TestNewFailedOperation(t *testing.T) {
 	}, {
 		name: "With wrapped error and non-empty operation",
 		args: args{
-			err: &modelx.ErrWrapper{
-				Failure:   modelx.FailureConnectionRefused,
-				Operation: modelx.ConnectOperation,
+			err: &errorx.ErrWrapper{
+				Failure:   errorx.FailureConnectionRefused,
+				Operation: errorx.ConnectOperation,
 			},
 		},
 		want: (func() *string {
-			s := modelx.ConnectOperation
+			s := errorx.ConnectOperation
 			return &s
 		})(),
 	}, {
 		name: "With wrapped error and empty operation",
 		args: args{
-			err: &modelx.ErrWrapper{
-				Failure: modelx.FailureConnectionRefused,
+			err: &errorx.ErrWrapper{
+				Failure: errorx.FailureConnectionRefused,
 			},
 		},
 		want: (func() *string {
-			s := modelx.UnknownOperation
+			s := errorx.UnknownOperation
 			return &s
 		})(),
 	}, {
@@ -1035,7 +1035,7 @@ func TestNewFailedOperation(t *testing.T) {
 			err: io.EOF,
 		},
 		want: (func() *string {
-			s := modelx.UnknownOperation
+			s := errorx.UnknownOperation
 			return &s
 		})(),
 	}}

--- a/netx/dialer/dns.go
+++ b/netx/dialer/dns.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 // DNSDialer is a dialer that uses the configured Resolver to resolver a
@@ -52,7 +52,7 @@ func reduceErrors(errorslist []error) error {
 	// the user has no IPv6 connectivity, an IPv6 error is going to
 	// appear later in the list of errors.
 	for _, err := range errorslist {
-		var wrapper *modelx.ErrWrapper
+		var wrapper *errorx.ErrWrapper
 		if errors.As(err, &wrapper) && !strings.HasPrefix(
 			err.Error(), "unknown_failure",
 		) {

--- a/netx/dialer/dns_test.go
+++ b/netx/dialer/dns_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestUnitDNSDialerNoPort(t *testing.T) {

--- a/netx/dialer/dns_test.go
+++ b/netx/dialer/dns_test.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestUnitDNSDialerNoPort(t *testing.T) {
@@ -155,15 +156,15 @@ func TestUnitReduceErrors(t *testing.T) {
 
 	t.Run("multiple errors with meaningful ones", func(t *testing.T) {
 		err1 := errors.New("mocked error #1")
-		err2 := &modelx.ErrWrapper{
+		err2 := &errorx.ErrWrapper{
 			Failure: "unknown_failure: antani",
 		}
-		err3 := &modelx.ErrWrapper{
-			Failure: modelx.FailureConnectionRefused,
+		err3 := &errorx.ErrWrapper{
+			Failure: errorx.FailureConnectionRefused,
 		}
 		err4 := errors.New("mocked error #3")
 		result := dialer.ReduceErrors([]error{err1, err2, err3, err4})
-		if result.Error() != modelx.FailureConnectionRefused {
+		if result.Error() != errorx.FailureConnectionRefused {
 			t.Fatal("wrong result")
 		}
 	})

--- a/netx/dialer/emitter.go
+++ b/netx/dialer/emitter.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // EmitterDialer is a Dialer that emits events

--- a/netx/dialer/emitter.go
+++ b/netx/dialer/emitter.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
-	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 )
 
 // EmitterDialer is a Dialer that emits events

--- a/netx/dialer/emitter_test.go
+++ b/netx/dialer/emitter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestEmitterFailure(t *testing.T) {

--- a/netx/dialer/emitter_test.go
+++ b/netx/dialer/emitter_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestEmitterFailure(t *testing.T) {

--- a/netx/dialer/errorwrapper.go
+++ b/netx/dialer/errorwrapper.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 // ErrorWrapperDialer is a dialer that performs err wrapping
@@ -23,7 +22,7 @@ func (d ErrorWrapperDialer) DialContext(ctx context.Context, network, address st
 		// does not make any sense (and is nil) if we succeded.
 		DialID:    dialID,
 		Error:     err,
-		Operation: modelx.ConnectOperation,
+		Operation: errorx.ConnectOperation,
 	}.MaybeBuild()
 	if err != nil {
 		return nil, err
@@ -46,7 +45,7 @@ func (c ErrorWrapperConn) Read(b []byte) (n int, err error) {
 		ConnID:    c.ConnID,
 		DialID:    c.DialID,
 		Error:     err,
-		Operation: modelx.ReadOperation,
+		Operation: errorx.ReadOperation,
 	}.MaybeBuild()
 	return
 }
@@ -58,7 +57,7 @@ func (c ErrorWrapperConn) Write(b []byte) (n int, err error) {
 		ConnID:    c.ConnID,
 		DialID:    c.DialID,
 		Error:     err,
-		Operation: modelx.WriteOperation,
+		Operation: errorx.WriteOperation,
 	}.MaybeBuild()
 	return
 }
@@ -70,7 +69,7 @@ func (c ErrorWrapperConn) Close() (err error) {
 		ConnID:    c.ConnID,
 		DialID:    c.DialID,
 		Error:     err,
-		Operation: modelx.CloseOperation,
+		Operation: errorx.CloseOperation,
 	}.MaybeBuild()
 	return
 }

--- a/netx/dialer/errorwrapper_test.go
+++ b/netx/dialer/errorwrapper_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 func TestErrorWrapperFailure(t *testing.T) {
@@ -18,14 +18,14 @@ func TestErrorWrapperFailure(t *testing.T) {
 	if conn != nil {
 		t.Fatal("expected a nil conn here")
 	}
-	errorWrapperCheckErr(t, err, modelx.ConnectOperation)
+	errorWrapperCheckErr(t, err, errorx.ConnectOperation)
 }
 
 func errorWrapperCheckErr(t *testing.T, err error, op string) {
 	if !errors.Is(err, io.EOF) {
 		t.Fatal("expected another error here")
 	}
-	var errWrapper *modelx.ErrWrapper
+	var errWrapper *errorx.ErrWrapper
 	if !errors.As(err, &errWrapper) {
 		t.Fatal("cannot cast to ErrWrapper")
 	}
@@ -35,7 +35,7 @@ func errorWrapperCheckErr(t *testing.T, err error, op string) {
 	if errWrapper.Operation != op {
 		t.Fatal("unexpected Operation")
 	}
-	if errWrapper.Failure != modelx.FailureEOFError {
+	if errWrapper.Failure != errorx.FailureEOFError {
 		t.Fatal("unexpected failure")
 	}
 }
@@ -51,11 +51,11 @@ func TestErrorWrapperSuccess(t *testing.T) {
 		t.Fatal("expected non-nil conn here")
 	}
 	count, err := conn.Read(nil)
-	errorWrapperCheckIOResult(t, count, err, modelx.ReadOperation)
+	errorWrapperCheckIOResult(t, count, err, errorx.ReadOperation)
 	count, err = conn.Write(nil)
-	errorWrapperCheckIOResult(t, count, err, modelx.WriteOperation)
+	errorWrapperCheckIOResult(t, count, err, errorx.WriteOperation)
 	err = conn.Close()
-	errorWrapperCheckErr(t, err, modelx.CloseOperation)
+	errorWrapperCheckErr(t, err, errorx.CloseOperation)
 }
 
 func errorWrapperCheckIOResult(t *testing.T, count int, err error, op string) {

--- a/netx/dialer/saver.go
+++ b/netx/dialer/saver.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/internal/tlsx"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -28,7 +28,7 @@ func (d SaverDialer) DialContext(ctx context.Context, network, address string) (
 		Address:  address,
 		Duration: stop.Sub(start),
 		Err:      err,
-		Name:     modelx.ConnectOperation,
+		Name:     errorx.ConnectOperation,
 		Proto:    network,
 		Time:     stop,
 	})
@@ -101,7 +101,7 @@ func (c saverConn) Read(p []byte) (int, error) {
 		Duration: stop.Sub(start),
 		Err:      err,
 		NumBytes: count,
-		Name:     modelx.ReadOperation,
+		Name:     errorx.ReadOperation,
 		Time:     stop,
 	})
 	return count, err
@@ -116,7 +116,7 @@ func (c saverConn) Write(p []byte) (int, error) {
 		Duration: stop.Sub(start),
 		Err:      err,
 		NumBytes: count,
-		Name:     modelx.WriteOperation,
+		Name:     errorx.WriteOperation,
 		Time:     stop,
 	})
 	return count, err

--- a/netx/dialer/saver_test.go
+++ b/netx/dialer/saver_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -43,7 +43,7 @@ func TestUnitSaverDialerFailure(t *testing.T) {
 	if !errors.Is(ev[0].Err, expected) {
 		t.Fatal("unexpected Err")
 	}
-	if ev[0].Name != modelx.ConnectOperation {
+	if ev[0].Name != errorx.ConnectOperation {
 		t.Fatal("unexpected Name")
 	}
 	if ev[0].Proto != "tcp" {
@@ -129,7 +129,7 @@ func TestIntegrationSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 			t.Fatal("unexpected NumBytes")
 		}
 		switch ev[idx].Name {
-		case modelx.ReadOperation, modelx.WriteOperation:
+		case errorx.ReadOperation, errorx.WriteOperation:
 		default:
 			t.Fatal("unexpected Name")
 		}

--- a/netx/dialer/tls.go
+++ b/netx/dialer/tls.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/connid"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 // TLSHandshaker is the generic TLS handshaker
@@ -67,7 +67,7 @@ func (h ErrorWrapperTLSHandshaker) Handshake(
 	err = errorx.SafeErrWrapperBuilder{
 		ConnID:    connID,
 		Error:     err,
-		Operation: modelx.TLSHandshakeOperation,
+		Operation: errorx.TLSHandshakeOperation,
 	}.MaybeBuild()
 	return tlsconn, state, err
 }

--- a/netx/dialer/tls.go
+++ b/netx/dialer/tls.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/connid"
-	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 // TLSHandshaker is the generic TLS handshaker

--- a/netx/dialer/tls_test.go
+++ b/netx/dialer/tls_test.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
 	"github.com/ooni/probe-engine/netx/dialer"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestUnitSystemTLSHandshakerEOFError(t *testing.T) {
@@ -104,17 +105,17 @@ func TestUnitErrorWrapperTLSHandshakerFailure(t *testing.T) {
 	if conn != nil {
 		t.Fatal("expected nil con here")
 	}
-	var errWrapper *modelx.ErrWrapper
+	var errWrapper *errorx.ErrWrapper
 	if !errors.As(err, &errWrapper) {
 		t.Fatal("cannot cast to ErrWrapper")
 	}
 	if errWrapper.ConnID == 0 {
 		t.Fatal("unexpected ConnID")
 	}
-	if errWrapper.Failure != modelx.FailureEOFError {
+	if errWrapper.Failure != errorx.FailureEOFError {
 		t.Fatal("unexpected Failure")
 	}
-	if errWrapper.Operation != modelx.TLSHandshakeOperation {
+	if errWrapper.Operation != errorx.TLSHandshakeOperation {
 		t.Fatal("unexpected Operation")
 	}
 }
@@ -267,7 +268,7 @@ func TestIntegrationDialTLSContextTimeout(t *testing.T) {
 		},
 	}
 	conn, err := dialer.DialTLSContext(context.Background(), "tcp", "google.com:443")
-	if err.Error() != modelx.FailureGenericTimeoutError {
+	if err.Error() != errorx.FailureGenericTimeoutError {
 		t.Fatal("not the error that we expected")
 	}
 	if conn != nil {

--- a/netx/dialer/tls_test.go
+++ b/netx/dialer/tls_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/netx/dialer"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
 func TestUnitSystemTLSHandshakerEOFError(t *testing.T) {

--- a/netx/errorx/errorx.go
+++ b/netx/errorx/errorx.go
@@ -7,11 +7,139 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
-// SafeErrWrapperBuilder contains a builder for modelx.ErrWrapper that
+const (
+	// FailureConnectionRefused means ECONNREFUSED.
+	FailureConnectionRefused = "connection_refused"
+
+	// FailureConnectionReset means ECONNRESET.
+	FailureConnectionReset = "connection_reset"
+
+	// FailureDNSBogonError means we detected bogon in DNS reply.
+	FailureDNSBogonError = "dns_bogon_error"
+
+	// FailureDNSNXDOMAINError means we got NXDOMAIN in DNS reply.
+	FailureDNSNXDOMAINError = "dns_nxdomain_error"
+
+	// FailureEOFError means we got unexpected EOF on connection.
+	FailureEOFError = "eof_error"
+
+	// FailureGenericTimeoutError means we got some timer has expired.
+	FailureGenericTimeoutError = "generic_timeout_error"
+
+	// FailureInterrupted means that the user interrupted us.
+	FailureInterrupted = "interrupted"
+
+	// FailureSSLInvalidHostname means we got certificate is not valid for SNI.
+	FailureSSLInvalidHostname = "ssl_invalid_hostname"
+
+	// FailureSSLUnknownAuthority means we cannot find CA validating certificate.
+	FailureSSLUnknownAuthority = "ssl_unknown_authority"
+
+	// FailureSSLInvalidCertificate means certificate experired or other
+	// sort of errors causing it to be invalid.
+	FailureSSLInvalidCertificate = "ssl_invalid_certificate"
+
+	// FailureJSONParseError indicates that we couldn't parse a JSON
+	FailureJSONParseError = "json_parse_error"
+)
+
+const (
+	// ResolveOperation is the operation where we resolve a domain name
+	ResolveOperation = "resolve"
+
+	// ConnectOperation is the operation where we do a TCP connect
+	ConnectOperation = "connect"
+
+	// TLSHandshakeOperation is the TLS handshake
+	TLSHandshakeOperation = "tls_handshake"
+
+	// HTTPRoundTripOperation is the HTTP round trip
+	HTTPRoundTripOperation = "http_round_trip"
+
+	// CloseOperation is when we close a socket
+	CloseOperation = "close"
+
+	// ReadOperation is when we read from a socket
+	ReadOperation = "read"
+
+	// WriteOperation is when we write to a socket
+	WriteOperation = "write"
+
+	// UnknownOperation is when we cannot determine the operation
+	UnknownOperation = "unknown"
+
+	// TopLevelOperation is used when the failure happens at top level. This
+	// happens for example with urlgetter with a cancelled context.
+	TopLevelOperation = "top_level"
+)
+
+// ErrDNSBogon indicates that we found a bogon address. This is the
+// correct value with which to initialize MeasurementRoot.ErrDNSBogon
+// to tell this library to return an error when a bogon is found.
+var ErrDNSBogon = errors.New("dns: detected bogon address")
+
+// ErrWrapper is our error wrapper for Go errors. The key objective of
+// this structure is to properly set Failure, which is also returned by
+// the Error() method, so be one of the OONI defined strings.
+type ErrWrapper struct {
+	// ConnID is the connection ID, or zero if not known.
+	ConnID int64
+
+	// DialID is the dial ID, or zero if not known.
+	DialID int64
+
+	// Failure is the OONI failure string. The failure strings are
+	// loosely backward compatible with Measurement Kit.
+	//
+	// This is either one of the FailureXXX strings or any other
+	// string like `unknown_failure ...`. The latter represents an
+	// error that we have not yet mapped to a failure.
+	Failure string
+
+	// Operation is the operation that failed. If possible, it
+	// SHOULD be a _major_ operation. Major operations are:
+	//
+	// - ResolveOperation: resolving a domain name failed
+	// - ConnectOperation: connecting to an IP failed
+	// - TLSHandshakeOperation: TLS handshaking failed
+	// - HTTPRoundTripOperation: other errors during round trip
+	//
+	// Because a network connection doesn't necessarily know
+	// what is the current major operation we also have the
+	// following _minor_ operations:
+	//
+	// - CloseOperation: CLOSE failed
+	// - ReadOperation: READ failed
+	// - WriteOperation: WRITE failed
+	//
+	// If an ErrWrapper referring to a major operation is wrapping
+	// another ErrWrapper and such ErrWrapper already refers to
+	// a major operation, then the new ErrWrapper should use the
+	// child ErrWrapper major operation. Otherwise, it should use
+	// its own major operation. This way, the topmost wrapper is
+	// supposed to refer to the major operation that failed.
+	Operation string
+
+	// TransactionID is the transaction ID, or zero if not known.
+	TransactionID int64
+
+	// WrappedErr is the error that we're wrapping.
+	WrappedErr error
+}
+
+// Error returns a description of the error that occurred.
+func (e *ErrWrapper) Error() string {
+	return e.Failure
+}
+
+// Unwrap allows to access the underlying error
+func (e *ErrWrapper) Unwrap() error {
+	return e.WrappedErr
+}
+
+// SafeErrWrapperBuilder contains a builder for ErrWrapper that
 // is safe, i.e., behaves correctly when the error is nil.
 type SafeErrWrapperBuilder struct {
 	// ConnID is the connection ID, if any
@@ -30,11 +158,11 @@ type SafeErrWrapperBuilder struct {
 	TransactionID int64
 }
 
-// MaybeBuild builds a new modelx.ErrWrapper, if b.Error is not nil, and returns
+// MaybeBuild builds a new ErrWrapper, if b.Error is not nil, and returns
 // a nil error value, instead, if b.Error is nil.
 func (b SafeErrWrapperBuilder) MaybeBuild() (err error) {
 	if b.Error != nil {
-		err = &modelx.ErrWrapper{
+		err = &ErrWrapper{
 			ConnID:        b.ConnID,
 			DialID:        b.DialID,
 			Failure:       toFailureString(b.Error),
@@ -50,65 +178,65 @@ func toFailureString(err error) string {
 	// The list returned here matches the values used by MK unless
 	// explicitly noted otherwise with a comment.
 
-	var errwrapper *modelx.ErrWrapper
+	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
 	}
 
-	if errors.Is(err, modelx.ErrDNSBogon) {
-		return modelx.FailureDNSBogonError // not in MK
+	if errors.Is(err, ErrDNSBogon) {
+		return FailureDNSBogonError // not in MK
 	}
 	if errors.Is(err, context.Canceled) {
-		return modelx.FailureInterrupted
+		return FailureInterrupted
 	}
 
 	var x509HostnameError x509.HostnameError
 	if errors.As(err, &x509HostnameError) {
 		// Test case: https://wrong.host.badssl.com/
-		return modelx.FailureSSLInvalidHostname
+		return FailureSSLInvalidHostname
 	}
 	var x509UnknownAuthorityError x509.UnknownAuthorityError
 	if errors.As(err, &x509UnknownAuthorityError) {
 		// Test case: https://self-signed.badssl.com/. This error has
 		// never been among the ones returned by MK.
-		return modelx.FailureSSLUnknownAuthority
+		return FailureSSLUnknownAuthority
 	}
 	var x509CertificateInvalidError x509.CertificateInvalidError
 	if errors.As(err, &x509CertificateInvalidError) {
 		// Test case: https://expired.badssl.com/
-		return modelx.FailureSSLInvalidCertificate
+		return FailureSSLInvalidCertificate
 	}
 
 	s := err.Error()
 	if strings.HasSuffix(s, "operation was canceled") {
-		return modelx.FailureInterrupted
+		return FailureInterrupted
 	}
 	if strings.HasSuffix(s, "EOF") {
-		return modelx.FailureEOFError
+		return FailureEOFError
 	}
 	if strings.HasSuffix(s, "connection refused") {
-		return modelx.FailureConnectionRefused
+		return FailureConnectionRefused
 	}
 	if strings.HasSuffix(s, "connection reset by peer") {
-		return modelx.FailureConnectionReset
+		return FailureConnectionReset
 	}
 	if strings.HasSuffix(s, "context deadline exceeded") {
-		return modelx.FailureGenericTimeoutError
+		return FailureGenericTimeoutError
 	}
 	if strings.HasSuffix(s, "transaction is timed out") {
-		return modelx.FailureGenericTimeoutError
+		return FailureGenericTimeoutError
 	}
 	if strings.HasSuffix(s, "i/o timeout") {
-		return modelx.FailureGenericTimeoutError
+		return FailureGenericTimeoutError
 	}
 	if strings.HasSuffix(s, "TLS handshake timeout") {
-		return modelx.FailureGenericTimeoutError
+		return FailureGenericTimeoutError
 	}
 	if strings.HasSuffix(s, "no such host") {
 		// This is dns_lookup_error in MK but such error is used as a
 		// generic "hey, the lookup failed" error. Instead, this error
 		// that we return here is significantly more specific.
-		return modelx.FailureDNSNXDOMAINError
+		return FailureDNSNXDOMAINError
 	}
 
 	formatted := fmt.Sprintf("unknown_failure: %s", s)
@@ -116,20 +244,20 @@ func toFailureString(err error) string {
 }
 
 func toOperationString(err error, operation string) string {
-	var errwrapper *modelx.ErrWrapper
+	var errwrapper *ErrWrapper
 	if errors.As(err, &errwrapper) {
-		// Basically, as explained in modelx.ErrWrapper docs, let's
+		// Basically, as explained in ErrWrapper docs, let's
 		// keep the child major operation, if any.
-		if errwrapper.Operation == modelx.ConnectOperation {
+		if errwrapper.Operation == ConnectOperation {
 			return errwrapper.Operation
 		}
-		if errwrapper.Operation == modelx.HTTPRoundTripOperation {
+		if errwrapper.Operation == HTTPRoundTripOperation {
 			return errwrapper.Operation
 		}
-		if errwrapper.Operation == modelx.ResolveOperation {
+		if errwrapper.Operation == ResolveOperation {
 			return errwrapper.Operation
 		}
-		if errwrapper.Operation == modelx.TLSHandshakeOperation {
+		if errwrapper.Operation == TLSHandshakeOperation {
 			return errwrapper.Operation
 		}
 		// FALLTHROUGH

--- a/netx/errorx/errorx_test.go
+++ b/netx/errorx/errorx_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/pion/stun"
 )
 
@@ -21,7 +20,7 @@ func TestMaybeBuildFactory(t *testing.T) {
 		Error:         errors.New("mocked error"),
 		TransactionID: 100,
 	}.MaybeBuild()
-	var target *modelx.ErrWrapper
+	var target *ErrWrapper
 	if errors.As(err, &target) == false {
 		t.Fatal("not the expected error type")
 	}
@@ -45,55 +44,55 @@ func TestMaybeBuildFactory(t *testing.T) {
 func TestToFailureString(t *testing.T) {
 	t.Run("for already wrapped error", func(t *testing.T) {
 		err := SafeErrWrapperBuilder{Error: io.EOF}.MaybeBuild()
-		if toFailureString(err) != modelx.FailureEOFError {
+		if toFailureString(err) != FailureEOFError {
 			t.Fatal("unexpected result")
 		}
 	})
-	t.Run("for modelx.ErrDNSBogon", func(t *testing.T) {
-		if toFailureString(modelx.ErrDNSBogon) != modelx.FailureDNSBogonError {
+	t.Run("for ErrDNSBogon", func(t *testing.T) {
+		if toFailureString(ErrDNSBogon) != FailureDNSBogonError {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for context.Canceled", func(t *testing.T) {
-		if toFailureString(context.Canceled) != modelx.FailureInterrupted {
+		if toFailureString(context.Canceled) != FailureInterrupted {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for x509.HostnameError", func(t *testing.T) {
 		var err x509.HostnameError
-		if toFailureString(err) != modelx.FailureSSLInvalidHostname {
+		if toFailureString(err) != FailureSSLInvalidHostname {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for x509.UnknownAuthorityError", func(t *testing.T) {
 		var err x509.UnknownAuthorityError
-		if toFailureString(err) != modelx.FailureSSLUnknownAuthority {
+		if toFailureString(err) != FailureSSLUnknownAuthority {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for x509.CertificateInvalidError", func(t *testing.T) {
 		var err x509.CertificateInvalidError
-		if toFailureString(err) != modelx.FailureSSLInvalidCertificate {
+		if toFailureString(err) != FailureSSLInvalidCertificate {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for operation was canceled error", func(t *testing.T) {
-		if toFailureString(errors.New("operation was canceled")) != modelx.FailureInterrupted {
+		if toFailureString(errors.New("operation was canceled")) != FailureInterrupted {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for EOF", func(t *testing.T) {
-		if toFailureString(io.EOF) != modelx.FailureEOFError {
+		if toFailureString(io.EOF) != FailureEOFError {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for connection_refused", func(t *testing.T) {
-		if toFailureString(syscall.ECONNREFUSED) != modelx.FailureConnectionRefused {
+		if toFailureString(syscall.ECONNREFUSED) != FailureConnectionRefused {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for connection_reset", func(t *testing.T) {
-		if toFailureString(syscall.ECONNRESET) != modelx.FailureConnectionReset {
+		if toFailureString(syscall.ECONNRESET) != FailureConnectionReset {
 			t.Fatal("unexpected results")
 		}
 	})
@@ -101,12 +100,12 @@ func TestToFailureString(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1)
 		defer cancel()
 		<-ctx.Done()
-		if toFailureString(ctx.Err()) != modelx.FailureGenericTimeoutError {
+		if toFailureString(ctx.Err()) != FailureGenericTimeoutError {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for stun's transaction is timed out", func(t *testing.T) {
-		if toFailureString(stun.ErrTransactionTimeOut) != modelx.FailureGenericTimeoutError {
+		if toFailureString(stun.ErrTransactionTimeOut) != FailureGenericTimeoutError {
 			t.Fatal("unexpected results")
 		}
 	})
@@ -120,20 +119,20 @@ func TestToFailureString(t *testing.T) {
 		if conn != nil {
 			t.Fatal("expected nil connection here")
 		}
-		if toFailureString(err) != modelx.FailureGenericTimeoutError {
+		if toFailureString(err) != FailureGenericTimeoutError {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for TLS handshake timeout error", func(t *testing.T) {
 		err := errors.New("net/http: TLS handshake timeout")
-		if toFailureString(err) != modelx.FailureGenericTimeoutError {
+		if toFailureString(err) != FailureGenericTimeoutError {
 			t.Fatal("unexpected results")
 		}
 	})
 	t.Run("for no such host", func(t *testing.T) {
 		if toFailureString(&net.DNSError{
 			Err: "no such host",
-		}) != modelx.FailureDNSNXDOMAINError {
+		}) != FailureDNSNXDOMAINError {
 			t.Fatal("unexpected results")
 		}
 	})
@@ -159,32 +158,32 @@ func TestUnitToOperationString(t *testing.T) {
 	t.Run("for connect", func(t *testing.T) {
 		// You're doing HTTP and connect fails. You want to know
 		// that connect failed not that HTTP failed.
-		err := &modelx.ErrWrapper{Operation: modelx.ConnectOperation}
-		if toOperationString(err, modelx.HTTPRoundTripOperation) != modelx.ConnectOperation {
+		err := &ErrWrapper{Operation: ConnectOperation}
+		if toOperationString(err, HTTPRoundTripOperation) != ConnectOperation {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for http_round_trip", func(t *testing.T) {
 		// You're doing DoH and something fails inside HTTP. You want
 		// to know about the internal HTTP error, not resolve.
-		err := &modelx.ErrWrapper{Operation: modelx.HTTPRoundTripOperation}
-		if toOperationString(err, modelx.ResolveOperation) != modelx.HTTPRoundTripOperation {
+		err := &ErrWrapper{Operation: HTTPRoundTripOperation}
+		if toOperationString(err, ResolveOperation) != HTTPRoundTripOperation {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for resolve", func(t *testing.T) {
 		// You're doing HTTP and the DNS fails. You want to
 		// know that resolve failed.
-		err := &modelx.ErrWrapper{Operation: modelx.ResolveOperation}
-		if toOperationString(err, modelx.HTTPRoundTripOperation) != modelx.ResolveOperation {
+		err := &ErrWrapper{Operation: ResolveOperation}
+		if toOperationString(err, HTTPRoundTripOperation) != ResolveOperation {
 			t.Fatal("unexpected result")
 		}
 	})
 	t.Run("for tls_handshake", func(t *testing.T) {
 		// You're doing HTTP and the TLS handshake fails. You want
 		// to know about a TLS handshake error.
-		err := &modelx.ErrWrapper{Operation: modelx.TLSHandshakeOperation}
-		if toOperationString(err, modelx.HTTPRoundTripOperation) != modelx.TLSHandshakeOperation {
+		err := &ErrWrapper{Operation: TLSHandshakeOperation}
+		if toOperationString(err, HTTPRoundTripOperation) != TLSHandshakeOperation {
 			t.Fatal("unexpected result")
 		}
 	})
@@ -192,8 +191,8 @@ func TestUnitToOperationString(t *testing.T) {
 		// You just noticed that TLS handshake failed and you
 		// have a child error telling you that read failed. Here
 		// you want to know about a TLS handshake error.
-		err := &modelx.ErrWrapper{Operation: modelx.ReadOperation}
-		if toOperationString(err, modelx.TLSHandshakeOperation) != modelx.TLSHandshakeOperation {
+		err := &ErrWrapper{Operation: ReadOperation}
+		if toOperationString(err, TLSHandshakeOperation) != TLSHandshakeOperation {
 			t.Fatal("unexpected result")
 		}
 	})

--- a/netx/httptransport/integration_test.go
+++ b/netx/httptransport/integration_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/apex/log"
 	"github.com/ooni/probe-engine/netx/bytecounter"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/httptransport"
-	"github.com/ooni/probe-engine/netx/modelx"
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
@@ -81,10 +81,10 @@ func TestIntegrationBogonResolutionNotBroken(t *testing.T) {
 		Logger:       log.Log,
 	})
 	addrs, err := r.LookupHost(context.Background(), "www.google.com")
-	if !errors.Is(err, modelx.ErrDNSBogon) {
+	if !errors.Is(err, errorx.ErrDNSBogon) {
 		t.Fatal("not the error we expected")
 	}
-	if err.Error() != modelx.FailureDNSBogonError {
+	if err.Error() != errorx.FailureDNSBogonError {
 		t.Fatal("error not correctly wrapped")
 	}
 	if len(addrs) != 1 || addrs[0] != "127.0.0.1" {

--- a/netx/resolver/bogon.go
+++ b/netx/resolver/bogon.go
@@ -5,7 +5,7 @@ import (
 	"net"
 
 	"github.com/ooni/probe-engine/internal/runtimex"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 )
 
 var privateIPBlocks []*net.IPNet
@@ -62,7 +62,7 @@ func (r BogonResolver) LookupHost(ctx context.Context, hostname string) ([]strin
 		if IsBogon(addr) == true {
 			// We need to return the addrs otherwise the caller cannot see/log/save
 			// the specific addresses that triggered our bogon filter
-			return addrs, modelx.ErrDNSBogon
+			return addrs, errorx.ErrDNSBogon
 		}
 	}
 	return addrs, err

--- a/netx/resolver/bogon_test.go
+++ b/netx/resolver/bogon_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
@@ -29,7 +29,7 @@ func TestUnitBogonAwareResolverWithBogon(t *testing.T) {
 		Resolver: resolver.NewFakeResolverWithResult([]string{"127.0.0.1"}),
 	}
 	addrs, err := r.LookupHost(context.Background(), "dns.google.com")
-	if !errors.Is(err, modelx.ErrDNSBogon) {
+	if !errors.Is(err, errorx.ErrDNSBogon) {
 		t.Fatal("not the error we expected")
 	}
 	if len(addrs) != 1 || addrs[0] != "127.0.0.1" {

--- a/netx/resolver/emitter.go
+++ b/netx/resolver/emitter.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 // EmitterTransport is a RoundTripper that emits events when they occur.

--- a/netx/resolver/emitter_test.go
+++ b/netx/resolver/emitter_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/miekg/dns"
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
-	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 

--- a/netx/resolver/emitter_test.go
+++ b/netx/resolver/emitter_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/legacy/netx/handlers"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/legacy/netx/modelx"
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 

--- a/netx/resolver/errorwrapper.go
+++ b/netx/resolver/errorwrapper.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
 	"github.com/ooni/probe-engine/netx/errorx"
-	"github.com/ooni/probe-engine/netx/modelx"
 )
 
 // ErrorWrapperResolver is a Resolver that knows about wrapping errors.
@@ -22,7 +21,7 @@ func (r ErrorWrapperResolver) LookupHost(ctx context.Context, hostname string) (
 	err = errorx.SafeErrWrapperBuilder{
 		DialID:        dialID,
 		Error:         err,
-		Operation:     modelx.ResolveOperation,
+		Operation:     errorx.ResolveOperation,
 		TransactionID: txID,
 	}.MaybeBuild()
 	return addrs, err

--- a/netx/resolver/errorwrapper_test.go
+++ b/netx/resolver/errorwrapper_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ooni/probe-engine/legacy/netx/dialid"
 	"github.com/ooni/probe-engine/legacy/netx/transactionid"
-	"github.com/ooni/probe-engine/netx/modelx"
+	"github.com/ooni/probe-engine/netx/errorx"
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
@@ -36,11 +36,11 @@ func TestUnitErrorWrapperFailure(t *testing.T) {
 	if addrs != nil {
 		t.Fatal("expected nil addr here")
 	}
-	var errWrapper *modelx.ErrWrapper
+	var errWrapper *errorx.ErrWrapper
 	if !errors.As(err, &errWrapper) {
 		t.Fatal("cannot properly cast the returned error")
 	}
-	if errWrapper.Failure != modelx.FailureDNSNXDOMAINError {
+	if errWrapper.Failure != errorx.FailureDNSNXDOMAINError {
 		t.Fatal("unexpected failure")
 	}
 	if errWrapper.ConnID != 0 {
@@ -52,7 +52,7 @@ func TestUnitErrorWrapperFailure(t *testing.T) {
 	if errWrapper.TransactionID == 0 {
 		t.Fatal("unexpected TransactionID")
 	}
-	if errWrapper.Operation != modelx.ResolveOperation {
+	if errWrapper.Operation != errorx.ResolveOperation {
 		t.Fatal("unexpected Operation")
 	}
 }


### PR DESCRIPTION
This visually simplifies taking apart what is netx today and what
is legacy netx that we will make unnecessary soon.

Part of https://github.com/ooni/probe-engine/issues/746