### PR TITLE
[API CHANGE] libminiooni: give up backwards compatibility and document

### DIFF
--- a/cmd/miniooni/README.md
+++ b/cmd/miniooni/README.md
@@ -4,3 +4,5 @@ This directory contains the source code of a simple CLI client that we
 use for research as well as for running QA scripts. We designed this tool
 to have a CLI similar to MK and OONI Probe v2.x to ease running Jafar
 scripts that check whether these tools behave similarly.
+
+See also libminiooni.

--- a/cmd/miniooni/main.go
+++ b/cmd/miniooni/main.go
@@ -1,5 +1,7 @@
 // Command miniooni is a simple binary for research and QA purposes
 // with a CLI interface similar to MK and OONI Probe v2.x.
+//
+// See also libminiooni, which is where we implement this CLI.
 package main
 
 import (

--- a/libminiooni/README.md
+++ b/libminiooni/README.md
@@ -1,0 +1,16 @@
+# Package github.com/ooni/probe-engine/libminiooni
+
+Package libminiooni implements the cmd/miniooni CLI. Miniooni is our
+experimental client used for research and QA testing.
+
+This CLI has CLI options that do not conflict with Measurement Kit
+v0.10.x CLI options. There are some options conflict with the legacy
+OONI Probe CLI options. Perfect backwards compatibility is not a
+design goal for miniooni. Rather, we aim to have as little conflict
+as possible such that we can run side by side QA checks.
+
+We extracted this package from cmd/miniooni to allow us to further
+integrate the miniooni CLI into other binaries (see for example the
+code at github.com/bassosimone/aladdin). In retrospect, this isn't
+particularly simple to keep up to date because it is complex to sync
+the dependencies used by Psiphon, which need precise pinning.

--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -1,6 +1,17 @@
-// Package libminiooni implements the cmd/miniooni CLI.
+// Package libminiooni implements the cmd/miniooni CLI. Miniooni is our
+// experimental client used for research and QA testing.
 //
-// This CLI is compatible with both OONI Probe v2.x and MK v0.10.x.
+// This CLI has CLI options that do not conflict with Measurement Kit
+// v0.10.x CLI options. There are some options conflict with the legacy
+// OONI Probe CLI options. Perfect backwards compatibility is not a
+// design goal for miniooni. Rather, we aim to have as little conflict
+// as possible such that we can run side by side QA checks.
+//
+// We extracted this package from cmd/miniooni to allow us to further
+// integrate the miniooni CLI into other binaries (see for example the
+// code at github.com/bassosimone/aladdin). In retrospect, this isn't
+// particularly simple to keep up to date because it is complex to sync
+// the dependencies used by Psiphon, which need precise pinning.
 package libminiooni
 
 import (
@@ -52,23 +63,13 @@ const (
 )
 
 var (
-	bouncerURLUnused   string
-	collectorURLUnused string
-	globalOptions      Options
-	startTime          = time.Now()
+	globalOptions Options
+	startTime     = time.Now()
 )
 
 func init() {
 	getopt.FlagLong(
 		&globalOptions.Annotations, "annotation", 'A', "Add annotaton", "KEY=VALUE",
-	)
-	getopt.FlagLong(
-		&bouncerURLUnused, "bouncer", 'b',
-		"Unsupported option that used to set the bouncer base URL", "URL",
-	)
-	getopt.FlagLong(
-		&collectorURLUnused, "collector", 'c',
-		"Unsupported option that used to set the collector base URL", "URL",
 	)
 	getopt.FlagLong(
 		&globalOptions.ExtraOptions, "option", 'O',
@@ -96,7 +97,7 @@ func init() {
 		&globalOptions.NoCollector, "no-collector", 'n', "Don't use a collector",
 	)
 	getopt.FlagLong(
-		&globalOptions.ProbeServicesURL, "probe-services-url", 0,
+		&globalOptions.ProbeServicesURL, "probe-services", 0,
 		"Set the URL of the probe-services instance you want to use", "URL",
 	)
 	getopt.FlagLong(
@@ -229,15 +230,6 @@ func gethomedir(optionsHome string) string {
 // This function will panic in case of a fatal error. It is up to you that
 // integrate this function to either handle the panic of ignore it.
 func MainWithConfiguration(experimentName string, currentOptions Options) {
-	fatalIfFalse(
-		bouncerURLUnused == "",
-		"-b,--bouncer is not supported anymore, use --probe-services-url instead",
-	)
-	fatalIfFalse(
-		collectorURLUnused == "",
-		"-c,--collector is not supported anymore, use --probe-services-url instead",
-	)
-
 	extraOptions := mustMakeMap(currentOptions.ExtraOptions)
 	annotations := mustMakeMap(currentOptions.Annotations)
 


### PR DESCRIPTION
This cannot be a fast moving research client if we are strongly constrained
by backwards compatibility with previous CLI interfaces.

Also, I discovered that, sadly, we've already broken OONI Probe v2.x CLI
by giving another semantics to `-i` and `-O`.

Therefore, really be explicit in our goal of moving fast and do research and
hence give up on backwards compatibility for miniooni.

While there, yet, aim for some consistency and use `--probe-services` as
a command line flag rather than `--probe-services-url`, which is redundant.

Also, remove unused `--bouncer` and `--collector` options which were only
cluttering the output and making the code more complicated.

Do not remove the `--no-geoip` option because it seems we're going to have to
support this functionality again in the future, to deal with the use case in
which the internet is mostly shutdown and we still wanna measure.

Part of https://github.com/ooni/probe-engine/issues/746