### PR TITLE
doc(netx/netx.go): explicitly link to issue describing design

### DIFF
--- a/netx/netx.go
+++ b/netx/netx.go
@@ -15,6 +15,10 @@
 // are also able to intercept and save DNS messages, as well as any
 // other interaction with the remote server (e.g., the result of the
 // TLS handshake for DoT and DoH).
+//
+// We described the design and implementation of the most recent version of
+// this package at <https://github.com/ooni/probe-engine/issues/359>. Such
+// issue also links to a previous design document.
 package netx
 
 import (


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/359, which is
now closed. Seems fine to provide explicit links in the doc.