### PR TITLE
oonimkall: use external testing and better coverage

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -461,7 +461,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 			},
 			config: &example.Config{
 				Message:   "Good day from the example experiment!",
-				SleepTime: int64(5 * time.Second),
+				SleepTime: int64(time.Second),
 			},
 			interruptible: true,
 			inputPolicy:   InputNone,
@@ -477,7 +477,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 			},
 			config: &example.Config{
 				Message:   "Good day from the example with input experiment!",
-				SleepTime: int64(5 * time.Second),
+				SleepTime: int64(time.Second),
 			},
 			interruptible: true,
 			inputPolicy:   InputRequired,
@@ -497,7 +497,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 			},
 			config: &example.Config{
 				Message:   "Good day from the example with input experiment!",
-				SleepTime: int64(5 * time.Second),
+				SleepTime: int64(time.Second),
 			},
 			interruptible: false,
 			inputPolicy:   InputRequired,
@@ -514,7 +514,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 			config: &example.Config{
 				Message:     "Good day from the example with failure experiment!",
 				ReturnError: true,
-				SleepTime:   int64(5 * time.Second),
+				SleepTime:   int64(time.Second),
 			},
 			interruptible: true,
 			inputPolicy:   InputNone,

--- a/oonimkall/task_test.go
+++ b/oonimkall/task_test.go
@@ -42,7 +42,6 @@ func TestIntegrationGood(t *testing.T) {
 		if err := json.Unmarshal([]byte(eventstr), &event); err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("%+v", event)
 	}
 	// make sure we only see task_terminated at this point
 	for {
@@ -80,7 +79,6 @@ func TestIntegrationGoodWithoutGeoIPLookup(t *testing.T) {
 		if err := json.Unmarshal([]byte(eventstr), &event); err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("%+v", event)
 	}
 }
 
@@ -106,7 +104,6 @@ func TestIntegrationWithMeasurementFailure(t *testing.T) {
 		if err := json.Unmarshal([]byte(eventstr), &event); err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("%+v", event)
 	}
 }
 
@@ -146,7 +143,6 @@ func TestIntegrationUnsupportedSetting(t *testing.T) {
 		if event.Key == "failure.startup" {
 			seen = true
 		}
-		t.Logf("%+v", event)
 	}
 	if !seen {
 		t.Fatal("did not see failure.startup")
@@ -176,7 +172,6 @@ func TestIntegrationEmptyStateDir(t *testing.T) {
 		if event.Key == "failure.startup" {
 			seen = true
 		}
-		t.Logf("%+v", event)
 	}
 	if !seen {
 		t.Fatal("did not see failure.startup")
@@ -206,7 +201,6 @@ func TestIntegrationEmptyAssetsDir(t *testing.T) {
 		if event.Key == "failure.startup" {
 			seen = true
 		}
-		t.Logf("%+v", event)
 	}
 	if !seen {
 		t.Fatal("did not see failure.startup")
@@ -237,7 +231,6 @@ func TestIntegrationUnknownExperiment(t *testing.T) {
 		if event.Key == "failure.startup" {
 			seen = true
 		}
-		t.Logf("%+v", event)
 	}
 	if !seen {
 		t.Fatal("did not see failure.startup")
@@ -270,7 +263,6 @@ func TestIntegrationInconsistentGeoIPSettings(t *testing.T) {
 		if event.Key == "failure.startup" {
 			seen = true
 		}
-		t.Logf("%+v", event)
 	}
 	if !seen {
 		t.Fatal("did not see failure.startup")
@@ -301,7 +293,6 @@ func TestIntegrationInputIsRequired(t *testing.T) {
 		if event.Key == "failure.startup" {
 			seen = true
 		}
-		t.Logf("%+v", event)
 	}
 	if !seen {
 		t.Fatal("did not see failure.startup")
@@ -325,9 +316,7 @@ func TestIntegrationMaxRuntime(t *testing.T) {
 		t.Fatal(err)
 	}
 	for !task.IsDone() {
-		ev := task.WaitForNextEvent()
-		delta := time.Now().Sub(begin)
-		fmt.Println(delta, ev)
+		task.WaitForNextEvent()
 	}
 	// The runtime is long because of ancillary operations and is even more
 	// longer because of self shaping we may be performing (especially in

--- a/oonimkall/tasks/chanlogger.go
+++ b/oonimkall/tasks/chanlogger.go
@@ -16,7 +16,7 @@ type ChanLogger struct {
 // Debug implements Logger.Debug
 func (cl *ChanLogger) Debug(msg string) {
 	if cl.hasdebug {
-		cl.emitter.Emit("log", eventLog{
+		cl.emitter.Emit("log", EventLog{
 			LogLevel: "DEBUG",
 			Message:  msg,
 		})
@@ -33,7 +33,7 @@ func (cl *ChanLogger) Debugf(format string, v ...interface{}) {
 // Info implements Logger.Info
 func (cl *ChanLogger) Info(msg string) {
 	if cl.hasinfo {
-		cl.emitter.Emit("log", eventLog{
+		cl.emitter.Emit("log", EventLog{
 			LogLevel: "INFO",
 			Message:  msg,
 		})
@@ -50,7 +50,7 @@ func (cl *ChanLogger) Infof(format string, v ...interface{}) {
 // Warn implements Logger.Warn
 func (cl *ChanLogger) Warn(msg string) {
 	if cl.haswarning {
-		cl.emitter.Emit("log", eventLog{
+		cl.emitter.Emit("log", EventLog{
 			LogLevel: "WARNING",
 			Message:  msg,
 		})

--- a/oonimkall/tasks/event.go
+++ b/oonimkall/tasks/event.go
@@ -2,11 +2,13 @@ package tasks
 
 type eventEmpty struct{}
 
-type eventFailureGeneric struct {
+// EventFailure contains information on a failure.
+type EventFailure struct {
 	Failure string `json:"failure"`
 }
 
-type eventLog struct {
+// EventLog is an event containing a log message.
+type EventLog struct {
 	LogLevel string `json:"log_level"`
 	Message  string `json:"message"`
 }
@@ -31,7 +33,8 @@ type eventStatusGeoIPLookup struct {
 	ProbeNetworkName string `json:"probe_network_name"`
 }
 
-type eventStatusProgress struct {
+// EventStatusProgress reports progress information.
+type EventStatusProgress struct {
 	Message    string  `json:"message"`
 	Percentage float64 `json:"percentage"`
 }

--- a/oonimkall/tasks/eventemitter.go
+++ b/oonimkall/tasks/eventemitter.go
@@ -23,12 +23,12 @@ func (ee *EventEmitter) EmitFailureStartup(failure string) {
 
 // EmitFailureGeneric emits a failure event
 func (ee *EventEmitter) EmitFailureGeneric(name, failure string) {
-	ee.Emit(name, eventFailureGeneric{Failure: failure})
+	ee.Emit(name, EventFailure{Failure: failure})
 }
 
 // EmitStatusProgress emits the status.Progress event
 func (ee *EventEmitter) EmitStatusProgress(percentage float64, message string) {
-	ee.Emit(statusProgress, eventStatusProgress{Message: message, Percentage: percentage})
+	ee.Emit(statusProgress, EventStatusProgress{Message: message, Percentage: percentage})
 }
 
 // Emit emits the specified event

--- a/oonimkall/tasks/eventemitter_test.go
+++ b/oonimkall/tasks/eventemitter_test.go
@@ -1,14 +1,16 @@
-package tasks
+package tasks_test
 
 import (
 	"testing"
+
+	"github.com/ooni/probe-engine/oonimkall/tasks"
 )
 
 func TestUnitDisabledEvents(t *testing.T) {
-	out := make(chan *Event)
-	emitter := NewEventEmitter([]string{"log"}, out)
+	out := make(chan *tasks.Event)
+	emitter := tasks.NewEventEmitter([]string{"log"}, out)
 	go func() {
-		emitter.Emit("log", eventLog{Message: "foo"})
+		emitter.Emit("log", tasks.EventLog{Message: "foo"})
 		close(out)
 	}()
 	var count int64
@@ -23,8 +25,8 @@ func TestUnitDisabledEvents(t *testing.T) {
 }
 
 func TestUnitEmitFailureStartup(t *testing.T) {
-	out := make(chan *Event)
-	emitter := NewEventEmitter([]string{}, out)
+	out := make(chan *tasks.Event)
+	emitter := tasks.NewEventEmitter([]string{}, out)
 	go func() {
 		emitter.EmitFailureStartup("mocked error")
 		close(out)
@@ -32,7 +34,7 @@ func TestUnitEmitFailureStartup(t *testing.T) {
 	var found bool
 	for ev := range out {
 		if ev.Key == "failure.startup" {
-			evv := ev.Value.(eventFailureGeneric) // panic if not castable
+			evv := ev.Value.(tasks.EventFailure) // panic if not castable
 			if evv.Failure == "mocked error" {
 				found = true
 			}
@@ -44,8 +46,8 @@ func TestUnitEmitFailureStartup(t *testing.T) {
 }
 
 func TestUnitEmitStatusProgress(t *testing.T) {
-	out := make(chan *Event)
-	emitter := NewEventEmitter([]string{}, out)
+	out := make(chan *tasks.Event)
+	emitter := tasks.NewEventEmitter([]string{}, out)
 	go func() {
 		emitter.EmitStatusProgress(0.7, "foo")
 		close(out)
@@ -53,7 +55,7 @@ func TestUnitEmitStatusProgress(t *testing.T) {
 	var found bool
 	for ev := range out {
 		if ev.Key == "status.progress" {
-			evv := ev.Value.(eventStatusProgress) // panic if not castable
+			evv := ev.Value.(tasks.EventStatusProgress) // panic if not castable
 			if evv.Message == "foo" && evv.Percentage == 0.7 {
 				found = true
 			}

--- a/oonimkall/tasks/runner.go
+++ b/oonimkall/tasks/runner.go
@@ -211,7 +211,7 @@ func (cb *runnerCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
 }
 
 func (cb *runnerCallbacks) OnProgress(percentage float64, message string) {
-	cb.emitter.Emit(statusProgress, eventStatusProgress{
+	cb.emitter.Emit(statusProgress, EventStatusProgress{
 		Percentage: 0.4 + (percentage * 0.6), // open report is 40%
 		Message:    message,
 	})

--- a/oonimkall/tasks/runner_internal_test.go
+++ b/oonimkall/tasks/runner_internal_test.go
@@ -1,0 +1,190 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	engine "github.com/ooni/probe-engine"
+)
+
+func TestUnitRunnerHasUnsupportedSettings(t *testing.T) {
+	out := make(chan *Event)
+	var falsebool bool
+	var zerodotzero float64
+	var zero int64
+	var emptystring string
+	settings := &Settings{
+		InputFilepaths: []string{"foo"},
+		Options: SettingsOptions{
+			AllEndpoints:          &falsebool,
+			Backend:               "foo",
+			BouncerBaseURL:        "https://ps-nonexistent.ooni.io/",
+			CABundlePath:          "foo",
+			CollectorBaseURL:      "https://ps-nonexistent.ooni.io/",
+			ConstantBitrate:       &falsebool,
+			DNSNameserver:         &emptystring,
+			DNSEngine:             &emptystring,
+			ExpectedBody:          &emptystring,
+			GeoIPASNPath:          "foo",
+			GeoIPCountryPath:      "foo",
+			Hostname:              &emptystring,
+			IgnoreBouncerError:    &falsebool,
+			IgnoreOpenReportError: &falsebool,
+			MLabNSAddressFamily:   &emptystring,
+			MLabNSBaseURL:         &emptystring,
+			MLabNSCountry:         &emptystring,
+			MLabNSMetro:           &emptystring,
+			MLabNSPolicy:          &emptystring,
+			MLabNSToolName:        &emptystring,
+			NoFileReport:          false,
+			Port:                  &zero,
+			ProbeASN:              "AS0",
+			ProbeCC:               "ZZ",
+			ProbeIP:               "127.0.0.1",
+			ProbeNetworkName:      "XXX",
+			RandomizeInput:        true,
+			SaveRealResolverIP:    &falsebool,
+			Server:                &emptystring,
+			TestSuite:             &zero,
+			Timeout:               &zerodotzero,
+			UUID:                  &emptystring,
+		},
+		OutputFilepath: "foo",
+	}
+	go func() {
+		defer close(out)
+		r := NewRunner(settings, out)
+		logger := NewChanLogger(r.emitter, "WARNING", r.out)
+		if r.hasUnsupportedSettings(logger) != true {
+			panic("expected to see unsupported settings")
+		}
+	}()
+	var fatal, warn []string
+	for ev := range out {
+		switch ev.Key {
+		case "failure.startup":
+			evv := ev.Value.(EventFailure)
+			if strings.HasSuffix("not supported", evv.Failure) {
+				log.Fatalf("invalid value: %s", evv.Failure)
+			}
+			fatal = append(fatal, evv.Failure)
+		case "log":
+			evv := ev.Value.(EventLog)
+			if strings.HasSuffix("not supported", evv.Message) {
+				log.Fatalf("invalid value: %s", evv.Message)
+			}
+			warn = append(warn, evv.Message)
+		default:
+			log.Fatalf("invalid key: %s", ev.Key)
+		}
+	}
+	expectedFatal := []string{
+		"InputFilepaths: not supported",
+		"Options.Backend: not supported",
+		"Options.BouncerBaseURL: not supported",
+		"Options.CollectorBaseURL: not supported",
+		"Options.Port: not supported",
+		"Options.RandomizeInput: not supported",
+		"Options.SaveRealResolverIP: not supported",
+		"Options.Server: not supported",
+		"Options.TestSuite: not supported",
+		"Options.Timeout: not supported",
+		"Options.UUID: not supported",
+		"OutputFilepath && !NoFileReport: not supported",
+	}
+	if diff := cmp.Diff(expectedFatal, fatal); diff != "" {
+		t.Fatal(diff)
+	}
+	expectedWarn := []string{
+		"Options.AllEndpoints: not supported",
+		"Options.CABundlePath: not supported",
+		"Options.ConstantBitrate: not supported",
+		"Options.DNSNameserver: not supported",
+		"Options.DNSEngine: not supported",
+		"Options.ExpectedBody: not supported",
+		"Options.GeoIPASNPath: not supported",
+		"Options.GeoIPCountryPath: not supported",
+		"Options.Hostname: not supported",
+		"Options.IgnoreBouncerError: not supported",
+		"Options.IgnoreOpenReportError: not supported",
+		"Options.MLabNSAddressFamily: not supported",
+		"Options.MLabNSBaseURL: not supported",
+		"Options.MLabNSCountry: not supported",
+		"Options.MLabNSMetro: not supported",
+		"Options.MLabNSPolicy: not supported",
+		"Options.MLabNSToolName: not supported",
+		"Options.ProbeASN: not supported",
+		"Options.ProbeCC: not supported",
+		"Options.ProbeIP: not supported",
+		"Options.ProbeNetworkName: not supported",
+	}
+	if diff := cmp.Diff(expectedWarn, warn); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestUnitMeasurementSubmissionEventName(t *testing.T) {
+	if measurementSubmissionEventName(nil) != statusMeasurementSubmission {
+		t.Fatal("unexpected submission event name")
+	}
+	if measurementSubmissionEventName(errors.New("mocked error")) != failureMeasurementSubmission {
+		t.Fatal("unexpected submission event name")
+	}
+}
+
+func TestUnitMeasurementSubmissionFailure(t *testing.T) {
+	if measurementSubmissionFailure(nil) != "" {
+		t.Fatal("unexpected submission failure")
+	}
+	if measurementSubmissionFailure(errors.New("mocked error")) != "mocked error" {
+		t.Fatal("unexpected submission failure")
+	}
+}
+
+func TestIntegrationRunnerMaybeLookupLocationFailure(t *testing.T) {
+	out := make(chan *Event)
+	settings := &Settings{
+		AssetsDir: "../../testdata/oonimkall/assets",
+		Name:      "Example",
+		Options: SettingsOptions{
+			SoftwareName:    "oonimkall-test",
+			SoftwareVersion: "0.1.0",
+		},
+		StateDir: "../../testdata/oonimkall/state",
+	}
+	seench := make(chan int64)
+	go func() {
+		var seen int64
+		for ev := range out {
+			switch ev.Key {
+			case "failure.ip_lookup", "failure.asn_lookup",
+				"failure.cc_lookup", "failure.resolver_lookup":
+				seen++
+			case "status.progress":
+				evv := ev.Value.(EventStatusProgress)
+				if evv.Percentage >= 0.2 {
+					panic(fmt.Sprintf("too much progress: %+v", ev))
+				}
+			case "status.queued", "status.started", "status.end":
+			default:
+				panic(fmt.Sprintf("unexpected key: %s", ev.Key))
+			}
+		}
+		seench <- seen
+	}()
+	expected := errors.New("mocked error")
+	r := NewRunner(settings, out)
+	r.maybeLookupLocation = func(*engine.Session) error {
+		return expected
+	}
+	r.Run(context.Background())
+	close(out)
+	if n := <-seench; n != 4 {
+		t.Fatal("unexpected number of events")
+	}
+}


### PR DESCRIPTION
External testing is better because it explicits what is the API.

I would also like to have very good inter package coverage. In this
case, sadly, it means duplicating some tests.

I think there is more yak shaving to rationalize and speed up
tests within oonimkall a bit, but not immediately.

This finishes the yak shaving before fully tackling
https://github.com/ooni/probe-engine/issues/893.