### PR TITLE
oonimkall: review and update the documentation

### DIFF
--- a/oonimkall/README.md
+++ b/oonimkall/README.md
@@ -7,12 +7,12 @@ We expose two APIs: the task API, which is derived from the
 API originally exposed by Measurement Kit, and the session API,
 which is a Go API that mobile apps can use via `gomobile`.
 
-This package is named oonimkall because it's a ooni/probe-engine
-mplementation of the mkall API implemented by Measurement Kit
+This package is named oonimkall because it contains a partial
+reimplementation of the mkall API implemented by Measurement Kit
 in, e.g., [mkall-ios](https://github.com/measurement-kit/mkall-ios).
 
 The basic tenet of the task API is that you define an experiment
-task you wanna run using a JSON, then you start such task, and
+task you wanna run using a JSON, then you start a task for it, and
 you receive events as serialized JSONs. In addition to this
 functionality, we also include extra APIs used by OONI mobile.
 

--- a/oonimkall/task.go
+++ b/oonimkall/task.go
@@ -5,14 +5,14 @@
 // API originally exposed by Measurement Kit, and the session API,
 // which is a Go API that mobile apps can use via `gomobile`.
 //
-// This package is named oonimkall because it's a ooni/probe-engine
-// implementation of the mkall API implemented by Measurement Kit
+// This package is named oonimkall because it contains a partial
+// reimplementation of the mkall API implemented by Measurement Kit
 // in, e.g., https://github.com/measurement-kit/mkall-ios.
 //
 // Task API
 //
 // The basic tenet of the task API is that you define an experiment
-// task you wanna run using a JSON, then you start such task, and
+// task you wanna run using a JSON, then you start a task for it, and
 // you receive events as serialized JSONs. In addition to this
 // functionality, we also include extra APIs used by OONI mobile.
 //
@@ -27,7 +27,7 @@
 // design document describing the task API.
 //
 // See also https://github.com/ooni/probe-engine/blob/master/DESIGN.md,
-// which explains why we implemented to oonimkall API.
+// which explains why we implemented the oonimkall API.
 //
 // Session API
 //
@@ -48,7 +48,17 @@ import (
 	"github.com/ooni/probe-engine/oonimkall/tasks"
 )
 
-// Task is an asynchronous task.
+// Task is an asynchronous task running an experiment. It mimics the
+// namesake concept initially implemented in Measurement Kit.
+//
+// Future directions
+//
+// Currently Task and Session are two unrelated APIs. As part of
+// evolving the APIs with which apps interact with the engine, we
+// will modify Task to run in the context of a Session. We will
+// do that to save extra lookups and to allow several experiments
+// running as subsequent Tasks to reuse the Session connections
+// created with the OONI probe services backends.
 type Task struct {
 	cancel    context.CancelFunc
 	isdone    *atomicx.Int64

--- a/oonimkall/uuid.go
+++ b/oonimkall/uuid.go
@@ -2,7 +2,8 @@ package oonimkall
 
 import "github.com/google/uuid"
 
-// NewUUID4 generates a new UUID4.
+// NewUUID4 generates a new UUID4 string. This functionality is typically
+// used by mobile apps to generate random unique identifiers.
 func NewUUID4() string {
 	return uuid.Must(uuid.NewRandom()).String()
 }


### PR DESCRIPTION
Part of finishing https://github.com/ooni/probe-engine/issues/893 and
of ensuring the Session API we're exposing is compliant with the compact
design at https://github.com/ooni/probe-engine/issues/893#issuecomment-689031449.