### PR TITLE
DESIGN.md: restrict the scope of the design document

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,9 +1,12 @@
-# OONI Measurement Engine
+# Replacing Measurement Kit
 
 | Author       | Simone Basso |
 |--------------|--------------|
-| Last-Updated | 2020-02-24   |
-| Status       | under review |
+| Last-Updated | 2020-07-09   |
+| Status       | historical   |
+
+*Abstract* we describe our plan of replacing Measurement Kit for OONI
+Probe Android and iOS (in particular) and (also) the CLI.
 
 ## Introduction
 
@@ -121,7 +124,9 @@ a few lines of C allow to implement an ABI compatible replacement.
 
 ## Other APIs of interest
 
-We currently don't have plans for replacing other APIs.
+We currently don't have plans for replacing other MK APIs. We will introduce
+new APIs specifically tailored for our OONI needs, but they will be out of
+scope with respect to the main goal of this design document.
 
 ## History
 


### PR DESCRIPTION
We've added new APIs in https://github.com/ooni/probe-engine/issues/893
but we didn't feel the need of updating DESIGN.md, rather it was more
productive to use an issue as a designing tool.

This is all fine and we should do whatever works(tm) but we should also
make sure we don't provide false expectations with DESIGN.md.

A cheap way to do that is to clearly mark this design document scope
to be that of describing how to replace Measurement Kit.