### PR TITLE
libminiooni: allow newline at EOF with -f/--file

### DIFF
--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -237,8 +237,14 @@ func loadFileInputs(opts *Options) {
 		}
 		content, err := ioutil.ReadFile(opts.InputFilePath)
 		fatalOnError(err, "cannot read input file")
-
-		opts.Inputs = strings.Split(string(content), "\n")
+		// Implementation note: when you save file with vim, you have newline at
+		// end of file and you don't want to consider that an input line. While there
+		// ignore any other empty line that may occur inside the file.
+		for _, input := range strings.Split(string(content), "\n") {
+			if input != "" {
+				opts.Inputs = append(opts.Inputs, input)
+			}
+		}
 	}
 }
 

--- a/libminiooni/libminiooni_unit_test.go
+++ b/libminiooni/libminiooni_unit_test.go
@@ -36,7 +36,9 @@ func TestInputFile(t *testing.T) {
 	// create test input file
 	input1 := "my input 1"
 	input2 := "my input 2"
-	file_contents := []byte(input1 + "\n" + input2)
+	// add newline at end of file like vim does; while there also allow blank
+	// lines in the middle of the file
+	file_contents := []byte(input1 + "\n\n" + input2 + "\n")
 	inputfile, err := ioutil.TempFile("", "myinput")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
It didn't occur to me initially, but the fact that vim adds a newline at
the end of the file adds an extra blank input to be tested.

We actually don't want to emit an error for such an input and the fix
is just to avoid adding blank inputs to the inputs list.

Since the fix is so easy, while there allow any other blank line in
the middle of the file, since it costs us nothing.

Part of https://github.com/ooni/probe-engine/issues/926