### PR TITLE
internal/mlablocatev2: use v2/nearest API

### DIFF
--- a/internal/mlablocatev2/mlablocatev2.go
+++ b/internal/mlablocatev2/mlablocatev2.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// ndt7URLPath is the URL path to be used for ndt
-	ndt7URLPath = "v2beta1/query/ndt/ndt7"
+	ndt7URLPath = "v2/nearest/ndt/ndt7"
 )
 
 var (


### PR DESCRIPTION
See https://github.com/ooni/probe-engine/issues/930