### PR TITLE
all: use ams-pg.ooni.org as testing probe service

### DIFF
--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -213,7 +213,7 @@ func newsession(t *testing.T) model.ExperimentSession {
 	sess, err := engine.NewSession(engine.SessionConfig{
 		AssetsDir: "../../testdata",
 		AvailableProbeServices: []model.Service{{
-			Address: "https://ps-test.ooni.io",
+			Address: "https://ams-pg.ooni.org",
 			Type:    "https",
 		}},
 		Logger: log.Log,

--- a/experiment/hhfm/hhfm_test.go
+++ b/experiment/hhfm/hhfm_test.go
@@ -540,7 +540,7 @@ func newsession(t *testing.T) model.ExperimentSession {
 	sess, err := engine.NewSession(engine.SessionConfig{
 		AssetsDir: "../../testdata",
 		AvailableProbeServices: []model.Service{{
-			Address: "https://ps-test.ooni.io",
+			Address: "https://ams-pg.ooni.org",
 			Type:    "https",
 		}},
 		Logger: log.Log,

--- a/experiment/hirl/hirl_test.go
+++ b/experiment/hirl/hirl_test.go
@@ -510,7 +510,7 @@ func newsession(t *testing.T) model.ExperimentSession {
 	sess, err := engine.NewSession(engine.SessionConfig{
 		AssetsDir: "../../testdata",
 		AvailableProbeServices: []model.Service{{
-			Address: "https://ps-test.ooni.io",
+			Address: "https://ams-pg.ooni.org",
 			Type:    "https",
 		}},
 		Logger: log.Log,

--- a/experiment/webconnectivity/webconnectivity_test.go
+++ b/experiment/webconnectivity/webconnectivity_test.go
@@ -196,7 +196,7 @@ func newsession(t *testing.T, lookupBackends bool) model.ExperimentSession {
 	sess, err := engine.NewSession(engine.SessionConfig{
 		AssetsDir: "../../testdata",
 		AvailableProbeServices: []model.Service{{
-			Address: "https://ps-test.ooni.io",
+			Address: "https://ams-pg.ooni.org",
 			Type:    "https",
 		}},
 		Logger: log.Log,

--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -84,7 +84,7 @@ func (sess *ExperimentSession) NewOrchestraClient(ctx context.Context) (model.Ex
 		return nil, sess.MockableOrchestraClientError
 	}
 	clnt, err := probeservices.NewClient(sess, model.Service{
-		Address: "https://ps-test.ooni.io/",
+		Address: "https://ams-pg.ooni.org/",
 		Type:    "https",
 	})
 	runtimex.PanicOnError(err, "orchestra.NewClient should not fail here")

--- a/oonimkall/session_test.go
+++ b/oonimkall/session_test.go
@@ -15,7 +15,7 @@ import (
 func NewSession() (*oonimkall.Session, error) {
 	return oonimkall.NewSession(&oonimkall.SessionConfig{
 		AssetsDir:        "../testdata/oonimkall/assets",
-		ProbeServicesURL: "https://ps-test.ooni.io/",
+		ProbeServicesURL: "https://ams-pg.ooni.org/",
 		SoftwareName:     "oonimkall-test",
 		SoftwareVersion:  "0.1.0",
 		StateDir:         "../testdata/oonimkall/state",

--- a/probeservices/probeservices_test.go
+++ b/probeservices/probeservices_test.go
@@ -26,7 +26,7 @@ func newclient() *probeservices.Client {
 			MockableLogger:     log.Log,
 		},
 		model.Service{
-			Address: "https://ps-test.ooni.io/",
+			Address: "https://ams-pg.ooni.org/",
 			Type:    "https",
 		},
 	)

--- a/probeservices/urls_test.go
+++ b/probeservices/urls_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestFetchURLListSuccess(t *testing.T) {
 	client := newclient()
-	client.BaseURL = "https://ps1.ooni.io" // ps-test.ooni.io is broken
+	client.BaseURL = "https://ams-pg.ooni.org"
 	config := model.URLListConfig{
 		Categories:  []string{"NEWS", "CULTR"},
 		CountryCode: "IT",

--- a/session_test.go
+++ b/session_test.go
@@ -70,7 +70,7 @@ func TestSessionTorArgsTorBinary(t *testing.T) {
 	sess, err := NewSession(SessionConfig{
 		AssetsDir: "testdata",
 		AvailableProbeServices: []model.Service{{
-			Address: "https://ps-test.ooni.io",
+			Address: "https://ams-pg.ooni.org",
 			Type:    "https",
 		}},
 		Logger: log.Log,
@@ -108,7 +108,7 @@ func newSessionForTestingNoLookupsWithProxyURL(t *testing.T, URL *url.URL) *Sess
 	sess, err := NewSession(SessionConfig{
 		AssetsDir: "testdata",
 		AvailableProbeServices: []model.Service{{
-			Address: "https://ps-test.ooni.io",
+			Address: "https://ams-pg.ooni.org",
 			Type:    "https",
 		}},
 		Logger: log.Log,
@@ -175,7 +175,7 @@ func TestUnitInitOrchestraClientMaybeRegisterError(t *testing.T) {
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	clnt, err := probeservices.NewClient(sess, model.Service{
-		Address: "https://ps-test.ooni.io/",
+		Address: "https://ams-pg.ooni.org/",
 		Type:    "https",
 	})
 	if err != nil {
@@ -197,7 +197,7 @@ func TestUnitInitOrchestraClientMaybeLoginError(t *testing.T) {
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	clnt, err := probeservices.NewClient(sess, model.Service{
-		Address: "https://ps-test.ooni.io/",
+		Address: "https://ams-pg.ooni.org/",
 		Type:    "https",
 	})
 	if err != nil {


### PR DESCRIPTION
There are two reasons for this change:

1. we wanna make sure ams-pg.ooni.org passes all tests

2. mia-ps-test.ooni.io is currently broken

See https://github.com/ooni/backend/issues/446