### PR TITLE
workaround to build probe-engine with go1.15

### DIFF
--- a/build-cli.sh
+++ b/build-cli.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
+set -e
+DISABLE_QUIC=""
+if [ ! -z "$(go version | grep go1.15)" ]; then DISABLE_QUIC="DISABLE_QUIC"; fi
+
 set -ex
 case $1 in
   darwin)
     export GOOS=darwin GOARCH=amd64
-    go build -o ./CLI/darwin/amd64 -ldflags="-s -w" ./cmd/miniooni;;
+    go build -o ./CLI/darwin/amd64 -ldflags="-s -w" -tags $DISABLE_QUIC ./cmd/miniooni;;
   linux)
     export GOOS=linux GOARCH=amd64
-    go build -o ./CLI/linux/amd64 -tags netgo -ldflags='-s -w -extldflags "-static"' ./cmd/miniooni;;
+    go build -o ./CLI/linux/amd64 -tags $DISABLE_QUIC,netgo -ldflags='-s -w -extldflags "-static"' ./cmd/miniooni;;
   windows)
     export GOOS=windows GOARCH=amd64
-    go build -o ./CLI/windows/amd64 -ldflags="-s -w" ./cmd/miniooni;;
+    go build -o ./CLI/windows/amd64 -tags $DISABLE_QUIC -ldflags="-s -w" ./cmd/miniooni;;
   *)
     echo "usage: $0 darwin|linux|windows" 1>&2
     exit 1

--- a/build-cli.sh
+++ b/build-cli.sh
@@ -7,7 +7,7 @@ set -ex
 case $1 in
   darwin)
     export GOOS=darwin GOARCH=amd64
-    go build -o ./CLI/darwin/amd64 -ldflags="-s -w" -tags $DISABLE_QUIC ./cmd/miniooni;;
+    go build -o ./CLI/darwin/amd64 -tags $DISABLE_QUIC -ldflags="-s -w" ./cmd/miniooni;;
   linux)
     export GOOS=linux GOARCH=amd64
     go build -o ./CLI/linux/amd64 -tags $DISABLE_QUIC,netgo -ldflags='-s -w -extldflags "-static"' ./cmd/miniooni;;

--- a/readme_compiletimecheck.go
+++ b/readme_compiletimecheck.go
@@ -1,0 +1,8 @@
+//+build !DISABLE_QUIC
+//+build go1.15
+
+package engine
+
+
+ATTENTION: If you are compiling probe-engine with go1.15 please make sure
+to pass -tags DISABLE_QUIC. Alternatively use the build script!


### PR DESCRIPTION
workaround for #866 