### PR TITLE
github/workflows: run more checks on pull request

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,6 +1,6 @@
 name: generate
 on:
-  push:
+  pull_request:
   schedule:
     - cron: "14 17 * * 3"
 jobs:

--- a/.github/workflows/jafar.yml
+++ b/.github/workflows/jafar.yml
@@ -1,6 +1,6 @@
 name: jafar
 on:
-  push:
+  pull_request:
   schedule:
     - cron: "14 17 * * 3"
 jobs:

--- a/.github/workflows/libooniffi.yml
+++ b/.github/workflows/libooniffi.yml
@@ -1,6 +1,6 @@
 name: libooniffi
 on:
-  push:
+  pull_request:
   schedule:
     - cron: "14 17 * * 3"
 jobs:

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -1,6 +1,6 @@
 name: miniooni
 on:
-  push:
+  pull_request:
   schedule:
     - cron: "14 17 * * 3"
 jobs:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,6 +1,6 @@
 name: qa
 on:
-  push:
+  pull_request:
   schedule:
     - cron: "14 17 * * 3"
 jobs:

--- a/.github/workflows/using.yml
+++ b/.github/workflows/using.yml
@@ -1,6 +1,6 @@
 name: using
 on:
-  pull_request:
+  push:
   schedule:
     - cron: "14 17 * * 3"
 jobs:

--- a/.github/workflows/using.yml
+++ b/.github/workflows/using.yml
@@ -1,6 +1,6 @@
 name: using
 on:
-  push:
+  pull_request:
   schedule:
     - cron: "14 17 * * 3"
 jobs:


### PR DESCRIPTION
Push is not triggered for external pull requests and, at the same time, it
makes sense we run more thorough checks when we have a PR.

Noticed when reviewing https://github.com/ooni/probe-engine/pull/944.