### PR TITLE
go1.15 workaround: add integration test and explanatory output

### DIFF
--- a/.github/workflows/go115.yml
+++ b/.github/workflows/go115.yml
@@ -1,0 +1,18 @@
+name: go115
+on:
+  pull_request:
+  schedule:
+    - cron: "14 17 * * 3"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.15"
+      - uses: actions/checkout@v2
+      - run: ./build-cli.sh linux
+      - run: ./CLI/linux/amd64/miniooni -nNi https://example.com web_connectivity
+      - run: ./build-cli.sh darwin
+      - run: sudo apt install --yes mingw-w64
+      - run: ./build-cli.sh windows

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - run: ./build-cli.sh linux
+      - run: ./CLI/linux/amd64/miniooni -nNi https://example.com web_connectivity
       - uses: actions/upload-artifact@v1
         with:
           name: miniooni-linux-amd64

--- a/build-cli.sh
+++ b/build-cli.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 set -e
 DISABLE_QUIC=""
-if [ ! -z "$(go version | grep go1.15)" ]; then DISABLE_QUIC="DISABLE_QUIC"; fi
-
+if [ ! -z "`go version | grep go1.15`" ]; then
+  echo "Warning: disabling QUIC when using Go 1.15."
+  echo "See https://github.com/ooni/probe-engine/issues/866 for more info."
+  DISABLE_QUIC="DISABLE_QUIC"
+fi
 set -ex
 case $1 in
   darwin)

--- a/readme_compiletimecheck.go
+++ b/readme_compiletimecheck.go
@@ -3,6 +3,5 @@
 
 package engine
 
-
 ATTENTION: If you are compiling probe-engine with go1.15 please make sure
-to pass -tags DISABLE_QUIC. Alternatively use the build script!
+to pass -tags DISABLE_QUIC. Alternatively use ./build-cli.sh.


### PR DESCRIPTION
This diff contains a bunch of small cosmetic tweaks for https://github.com/ooni/probe-engine/issues/866 as well as a smoke test to make sure we're not going to break future builds of people using Go 1.15.