### PR TITLE
oonimkall/session.go: significantly simplify the implementation

### DIFF
--- a/legacy/netx/resolver_test.go
+++ b/legacy/netx/resolver_test.go
@@ -27,7 +27,8 @@ func testresolverquick(t *testing.T, network, address string) {
 	}
 	var foundquad8 bool
 	for _, addr := range addrs {
-		if addr == "8.8.8.8" {
+		// See https://github.com/ooni/probe-engine/pull/954/checks?check_run_id=1182269025
+		if addr == "8.8.8.8" || addr == "2001:4860:4860::8888" {
 			foundquad8 = true
 		}
 	}

--- a/legacy/netx/resolver_test.go
+++ b/legacy/netx/resolver_test.go
@@ -20,7 +20,7 @@ func testresolverquick(t *testing.T, network, address string) {
 	}
 	addrs, err := resolver.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("legacy/netx/resolver_test.go: %+v", err)
 	}
 	if addrs == nil {
 		t.Fatal("expected non-nil addrs here")
@@ -32,7 +32,7 @@ func testresolverquick(t *testing.T, network, address string) {
 		}
 	}
 	if !foundquad8 {
-		t.Fatal("did not find 8.8.8.8 in ouput")
+		t.Fatalf("did not find 8.8.8.8 in ouput; output=%+v", addrs)
 	}
 }
 

--- a/netx/resolver/integration_test.go
+++ b/netx/resolver/integration_test.go
@@ -28,12 +28,13 @@ func testresolverquick(t *testing.T, reso resolver.Resolver) {
 	}
 	var foundquad8 bool
 	for _, addr := range addrs {
-		if addr == "8.8.8.8" {
+		// See https://github.com/ooni/probe-engine/pull/954/checks?check_run_id=1182269025
+		if addr == "8.8.8.8" || addr == "2001:4860:4860::8888" {
 			foundquad8 = true
 		}
 	}
 	if !foundquad8 {
-		t.Fatal("did not find 8.8.8.8 in ouput")
+		t.Fatalf("did not find 8.8.8.8 in ouput; output=%+v", addrs)
 	}
 }
 

--- a/oonimkall/session.go
+++ b/oonimkall/session.go
@@ -3,7 +3,9 @@ package oonimkall
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
+	"runtime"
+	"sync"
 	"time"
 
 	engine "github.com/ooni/probe-engine"
@@ -65,11 +67,9 @@ type SessionConfig struct {
 
 // Session contains shared state for running experiments and/or other
 // OONI related task (e.g. geolocation). Note that the Session isn't
-// mean to be shared across threads. It is also not meant to be a long
-// living object. The workflow is to create a Session, do the operations
-// you need to do with it now, then call Session.Close. All of this is
-// supposed to happen within the same Java/ObjC thread. If wanna cancel
-// any operation from other threads, all tasks have a Cancel method.
+// mean to be a long living object. The workflow is to create a Session,
+// do the operations you need to do with it now, then make sure it is
+// not referenced by other variables, so the Go GC can finalize it.
 //
 // Future directions
 //
@@ -79,19 +79,20 @@ type SessionConfig struct {
 // are in the suboptimal situations where Tasks create, use, and close
 // their own session, thus running more lookups than needed.
 type Session struct {
-	sp *engine.Session
+	cl        []context.CancelFunc
+	mtx       sync.Mutex
+	submitter *probeservices.Submitter
+	sessp     *engine.Session
 }
 
-var errNullPointer = errors.New("oonimkall: you passed me a null pointer")
-
 // NewSession creates a new session. You should use a session for running
-// related operation in a relatively short time frame. You should not create
+// a set of operations in a relatively short time frame. You SHOULD NOT create
 // a single session and keep it all alive for the whole app lifecyle, since
 // the Session code is not specifically designed for this use case.
+//
+// This function will abort if config is a null pointer. This function will
+// register a finalizer for the returned Session instance.
 func NewSession(config *SessionConfig) (*Session, error) {
-	if config == nil {
-		return nil, errNullPointer
-	}
 	kvstore, err := engine.NewFileSystemKVStore(config.StateDir)
 	if err != nil {
 		return nil, err
@@ -112,72 +113,59 @@ func NewSession(config *SessionConfig) (*Session, error) {
 		SoftwareVersion:        config.SoftwareVersion,
 		TempDir:                config.TempDir,
 	}
-	sess, err := engine.NewSession(engineConfig)
+	sessp, err := engine.NewSession(engineConfig)
 	if err != nil {
 		return nil, err
 	}
-	return &Session{sp: sess}, nil
+	sess := &Session{sessp: sessp}
+	runtime.SetFinalizer(sess, sessionFinalizer)
+	return sess, nil
 }
 
-func (sess *Session) probeASNString() string {
-	return sess.sp.ProbeASNString()
+// sessionFinalizer finalizes a Session. While in general in Go code using a
+// finalizer is probably unclean, it seems that using a finalizer when binding
+// with Java/ObjC code is actually useful to simplify the apps.
+func sessionFinalizer(sess *Session) {
+	for _, fn := range sess.cl {
+		fn()
+	}
+	if sess.submitter != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancel()
+		sess.submitter.Close(ctx) // ignore return value
+	}
+	sess.sessp.Close() // ignore return value
 }
 
-func (sess *Session) probeCC() string {
-	return sess.sp.ProbeCC()
-}
-
-func (sess *Session) probeIP() string {
-	return sess.sp.ProbeIP()
-}
-
-func (sess *Session) probeNetworkName() string {
-	return sess.sp.ProbeNetworkName()
-}
-
-func (sess *Session) maybeLookupLocationContext(ctx context.Context) (err error) {
-	return sess.sp.MaybeLookupLocationContext(ctx)
-}
-
-func (sess *Session) newProbeServicesClient(ctx context.Context) (*probeservices.Client, error) {
-	return sess.sp.NewProbeServicesClient(ctx)
-}
-
-// NewGeolocateTask creates a new GeolocateTask. This task will allow you
-// to geolocate the probe. The timeout for the task is in seconds. When
-// the timeout value is zero or negative, there won't be any timeout.
-func (sess *Session) NewGeolocateTask(timeout int64) *GeolocateTask {
-	ctx, cancel := newContext(timeout)
-	return &GeolocateTask{cancel: cancel, ctx: ctx, sess: sess}
-}
-
-// NewMakeSubmitterTask creates a new MakeSubmitterTask. This task will
-// allow you to create a Submitter. The Submitter is an object that knows
-// how to submit measurements to the OONI collector. The timeout for the
-// task has exactly the same semantics of NewGeolocateTask.
-func (sess *Session) NewMakeSubmitterTask(timeout int64) *MakeSubmitterTask {
-	ctx, cancel := newContext(timeout)
-	return &MakeSubmitterTask{cancel: cancel, ctx: ctx, sess: sess}
-}
-
-// Close releases the resources allocated by a Session. This method MAY
-// NOT be thread safe and MAY NOT be idempotent.
-func (sess *Session) Close() error {
-	return sess.sp.Close()
-}
-
-// GeolocateTask allows you to geolocation the probe.
-//
-// Bug
-//
-// After the first lookup is done, the result will be memoized
-// by the Session. Therefore, to obtain fresh geolocate results
-// you actually need to create a new Session. This is poised
-// to change in a future release of probe-engine.
-type GeolocateTask struct {
+// Context is the context of an operation. You use this context
+// to cancel a long running operation by calling Cancel(). Because
+// you create a Context from a Session and because the Session is
+// keeping track of the Context instances it owns, you do don't
+// need to call the Cancel method when you're done.
+type Context struct {
 	cancel context.CancelFunc
 	ctx    context.Context
-	sess   *Session
+}
+
+// Cancel cancels pending operations using this context.
+func (oc *Context) Cancel() {
+	oc.cancel()
+}
+
+// NewContext creates an new interruptible Context.
+func (sess *Session) NewContext() *Context {
+	return sess.NewContextWithTimeout(-1)
+}
+
+// NewContextWithTimeout creates an new interruptible Context that will automatically
+// cancel itself after the given timeout. Setting a zero or negative timeout implies
+// there is no actual timeout configured for the Context.
+func (sess *Session) NewContextWithTimeout(timeout int64) *Context {
+	sess.mtx.Lock()
+	defer sess.mtx.Unlock()
+	ctx, cancel := newContext(timeout)
+	sess.cl = append(sess.cl, cancel)
+	return &Context{cancel: cancel, ctx: ctx}
 }
 
 // GeolocateResults contains the GeolocateTask results.
@@ -195,106 +183,21 @@ type GeolocateResults struct {
 	Org string
 }
 
-// Run runs the GeolocateTask and returns either the results of the
-// task, on success, or the error that occurred, on failure.
-func (task *GeolocateTask) Run() (*GeolocateResults, error) {
-	if err := task.sess.maybeLookupLocationContext(task.ctx); err != nil {
-		return nil, err
-	}
-	info := &GeolocateResults{
-		ASN:     task.sess.probeASNString(),
-		Country: task.sess.probeCC(),
-		IP:      task.sess.probeIP(),
-		Org:     task.sess.probeNetworkName(),
-	}
-	return info, nil
-}
-
-// Cancel cancels the GeolocateTask. This method is thread safe
-// and idempotent. You can use it to interrupt the task.
-func (task *GeolocateTask) Cancel() {
-	task.cancel()
-}
-
-// Close releases the resources allocated by the task. This method MAY
-// NOT be thread safe and MAY NOT be idempotent.
-func (task *GeolocateTask) Close() error {
-	task.cancel()
-	return nil
-}
-
-// MakeSubmitterTask allows you to construct a Submitter. That is, an
-// abstraction that knows how to submit measurements to the OONI collector.
-type MakeSubmitterTask struct {
-	cancel context.CancelFunc
-	ctx    context.Context
-	sess   *Session
-}
-
-// Run constructs a Submitter and returns it, on success, or
-// returns the error that occurred, in case of failure.
-func (mst *MakeSubmitterTask) Run() (*Submitter, error) {
-	psc, err := mst.sess.newProbeServicesClient(mst.ctx)
+// Geolocate performs a geolocate operation and returns the results. This method
+// is (in Java terminology) synchronized with the session instance.
+func (sess *Session) Geolocate(oc *Context) (*GeolocateResults, error) {
+	sess.mtx.Lock()
+	defer sess.mtx.Unlock()
+	info, err := sess.sessp.LookupLocationContext(oc.ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &Submitter{submitter: probeservices.NewSubmitter(psc)}, nil
-}
-
-// Cancel cancels the MakeSubmitterTask. This method is thread safe
-// and idempotent. You can use it to interrupt the task.
-func (mst *MakeSubmitterTask) Cancel() {
-	mst.cancel()
-}
-
-// Close releases the resources allocated by the task. This method MAY
-// NOT be thread safe and MAY NOT be idempotent.
-func (mst *MakeSubmitterTask) Close() error {
-	mst.cancel()
-	return nil
-}
-
-// Submitter allows you to create SubmitMeasurementTask tasks. That is, tasks
-// allowing to submit a single measurements to OONI's collector.
-//
-// Bug
-//
-// The Submitter is not designed to submit measurements in parallel. Doing
-// this may work but could also cause unnecessary open/close report operations
-// if the measurements are unrelated. You should typically only have a single
-// SubmitMeasurementTask using this Submitter at any given time.
-type Submitter struct {
-	submitter *probeservices.Submitter
-}
-
-func (sub *Submitter) submit(ctx context.Context, m *model.Measurement) error {
-	return sub.submitter.Submit(ctx, m)
-}
-
-// NewSubmitMeasurementTask creates a new SubmitMeasurementTask. You may
-// should not run more than one such tasks in parallel because the submitter
-// is not designed for parallel submission. If you wish to do so, then you
-// should better create more than one Submitter. The timeout argument
-// has the same semantics of, e.g., NewGeolocateTask.
-func (sub *Submitter) NewSubmitMeasurementTask(timeout int64) *SubmitMeasurementTask {
-	ctx, cancel := newContext(timeout)
-	return &SubmitMeasurementTask{cancel: cancel, ctx: ctx, sub: sub}
-}
-
-// Close releases the resources allocated by the submitter. This method MAY
-// NOT be thread safe and MAY NOT be idempotent.
-func (sub *Submitter) Close() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
-	defer cancel()
-	return sub.submitter.Close(ctx)
-}
-
-// SubmitMeasurementTask submits measurements to the OONI collector API using
-// the specific Submitter from which this task was created.
-type SubmitMeasurementTask struct {
-	cancel context.CancelFunc
-	ctx    context.Context
-	sub    *Submitter
+	return &GeolocateResults{
+		ASN:     fmt.Sprintf("AS%d", info.ASN),
+		Country: info.CountryCode,
+		IP:      info.ProbeIP,
+		Org:     info.NetworkName,
+	}, nil
 }
 
 // SubmitMeasurementResults contains the results of a single measurement submission
@@ -304,14 +207,23 @@ type SubmitMeasurementResults struct {
 	UpdatedReportID    string
 }
 
-// Run submits the selected measurement to the OONI collector and returns the
-// results, in case of success, or an error, in case of failure.
-func (task *SubmitMeasurementTask) Run(measurement string) (*SubmitMeasurementResults, error) {
+// Submit submits the given measurement and returns the results. This method is (in
+// Java terminology) synchronized with the Session instance.
+func (sess *Session) Submit(oc *Context, measurement string) (*SubmitMeasurementResults, error) {
+	sess.mtx.Lock()
+	defer sess.mtx.Unlock()
+	if sess.submitter == nil {
+		psc, err := sess.sessp.NewProbeServicesClient(oc.ctx)
+		if err != nil {
+			return nil, err
+		}
+		sess.submitter = probeservices.NewSubmitter(psc)
+	}
 	var mm model.Measurement
 	if err := json.Unmarshal([]byte(measurement), &mm); err != nil {
 		return nil, err
 	}
-	if err := task.sub.submit(task.ctx, &mm); err != nil {
+	if err := sess.submitter.Submit(oc.ctx, &mm); err != nil {
 		return nil, err
 	}
 	data, err := json.Marshal(mm)
@@ -320,17 +232,4 @@ func (task *SubmitMeasurementTask) Run(measurement string) (*SubmitMeasurementRe
 		UpdatedMeasurement: string(data),
 		UpdatedReportID:    mm.ReportID,
 	}, nil
-}
-
-// Cancel cancels the SubmitMeasurementTask. This method is thread safe
-// and idempotent. You can use it to interrupt the task.
-func (task *SubmitMeasurementTask) Cancel() {
-	task.cancel()
-}
-
-// Close releases the resources allocated by the task. This method MAY
-// NOT be thread safe and MAY NOT be idempotent.
-func (task *SubmitMeasurementTask) Close() error {
-	task.cancel()
-	return nil
 }

--- a/oonimkall/session.go
+++ b/oonimkall/session.go
@@ -15,8 +15,8 @@ import (
 	"github.com/ooni/probe-engine/probeservices"
 )
 
-// The following two variables contains metrics pertaining to the number
-// of object that are currently being used.
+// The following two variables contain metrics pertaining to the number
+// of Sessions and Contexts that are currently being used.
 var (
 	ActiveSessions = atomicx.NewInt64()
 	ActiveContexts = atomicx.NewInt64()
@@ -97,9 +97,6 @@ type Session struct {
 // a set of operations in a relatively short time frame. You SHOULD NOT create
 // a single session and keep it all alive for the whole app lifecyle, since
 // the Session code is not specifically designed for this use case.
-//
-// This function will abort if config is a null pointer. This function will
-// register a finalizer for the returned Session instance.
 func NewSession(config *SessionConfig) (*Session, error) {
 	kvstore, err := engine.NewFileSystemKVStore(config.StateDir)
 	if err != nil {

--- a/oonimkall/session_internal_test.go
+++ b/oonimkall/session_internal_test.go
@@ -1,3 +1,0 @@
-package oonimkall
-
-var ErrNullPointer = errNullPointer

--- a/oonimkall/task.go
+++ b/oonimkall/task.go
@@ -32,7 +32,7 @@
 // Session API
 //
 // The Session API is a Go API that can be exported to mobile apps
-// using the gomobile tool. The design for this API is at
+// using the gomobile tool. The original design document for this API is at
 // https://github.com/ooni/probe-engine/issues/893#issuecomment-689031449.
 //
 // The basic tenet of the session API is that you create an instance

--- a/oonimkall/task.go
+++ b/oonimkall/task.go
@@ -32,8 +32,8 @@
 // Session API
 //
 // The Session API is a Go API that can be exported to mobile apps
-// using the gomobile tool. The original design document for this API is at
-// https://github.com/ooni/probe-engine/issues/893#issuecomment-689031449.
+// using the gomobile tool. The latest design document for this API is
+// at https://github.com/ooni/probe-engine/pull/954.
 //
 // The basic tenet of the session API is that you create an instance
 // of `Session` and use it to perform the operations you need.

--- a/session.go
+++ b/session.go
@@ -500,51 +500,62 @@ func (s *Session) maybeLookupBackends(ctx context.Context) error {
 	return nil
 }
 
-// MaybeLookupLocationContext is like MaybeLookupLocation but with a context
-// that can be used to interrupt this long running operation.
-func (s *Session) MaybeLookupLocationContext(ctx context.Context) (err error) {
-	if s.location == nil {
-		defer func() {
-			if recover() != nil {
-				// JUST KNOW WE'VE BEEN HERE
-			}
-		}()
-		var (
-			probeIP     string
-			asn         uint
-			org         string
-			cc          string
-			resolverASN uint   = model.DefaultResolverASN
-			resolverIP  string = model.DefaultResolverIP
-			resolverOrg string
+// LookupLocationContext perform a location lookup. If we want memoisation
+// of the results, you should use MaybeLookupLocationContext.
+func (s *Session) LookupLocationContext(ctx context.Context) (out *model.LocationInfo, err error) {
+	defer func() {
+		if recover() != nil {
+			// JUST KNOW WE'VE BEEN HERE
+		}
+	}()
+	var (
+		probeIP     string
+		asn         uint
+		org         string
+		cc          string
+		resolverASN uint   = model.DefaultResolverASN
+		resolverIP  string = model.DefaultResolverIP
+		resolverOrg string
+	)
+	err = s.fetchResourcesIdempotent(ctx)
+	runtimex.PanicOnError(err, "s.fetchResourcesIdempotent failed")
+	probeIP, err = s.lookupProbeIP(ctx)
+	runtimex.PanicOnError(err, "s.lookupProbeIP failed")
+	asn, org, err = s.lookupASN(s.ASNDatabasePath(), probeIP)
+	runtimex.PanicOnError(err, "s.lookupASN #1 failed")
+	cc, err = s.lookupProbeCC(s.CountryDatabasePath(), probeIP)
+	runtimex.PanicOnError(err, "s.lookupProbeCC failed")
+	if s.proxyURL == nil {
+		resolverIP, err = s.lookupResolverIP(ctx)
+		runtimex.PanicOnError(err, "s.lookupResolverIP failed")
+		resolverASN, resolverOrg, err = s.lookupASN(
+			s.ASNDatabasePath(), resolverIP,
 		)
-		err = s.fetchResourcesIdempotent(ctx)
-		runtimex.PanicOnError(err, "s.fetchResourcesIdempotent failed")
-		probeIP, err = s.lookupProbeIP(ctx)
-		runtimex.PanicOnError(err, "s.lookupProbeIP failed")
-		asn, org, err = s.lookupASN(s.ASNDatabasePath(), probeIP)
-		runtimex.PanicOnError(err, "s.lookupASN #1 failed")
-		cc, err = s.lookupProbeCC(s.CountryDatabasePath(), probeIP)
-		runtimex.PanicOnError(err, "s.lookupProbeCC failed")
-		if s.proxyURL == nil {
-			resolverIP, err = s.lookupResolverIP(ctx)
-			runtimex.PanicOnError(err, "s.lookupResolverIP failed")
-			resolverASN, resolverOrg, err = s.lookupASN(
-				s.ASNDatabasePath(), resolverIP,
-			)
-			runtimex.PanicOnError(err, "s.lookupASN #2 failed")
-		}
-		s.location = &model.LocationInfo{
-			ASN:                 asn,
-			CountryCode:         cc,
-			NetworkName:         org,
-			ProbeIP:             probeIP,
-			ResolverASN:         resolverASN,
-			ResolverIP:          resolverIP,
-			ResolverNetworkName: resolverOrg,
-		}
+		runtimex.PanicOnError(err, "s.lookupASN #2 failed")
+	}
+	out = &model.LocationInfo{
+		ASN:                 asn,
+		CountryCode:         cc,
+		NetworkName:         org,
+		ProbeIP:             probeIP,
+		ResolverASN:         resolverASN,
+		ResolverIP:          resolverIP,
+		ResolverNetworkName: resolverOrg,
 	}
 	return
+}
+
+// MaybeLookupLocationContext is like MaybeLookupLocation but with a context
+// that can be used to interrupt this long running operation.
+func (s *Session) MaybeLookupLocationContext(ctx context.Context) error {
+	if s.location == nil {
+		location, err := s.LookupLocationContext(ctx)
+		if err != nil {
+			return err
+		}
+		s.location = location
+	}
+	return nil
 }
 
 var _ model.ExperimentSession = &Session{}

--- a/session.go
+++ b/session.go
@@ -500,7 +500,7 @@ func (s *Session) maybeLookupBackends(ctx context.Context) error {
 	return nil
 }
 
-// LookupLocationContext perform a location lookup. If we want memoisation
+// LookupLocationContext performs a location lookup. If you want memoisation
 // of the results, you should use MaybeLookupLocationContext.
 func (s *Session) LookupLocationContext(ctx context.Context) (out *model.LocationInfo, err error) {
 	defer func() {


### PR DESCRIPTION
When helping @lorenzoPrimi with https://github.com/ooni/probe-android/pull/360
I had the impression there was too much complexity.

Then we said we could improve the situation by changing the class names
as written in https://github.com/ooni/probe-engine/issues/951#issue-708184925.

But then there was still too much complexity. I could not easily picture in
my mind why each class was needed. This was actually a strong signal that we
needed to refactor the code more than just renaming clases.

So, here's the new approach (for which I'll write soon a mini design document
that will be referenced inside the code - or maybe this is the document!):

1. Session uses runtime.SetFinalizer therefore we don't need to be concerned
about wrapping it and using AutoCloseable in Java. It is not normal for Go code
to use finalizers, but I believe it makes sense in this context, _because_ it
simplifies interfacing Go and Java code.

2. We introduce again a Context instance _because_ it was too painful to have
each Task define the same operations and also too bloated.

3. A Context is created from a Session, therefore the Session can keep track
of what `cancel()` functions to be called when done. So now the programmer is
feee to just not be concerned about calling `cancel()` _unless_ there is the
need for really cancelling the operation. The Session will specifically call
all the cancelling functions inside of its finalizer.

4. All Session methods are now "synchronized" with respect to a mutex that
is inside of the session itself. This removes any concerns regarding the usage
from multiple threads. Yet, we're still not able to have a long running
session yet, mainly because now we're tracking child contexts. But I also
do not think pushing for a global session is particularly useful.

5. The resubmission now happens within a session. We have a submitter inside
the session and we are confident thread-safe-wise there are no issues since
also the method for submitting is, of course, thread safe.

This strategy completely eliminates the need of wrappers for the sake of
introducing AutoCloseable properties in the code.

While there, I also modified `/session.go` such that it's possible to perform
an unmemoised lookup of the probe location. This has been instrumental to remove
one more limitation of the previous `/oonimkall/session.go` API.