### PR TITLE
refactor(model/experiment.go): less code depends on ExperimentSession (1/n)

### DIFF
--- a/internal/psiphonx/psiphonx.go
+++ b/internal/psiphonx/psiphonx.go
@@ -14,6 +14,12 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
+// Session is the way in which this package sees a Session.
+type Session interface {
+	NewOrchestraClient(ctx context.Context) (model.ExperimentOrchestraClient, error)
+	TempDir() string
+}
+
 // Dependencies contains dependencies for Start
 type Dependencies interface {
 	MkdirAll(path string, perm os.FileMode) error
@@ -69,7 +75,7 @@ func makeworkingdir(config Config) (string, error) {
 
 // Start starts the psiphon tunnel.
 func Start(
-	ctx context.Context, sess model.ExperimentSession, config Config) (*Tunnel, error) {
+	ctx context.Context, sess Session, config Config) (*Tunnel, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err() // simplifies unit testing this code

--- a/internal/sessiontunnel/sessiontunnel.go
+++ b/internal/sessiontunnel/sessiontunnel.go
@@ -11,6 +11,15 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
+// Session is the way in which this package sees a Session.
+type Session interface {
+	Logger() model.Logger
+	NewOrchestraClient(ctx context.Context) (model.ExperimentOrchestraClient, error)
+	TempDir() string
+	TorArgs() []string
+	TorBinary() string
+}
+
 // Tunnel is a tunnel used by the session
 type Tunnel interface {
 	BootstrapTime() time.Duration
@@ -21,7 +30,7 @@ type Tunnel interface {
 // Config contains config for the session tunnel.
 type Config struct {
 	Name    string
-	Session model.ExperimentSession
+	Session Session
 }
 
 // Start starts a new tunnel by name or returns an error. Note that if you

--- a/internal/sessiontunnel/sessiontunnel.go
+++ b/internal/sessiontunnel/sessiontunnel.go
@@ -13,11 +13,9 @@ import (
 
 // Session is the way in which this package sees a Session.
 type Session interface {
+	psiphonx.Session
+	torx.Session
 	Logger() model.Logger
-	NewOrchestraClient(ctx context.Context) (model.ExperimentOrchestraClient, error)
-	TempDir() string
-	TorArgs() []string
-	TorBinary() string
 }
 
 // Tunnel is a tunnel used by the session

--- a/internal/torx/torx.go
+++ b/internal/torx/torx.go
@@ -11,8 +11,14 @@ import (
 
 	"github.com/cretz/bine/control"
 	"github.com/cretz/bine/tor"
-	"github.com/ooni/probe-engine/model"
 )
+
+// Session is the way in which this package sees a Session.
+type Session interface {
+	TempDir() string
+	TorArgs() []string
+	TorBinary() string
+}
 
 // TorProcess is a running tor process
 type TorProcess interface {
@@ -51,14 +57,14 @@ func (tt *Tunnel) Stop() {
 
 // StartConfig contains the configuration for StartWithConfig
 type StartConfig struct {
-	Sess          model.ExperimentSession
+	Sess          Session
 	Start         func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error)
 	EnableNetwork func(ctx context.Context, tor *tor.Tor, wait bool) error
 	GetInfo       func(ctrl *control.Conn, keys ...string) ([]*control.KeyVal, error)
 }
 
 // Start starts the tor tunnel
-func Start(ctx context.Context, sess model.ExperimentSession) (*Tunnel, error) {
+func Start(ctx context.Context, sess Session) (*Tunnel, error) {
 	return StartWithConfig(ctx, StartConfig{
 		Sess: sess,
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
@@ -126,6 +132,6 @@ func StartWithConfig(ctx context.Context, config StartConfig) (*Tunnel, error) {
 
 // LogFile returns the name of tor logs given a specific session. The file
 // is always located somewhere inside the sess.TempDir() directory.
-func LogFile(sess model.ExperimentSession) string {
+func LogFile(sess Session) string {
 	return path.Join(sess.TempDir(), "tor.log")
 }

--- a/model/experiment.go
+++ b/model/experiment.go
@@ -36,8 +36,6 @@ type ExperimentSession interface {
 	SoftwareName() string
 	SoftwareVersion() string
 	TempDir() string
-	TorArgs() []string
-	TorBinary() string
 	TunnelBootstrapTime() time.Duration
 	UserAgent() string
 }


### PR DESCRIPTION
ExperimentSession is a large interface in the model package that is
too large and too widely used to be easily modifiable.

I noticed this issue when I started investigating the issue at
https://github.com/ooni/explorer/issues/495.

Before we embark into more substantial changes, let us clear the
table a little bit by reducing the scope of ExperimentSession.