### PR TITLE
refactor(model/experiment.go): less code depends on ExperimentSession (2/n)

### DIFF
--- a/probeservices/benchselect.go
+++ b/probeservices/benchselect.go
@@ -77,7 +77,7 @@ type Candidate struct {
 	TestHelpers map[string][]model.Service
 }
 
-func (c *Candidate) try(ctx context.Context, sess model.ExperimentSession) {
+func (c *Candidate) try(ctx context.Context, sess Session) {
 	client, err := NewClient(sess, c.Endpoint)
 	if err != nil {
 		c.Err = err
@@ -91,7 +91,7 @@ func (c *Candidate) try(ctx context.Context, sess model.ExperimentSession) {
 	sess.Logger().Debugf("probe services: %+v: %+v %s", c.Endpoint, err, c.Duration)
 }
 
-func try(ctx context.Context, sess model.ExperimentSession, svc model.Service) *Candidate {
+func try(ctx context.Context, sess Session, svc model.Service) *Candidate {
 	candidate := &Candidate{Endpoint: svc}
 	candidate.try(ctx, sess)
 	return candidate
@@ -107,7 +107,7 @@ func try(ctx context.Context, sess model.ExperimentSession, svc model.Service) *
 // such case, you will see a list of N failing HTTPS candidates, followed by a single
 // successful fallback candidate (e.g. cloudfronted). If all candidates fail, you
 // see in output a list containing all entries where Err is not nil.
-func TryAll(ctx context.Context, sess model.ExperimentSession, in []model.Service) (out []*Candidate) {
+func TryAll(ctx context.Context, sess Session, in []model.Service) (out []*Candidate) {
 	var found bool
 	for _, svc := range OnlyHTTPS(in) {
 		candidate := try(ctx, sess, svc)

--- a/probeservices/probeservices.go
+++ b/probeservices/probeservices.go
@@ -25,6 +25,7 @@ package probeservices
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 
 	"github.com/ooni/probe-engine/atomicx"
@@ -53,6 +54,15 @@ var (
 	ErrInvalidMetadata = errors.New("invalid metadata")
 )
 
+// Session is how this package sees a Session.
+type Session interface {
+	DefaultHTTPClient() *http.Client
+	KeyValueStore() model.KeyValueStore
+	Logger() model.Logger
+	ProxyURL() *url.URL
+	UserAgent() string
+}
+
 // Client is a client for the OONI probe services API.
 type Client struct {
 	httpx.Client
@@ -79,7 +89,7 @@ func (c Client) GetCredsAndAuth() (*LoginCredentials, *LoginAuth, error) {
 
 // NewClient creates a new client for the specified probe services endpoint. This
 // function fails, e.g., we don't support the specified endpoint.
-func NewClient(sess model.ExperimentSession, endpoint model.Service) (*Client, error) {
+func NewClient(sess Session, endpoint model.Service) (*Client, error) {
 	client := &Client{
 		Client: httpx.Client{
 			BaseURL:    endpoint.Address,


### PR DESCRIPTION
This continues the work initiated in https://github.com/ooni/probe-engine/pull/960 and the rationale is also of course the same. This work is indeed yak shaving while looking into https://github.com/ooni/explorer/issues/495.