### PR TITLE
refactor(model/experiment.go): less code depends on ExperimentSession (3/3)

### DIFF
--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -28,7 +28,7 @@ func TestUnitRunnerLoopLocateFailure(t *testing.T) {
 			},
 		},
 		saver: new(trace.Saver),
-		sess: &mockable.ExperimentSession{
+		sess: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 		tk: new(TestKeys),
@@ -58,7 +58,7 @@ func TestUnitRunnerLoopNegotiateFailure(t *testing.T) {
 			},
 		},
 		saver: new(trace.Saver),
-		sess: &mockable.ExperimentSession{
+		sess: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 		tk: new(TestKeys),
@@ -95,7 +95,7 @@ func TestUnitRunnerLoopMeasureFailure(t *testing.T) {
 			},
 		},
 		saver: new(trace.Saver),
-		sess: &mockable.ExperimentSession{
+		sess: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 		tk: new(TestKeys),
@@ -140,7 +140,7 @@ func TestUnitRunnerLoopCollectFailure(t *testing.T) {
 			},
 		},
 		saver: saver,
-		sess: &mockable.ExperimentSession{
+		sess: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 		tk: new(TestKeys),
@@ -189,7 +189,7 @@ func TestUnitRunnerLoopSuccess(t *testing.T) {
 			},
 		},
 		saver: saver,
-		sess: &mockable.ExperimentSession{
+		sess: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 		tk: new(TestKeys),
@@ -273,7 +273,7 @@ func TestUnitMeasureWithCancelledContext(t *testing.T) {
 	m := &Measurer{}
 	err := m.Run(
 		ctx,
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		},
@@ -292,7 +292,7 @@ func TestUnitMeasurerMaybeStartTunnelFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	err := m.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient:          http.DefaultClient,
 			MockableMaybeStartTunnelErr: expected,
 			MockableLogger:              log.Log,
@@ -312,7 +312,7 @@ func TestUnitMeasureWithProxyURL(t *testing.T) {
 	measurement := &model.Measurement{}
 	err := m.Run(
 		ctx,
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 			MockableProxyURL:   &url.URL{Host: "1.1.1.1:22"},

--- a/experiment/example/example_test.go
+++ b/experiment/example/example_test.go
@@ -16,7 +16,7 @@ func TestIntegrationSuccess(t *testing.T) {
 		SleepTime: int64(2 * time.Second),
 	}, "example")
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableLogger: log.Log,
 	}
 	callbacks := model.NewPrinterCallbacks(sess.Logger())
@@ -32,7 +32,7 @@ func TestIntegrationFailure(t *testing.T) {
 		ReturnError: true,
 	}, "example")
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableLogger: log.Log,
 	}
 	callbacks := model.NewPrinterCallbacks(sess.Logger())

--- a/experiment/hhfm/hhfm_test.go
+++ b/experiment/hhfm/hhfm_test.go
@@ -242,7 +242,7 @@ func TestIntegrationCancelledContext(t *testing.T) {
 func TestNoHelpers(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{}
+	sess := &mockable.Session{}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)
@@ -288,7 +288,7 @@ func TestNoHelpers(t *testing.T) {
 func TestNoActualHelpersInList(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"http-return-json-headers": nil,
 		},
@@ -338,7 +338,7 @@ func TestNoActualHelpersInList(t *testing.T) {
 func TestWrongTestHelperType(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"http-return-json-headers": {{
 				Address: "http://127.0.0.1",
@@ -391,7 +391,7 @@ func TestWrongTestHelperType(t *testing.T) {
 func TestNewRequestFailure(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"http-return-json-headers": {{
 				Address: "http://127.0.0.1\t\t\t", // invalid
@@ -448,7 +448,7 @@ func TestInvalidJSONBody(t *testing.T) {
 	defer server.Close()
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"http-return-json-headers": {{
 				Address: server.URL,

--- a/experiment/hirl/hirl_test.go
+++ b/experiment/hirl/hirl_test.go
@@ -157,7 +157,7 @@ func TestWithFakeMethods(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"tcp-echo": {{
 				Address: "127.0.0.1",
@@ -218,7 +218,7 @@ func TestWithNoMethods(t *testing.T) {
 		Methods: []hirl.Method{},
 	}
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"tcp-echo": {{
 				Address: "127.0.0.1",
@@ -253,7 +253,7 @@ func TestWithNoMethods(t *testing.T) {
 func TestNoHelpers(t *testing.T) {
 	measurer := hirl.NewExperimentMeasurer(hirl.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{}
+	sess := &mockable.Session{}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)
@@ -281,7 +281,7 @@ func TestNoHelpers(t *testing.T) {
 func TestNoActualHelperInList(t *testing.T) {
 	measurer := hirl.NewExperimentMeasurer(hirl.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"tcp-echo": nil,
 		},
@@ -313,7 +313,7 @@ func TestNoActualHelperInList(t *testing.T) {
 func TestWrongTestHelperType(t *testing.T) {
 	measurer := hirl.NewExperimentMeasurer(hirl.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableTestHelpers: map[string][]model.Service{
 			"tcp-echo": {{
 				Address: "127.0.0.1",

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -25,7 +25,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 
 func TestUnitDiscoverCancelledContext(t *testing.T) {
 	m := new(Measurer)
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 		MockableUserAgent:  "miniooni/0.1.0-dev",
@@ -54,7 +54,7 @@ func (txp *verifyRequestTransport) RoundTrip(req *http.Request) (*http.Response,
 
 func TestUnitDoDownloadWithCancelledContext(t *testing.T) {
 	m := new(Measurer)
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 		MockableUserAgent:  "miniooni/0.1.0-dev",
@@ -71,7 +71,7 @@ func TestUnitDoDownloadWithCancelledContext(t *testing.T) {
 
 func TestUnitDoUploadWithCancelledContext(t *testing.T) {
 	m := new(Measurer)
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 		MockableUserAgent:  "miniooni/0.1.0-dev",
@@ -88,7 +88,7 @@ func TestUnitDoUploadWithCancelledContext(t *testing.T) {
 
 func TestUnitRunWithCancelledContext(t *testing.T) {
 	m := new(Measurer)
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 		MockableUserAgent:  "miniooni/0.1.0-dev",
@@ -104,7 +104,7 @@ func TestUnitRunWithCancelledContext(t *testing.T) {
 func TestUnitRunWithMaybeStartTunnelFailure(t *testing.T) {
 	m := new(Measurer)
 	expected := errors.New("mocked error")
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient:          http.DefaultClient,
 		MockableMaybeStartTunnelErr: expected,
 		MockableLogger:              log.Log,
@@ -119,7 +119,7 @@ func TestUnitRunWithMaybeStartTunnelFailure(t *testing.T) {
 
 func TestUnitRunWithProxyURL(t *testing.T) {
 	m := new(Measurer)
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 		MockableProxyURL:   &url.URL{Host: "1.1.1.1:22"},
@@ -141,7 +141,7 @@ func TestIntegration(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		},
@@ -162,7 +162,7 @@ func TestIntegrationFailDownload(t *testing.T) {
 	}
 	err := measurer.Run(
 		ctx,
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		},
@@ -183,7 +183,7 @@ func TestIntegrationFailUpload(t *testing.T) {
 	}
 	err := measurer.Run(
 		ctx,
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		},
@@ -205,7 +205,7 @@ func TestIntegrationDownloadJSONUnmarshalFail(t *testing.T) {
 	}
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		},

--- a/experiment/psiphon/psiphon_test.go
+++ b/experiment/psiphon/psiphon_test.go
@@ -101,5 +101,5 @@ func (d observerCallbacks) OnProgress(percentage float64, message string) {
 }
 
 func newfakesession() model.ExperimentSession {
-	return &mockable.ExperimentSession{MockableLogger: log.Log}
+	return &mockable.Session{MockableLogger: log.Log}
 }

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -183,7 +183,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	cancel() // immediately cancel the context
 	result := new(Measurer).measureone(
 		ctx,
-		&mockable.ExperimentSession{MockableLogger: log.Log},
+		&mockable.Session{MockableLogger: log.Log},
 		time.Now(),
 		"kernel.org",
 		"example.com:443",
@@ -235,7 +235,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 func TestUnitMeasureoneWithPreMeasurementFailure(t *testing.T) {
 	result := new(Measurer).measureone(
 		context.Background(),
-		&mockable.ExperimentSession{MockableLogger: log.Log},
+		&mockable.Session{MockableLogger: log.Log},
 		time.Now(),
 		"kernel.org",
 		"example.com:443\t\t\t", // cause URL parse error
@@ -287,7 +287,7 @@ func TestUnitMeasureoneWithPreMeasurementFailure(t *testing.T) {
 func TestUnitMeasureoneSuccess(t *testing.T) {
 	result := new(Measurer).measureone(
 		context.Background(),
-		&mockable.ExperimentSession{MockableLogger: log.Log},
+		&mockable.Session{MockableLogger: log.Log},
 		time.Now(),
 		"kernel.org",
 		"example.com:443",
@@ -343,7 +343,7 @@ func TestUnitMeasureonewithcacheWorks(t *testing.T) {
 		measurer.measureonewithcache(
 			context.Background(),
 			output,
-			&mockable.ExperimentSession{MockableLogger: log.Log},
+			&mockable.Session{MockableLogger: log.Log},
 			time.Now(),
 			"kernel.org",
 			"example.com:443",
@@ -423,5 +423,5 @@ func TestUnitMaybeURLToSNI(t *testing.T) {
 }
 
 func newsession() model.ExperimentSession {
-	return &mockable.ExperimentSession{MockableLogger: log.Log}
+	return &mockable.Session{MockableLogger: log.Log}
 }

--- a/experiment/stunreachability/stunreachability_test.go
+++ b/experiment/stunreachability/stunreachability_test.go
@@ -35,7 +35,7 @@ func TestIntegrationRun(t *testing.T) {
 	measurement := new(model.Measurement)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{},
+		&mockable.Session{},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -64,7 +64,7 @@ func TestIntegrationRunCustomInput(t *testing.T) {
 	measurement.Input = model.MeasurementTarget(input)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{},
+		&mockable.Session{},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -93,7 +93,7 @@ func TestCancelledContext(t *testing.T) {
 	measurement := new(model.Measurement)
 	err := measurer.Run(
 		ctx,
-		&mockable.ExperimentSession{},
+		&mockable.Session{},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -126,7 +126,7 @@ func TestNewClientFailure(t *testing.T) {
 	measurement := new(model.Measurement)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{},
+		&mockable.Session{},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -160,7 +160,7 @@ func TestStartFailure(t *testing.T) {
 	measurement := new(model.Measurement)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{},
+		&mockable.Session{},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
@@ -195,7 +195,7 @@ func TestReadFailure(t *testing.T) {
 	measurement := new(model.Measurement)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{},
+		&mockable.Session{},
 		measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -28,7 +28,7 @@ func TestIntegration(t *testing.T) {
 	measurement := new(model.Measurement)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		measurement,
@@ -283,7 +283,7 @@ func TestWeConfigureWebChecksToFailOnHTTPError(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableLogger: log.Log,
 	}
 	measurement := new(model.Measurement)

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -39,7 +39,7 @@ func TestUnitMeasurerMeasureNewOrchestraClientError(t *testing.T) {
 	}
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -61,7 +61,7 @@ func TestUnitMeasurerMeasureFetchTorTargetsError(t *testing.T) {
 	}
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -83,7 +83,7 @@ func TestUnitMeasurerMeasureFetchTorTargetsEmptyList(t *testing.T) {
 	measurement := new(model.Measurement)
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		measurement,
@@ -110,7 +110,7 @@ func TestUnitMeasurerMeasureGood(t *testing.T) {
 	}
 	err := measurer.Run(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -224,7 +224,7 @@ func TestUnitMeasurerMeasureTargetsNoInput(t *testing.T) {
 	measurer := new(Measurer)
 	measurer.measureTargets(
 		context.Background(),
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		&measurement,
@@ -243,7 +243,7 @@ func TestUnitMeasurerMeasureTargetsCanceledContext(t *testing.T) {
 	measurer := new(Measurer)
 	measurer.measureTargets(
 		ctx,
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		&measurement,
@@ -274,7 +274,7 @@ func wrapTestingTarget(tt model.TorTarget) keytarget {
 
 func TestUnitResultsCollectorMeasureSingleTargetGood(t *testing.T) {
 	rc := newResultsCollector(
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -308,7 +308,7 @@ func TestUnitResultsCollectorMeasureSingleTargetGood(t *testing.T) {
 
 func TestUnitResultsCollectorMeasureSingleTargetWithFailure(t *testing.T) {
 	rc := newResultsCollector(
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -345,7 +345,7 @@ func TestUnitResultsCollectorMeasureSingleTargetWithFailure(t *testing.T) {
 
 func TestUnitDefautFlexibleConnectDirPort(t *testing.T) {
 	rc := newResultsCollector(
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -367,7 +367,7 @@ func TestUnitDefautFlexibleConnectDirPort(t *testing.T) {
 
 func TestUnitDefautFlexibleConnectOrPort(t *testing.T) {
 	rc := newResultsCollector(
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -392,7 +392,7 @@ func TestUnitDefautFlexibleConnectOrPort(t *testing.T) {
 
 func TestUnitDefautFlexibleConnectOBFS4(t *testing.T) {
 	rc := newResultsCollector(
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -417,7 +417,7 @@ func TestUnitDefautFlexibleConnectOBFS4(t *testing.T) {
 
 func TestUnitDefautFlexibleConnectDefault(t *testing.T) {
 	rc := newResultsCollector(
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableLogger: log.Log,
 		},
 		new(model.Measurement),
@@ -550,8 +550,8 @@ func TestUnitFillToplevelKeys(t *testing.T) {
 	}
 }
 
-func newsession() *mockable.ExperimentSession {
-	return &mockable.ExperimentSession{
+func newsession() *mockable.Session {
+	return &mockable.Session{
 		MockableLogger:     log.Log,
 		MockableHTTPClient: http.DefaultClient,
 	}

--- a/experiment/urlgetter/getter_test.go
+++ b/experiment/urlgetter/getter_test.go
@@ -18,7 +18,7 @@ func TestGetterWithCancelledContextVanilla(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	g := urlgetter.Getter{
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 		Target:  "https://www.google.com",
 	}
 	tk, err := g.Get(ctx)
@@ -86,7 +86,7 @@ func TestGetterWithCancelledContextAndMethod(t *testing.T) {
 	cancel()
 	g := urlgetter.Getter{
 		Config:  urlgetter.Config{Method: "POST"},
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 		Target:  "https://www.google.com",
 	}
 	tk, err := g.Get(ctx)
@@ -156,7 +156,7 @@ func TestGetterWithCancelledContextNoFollowRedirects(t *testing.T) {
 		Config: urlgetter.Config{
 			NoFollowRedirects: true,
 		},
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 		Target:  "https://www.google.com",
 	}
 	tk, err := g.Get(ctx)
@@ -223,7 +223,7 @@ func TestGetterWithCancelledContextCannotStartTunnel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	g := urlgetter.Getter{
-		Session: &mockable.ExperimentSession{
+		Session: &mockable.Session{
 			MockableMaybeStartTunnelErr: io.EOF,
 		},
 		Target: "https://www.google.com",
@@ -281,7 +281,7 @@ func TestGetterWithCancelledContextWithTunnel(t *testing.T) {
 		Config: urlgetter.Config{
 			Tunnel: "psiphon",
 		},
-		Session: &mockable.ExperimentSession{
+		Session: &mockable.Session{
 			MockableProxyURL:            tunnelURL,
 			MockableTunnelBootstrapTime: 10 * time.Second,
 		},
@@ -354,7 +354,7 @@ func TestGetterWithCancelledContextUnknownResolverURL(t *testing.T) {
 		Config: urlgetter.Config{
 			ResolverURL: "antani://8.8.8.8:53",
 		},
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 		Target:  "https://www.google.com",
 	}
 	tk, err := g.Get(ctx)
@@ -408,7 +408,7 @@ func TestGetterIntegrationHTTPS(t *testing.T) {
 		Config: urlgetter.Config{
 			NoFollowRedirects: true, // reduce number of events
 		},
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 		Target:  "https://www.google.com",
 	}
 	tk, err := g.Get(ctx)
@@ -525,7 +525,7 @@ func TestGetterIntegrationRedirect(t *testing.T) {
 	ctx := context.Background()
 	g := urlgetter.Getter{
 		Config:  urlgetter.Config{NoFollowRedirects: true},
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 		Target:  "http://web.whatsapp.com",
 	}
 	tk, err := g.Get(ctx)
@@ -549,7 +549,7 @@ func TestGetterIntegrationTLSHandshake(t *testing.T) {
 		Config: urlgetter.Config{
 			NoFollowRedirects: true, // reduce number of events
 		},
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 		Target:  "tlshandshake://www.google.com:443",
 	}
 	tk, err := g.Get(ctx)

--- a/experiment/urlgetter/multi_test.go
+++ b/experiment/urlgetter/multi_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMultiIntegration(t *testing.T) {
-	multi := urlgetter.Multi{Session: &mockable.ExperimentSession{}}
+	multi := urlgetter.Multi{Session: &mockable.Session{}}
 	inputs := []urlgetter.MultiInput{{
 		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
 		Target: "https://www.google.com",
@@ -73,7 +73,7 @@ func TestMultiIntegrationWithBaseTime(t *testing.T) {
 	begin := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	multi := urlgetter.Multi{
 		Begin:   begin,
-		Session: &mockable.ExperimentSession{},
+		Session: &mockable.Session{},
 	}
 	inputs := []urlgetter.MultiInput{{
 		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
@@ -119,7 +119,7 @@ func TestMultiIntegrationWithBaseTime(t *testing.T) {
 func TestMultiIntegrationWithoutBaseTime(t *testing.T) {
 	// We use the default beginning of time and then fail the test
 	// if we see any T smaller than 60 seconds.
-	multi := urlgetter.Multi{Session: &mockable.ExperimentSession{}}
+	multi := urlgetter.Multi{Session: &mockable.Session{}}
 	inputs := []urlgetter.MultiInput{{
 		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
 		Target: "https://www.google.com",
@@ -162,7 +162,7 @@ func TestMultiIntegrationWithoutBaseTime(t *testing.T) {
 }
 
 func TestMultiContextCanceled(t *testing.T) {
-	multi := urlgetter.Multi{Session: &mockable.ExperimentSession{}}
+	multi := urlgetter.Multi{Session: &mockable.Session{}}
 	inputs := []urlgetter.MultiInput{{
 		Config: urlgetter.Config{Method: "HEAD", NoFollowRedirects: true},
 		Target: "https://www.google.com",

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -24,7 +24,7 @@ func TestMeasurer(t *testing.T) {
 	measurement := new(model.Measurement)
 	measurement.Input = "https://www.google.com"
 	err := m.Run(
-		ctx, &mockable.ExperimentSession{},
+		ctx, &mockable.Session{},
 		measurement, model.NewPrinterCallbacks(log.Log),
 	)
 	if !errors.Is(err, context.Canceled) {
@@ -54,7 +54,7 @@ func TestMeasurerDNSCache(t *testing.T) {
 	measurement := new(model.Measurement)
 	measurement.Input = "https://www.google.com"
 	err := m.Run(
-		ctx, &mockable.ExperimentSession{},
+		ctx, &mockable.Session{},
 		measurement, model.NewPrinterCallbacks(log.Log),
 	)
 	if !errors.Is(err, context.Canceled) {

--- a/experiment/webconnectivity/control_test.go
+++ b/experiment/webconnectivity/control_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestFillASNsEmpty(t *testing.T) {
 	dns := new(webconnectivity.ControlDNSResult)
-	dns.FillASNs(new(mockable.ExperimentSession))
+	dns.FillASNs(new(mockable.Session))
 	if diff := cmp.Diff(dns.ASNs, []int64{}); diff != "" {
 		t.Fatal(diff)
 	}
@@ -19,7 +19,7 @@ func TestFillASNsEmpty(t *testing.T) {
 func TestFillASNsNoDatabase(t *testing.T) {
 	dns := new(webconnectivity.ControlDNSResult)
 	dns.Addrs = []string{"8.8.8.8", "1.1.1.1"}
-	dns.FillASNs(new(mockable.ExperimentSession))
+	dns.FillASNs(new(mockable.Session))
 	if diff := cmp.Diff(dns.ASNs, []int64{0, 0}); diff != "" {
 		t.Fatal(diff)
 	}

--- a/experiment/whatsapp/whatsapp_test.go
+++ b/experiment/whatsapp/whatsapp_test.go
@@ -29,7 +29,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 func TestIntegrationSuccess(t *testing.T) {
 	measurer := whatsapp.NewExperimentMeasurer(whatsapp.Config{})
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{MockableLogger: log.Log}
+	sess := &mockable.Session{MockableLogger: log.Log}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)
@@ -64,7 +64,7 @@ func TestIntegrationFailureAllEndpoints(t *testing.T) {
 	measurer := whatsapp.NewExperimentMeasurer(whatsapp.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	sess := &mockable.ExperimentSession{MockableLogger: log.Log}
+	sess := &mockable.Session{MockableLogger: log.Log}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)
@@ -580,7 +580,7 @@ func TestWeConfigureWebChecksCorrectly(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableLogger: log.Log,
 	}
 	measurement := new(model.Measurement)

--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -8,14 +8,17 @@ import (
 	"time"
 
 	"github.com/ooni/probe-engine/internal/kvstore"
+	"github.com/ooni/probe-engine/internal/psiphonx"
 	"github.com/ooni/probe-engine/internal/runtimex"
+	"github.com/ooni/probe-engine/internal/sessiontunnel"
+	"github.com/ooni/probe-engine/internal/torx"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/probeservices"
 	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
-// ExperimentSession is a mockable ExperimentSession.
-type ExperimentSession struct {
+// Session allows to mock sessions.
+type Session struct {
 	MockableASNDatabasePath      string
 	MockableCABundlePath         string
 	MockableTestHelpers          map[string][]model.Service
@@ -40,43 +43,43 @@ type ExperimentSession struct {
 }
 
 // ASNDatabasePath implements ExperimentSession.ASNDatabasePath
-func (sess *ExperimentSession) ASNDatabasePath() string {
+func (sess *Session) ASNDatabasePath() string {
 	return sess.MockableASNDatabasePath
 }
 
 // CABundlePath implements ExperimentSession.CABundlePath
-func (sess *ExperimentSession) CABundlePath() string {
+func (sess *Session) CABundlePath() string {
 	return sess.MockableCABundlePath
 }
 
 // GetTestHelpersByName implements ExperimentSession.GetTestHelpersByName
-func (sess *ExperimentSession) GetTestHelpersByName(name string) ([]model.Service, bool) {
+func (sess *Session) GetTestHelpersByName(name string) ([]model.Service, bool) {
 	services, okay := sess.MockableTestHelpers[name]
 	return services, okay
 }
 
 // DefaultHTTPClient implements ExperimentSession.DefaultHTTPClient
-func (sess *ExperimentSession) DefaultHTTPClient() *http.Client {
+func (sess *Session) DefaultHTTPClient() *http.Client {
 	return sess.MockableHTTPClient
 }
 
 // KeyValueStore returns the configured key-value store.
-func (sess *ExperimentSession) KeyValueStore() model.KeyValueStore {
+func (sess *Session) KeyValueStore() model.KeyValueStore {
 	return kvstore.NewMemoryKeyValueStore()
 }
 
 // Logger implements ExperimentSession.Logger
-func (sess *ExperimentSession) Logger() model.Logger {
+func (sess *Session) Logger() model.Logger {
 	return sess.MockableLogger
 }
 
 // MaybeStartTunnel implements ExperimentSession.MaybeStartTunnel
-func (sess *ExperimentSession) MaybeStartTunnel(ctx context.Context, name string) error {
+func (sess *Session) MaybeStartTunnel(ctx context.Context, name string) error {
 	return sess.MockableMaybeStartTunnelErr
 }
 
 // NewOrchestraClient implements ExperimentSession.NewOrchestraClient
-func (sess *ExperimentSession) NewOrchestraClient(ctx context.Context) (model.ExperimentOrchestraClient, error) {
+func (sess *Session) NewOrchestraClient(ctx context.Context) (model.ExperimentOrchestraClient, error) {
 	if sess.MockableOrchestraClient != nil {
 		return sess.MockableOrchestraClient, nil
 	}
@@ -99,71 +102,75 @@ func (sess *ExperimentSession) NewOrchestraClient(ctx context.Context) (model.Ex
 }
 
 // ProbeASNString implements ExperimentSession.ProbeASNString
-func (sess *ExperimentSession) ProbeASNString() string {
+func (sess *Session) ProbeASNString() string {
 	return sess.MockableProbeASNString
 }
 
 // ProbeCC implements ExperimentSession.ProbeCC
-func (sess *ExperimentSession) ProbeCC() string {
+func (sess *Session) ProbeCC() string {
 	return sess.MockableProbeCC
 }
 
 // ProbeIP implements ExperimentSession.ProbeIP
-func (sess *ExperimentSession) ProbeIP() string {
+func (sess *Session) ProbeIP() string {
 	return sess.MockableProbeIP
 }
 
 // ProbeNetworkName implements ExperimentSession.ProbeNetworkName
-func (sess *ExperimentSession) ProbeNetworkName() string {
+func (sess *Session) ProbeNetworkName() string {
 	return sess.MockableProbeNetworkName
 }
 
 // ProxyURL implements ExperimentSession.ProxyURL
-func (sess *ExperimentSession) ProxyURL() *url.URL {
+func (sess *Session) ProxyURL() *url.URL {
 	return sess.MockableProxyURL
 }
 
 // ResolverIP implements ExperimentSession.ResolverIP
-func (sess *ExperimentSession) ResolverIP() string {
+func (sess *Session) ResolverIP() string {
 	return sess.MockableResolverIP
 }
 
 // SoftwareName implements ExperimentSession.SoftwareName
-func (sess *ExperimentSession) SoftwareName() string {
+func (sess *Session) SoftwareName() string {
 	return sess.MockableSoftwareName
 }
 
 // SoftwareVersion implements ExperimentSession.SoftwareVersion
-func (sess *ExperimentSession) SoftwareVersion() string {
+func (sess *Session) SoftwareVersion() string {
 	return sess.MockableSoftwareVersion
 }
 
 // TempDir implements ExperimentSession.TempDir
-func (sess *ExperimentSession) TempDir() string {
+func (sess *Session) TempDir() string {
 	return sess.MockableTempDir
 }
 
 // TorArgs implements ExperimentSession.TorArgs.
-func (sess *ExperimentSession) TorArgs() []string {
+func (sess *Session) TorArgs() []string {
 	return sess.MockableTorArgs
 }
 
 // TorBinary implements ExperimentSession.TorBinary.
-func (sess *ExperimentSession) TorBinary() string {
+func (sess *Session) TorBinary() string {
 	return sess.MockableTorBinary
 }
 
 // TunnelBootstrapTime implements ExperimentSession.TunnelBootstrapTime
-func (sess *ExperimentSession) TunnelBootstrapTime() time.Duration {
+func (sess *Session) TunnelBootstrapTime() time.Duration {
 	return sess.MockableTunnelBootstrapTime
 }
 
 // UserAgent implements ExperimentSession.UserAgent
-func (sess *ExperimentSession) UserAgent() string {
+func (sess *Session) UserAgent() string {
 	return sess.MockableUserAgent
 }
 
-var _ model.ExperimentSession = &ExperimentSession{}
+var _ model.ExperimentSession = &Session{}
+var _ probeservices.Session = &Session{}
+var _ psiphonx.Session = &Session{}
+var _ sessiontunnel.Session = &Session{}
+var _ torx.Session = &Session{}
 
 // ExperimentOrchestraClient is the experiment's view of
 // a client for querying the OONI orchestra.

--- a/internal/psiphonx/psiphonx_test.go
+++ b/internal/psiphonx/psiphonx_test.go
@@ -59,7 +59,7 @@ func TestIntegrationStartStop(t *testing.T) {
 
 func TestUnitNewOrchestraClientFailure(t *testing.T) {
 	expected := errors.New("mocked error")
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableOrchestraClientError: expected,
 	}
 	tunnel, err := psiphonx.Start(context.Background(), sess, psiphonx.Config{})
@@ -76,7 +76,7 @@ func TestUnitFetchPsiphonConfigFailure(t *testing.T) {
 	clnt := mockable.ExperimentOrchestraClient{
 		MockableFetchPsiphonConfigErr: expected,
 	}
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableOrchestraClient: clnt,
 	}
 	tunnel, err := psiphonx.Start(context.Background(), sess, psiphonx.Config{})
@@ -96,7 +96,7 @@ func TestUnitMakeMkdirAllFailure(t *testing.T) {
 	clnt := mockable.ExperimentOrchestraClient{
 		MockableFetchPsiphonConfigResult: []byte(`{}`),
 	}
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableOrchestraClient: clnt,
 	}
 	tunnel, err := psiphonx.Start(context.Background(), sess, psiphonx.Config{
@@ -118,7 +118,7 @@ func TestUnitMakeRemoveAllFailure(t *testing.T) {
 	clnt := mockable.ExperimentOrchestraClient{
 		MockableFetchPsiphonConfigResult: []byte(`{}`),
 	}
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableOrchestraClient: clnt,
 	}
 	tunnel, err := psiphonx.Start(context.Background(), sess, psiphonx.Config{
@@ -140,7 +140,7 @@ func TestUnitMakeStartFailure(t *testing.T) {
 	clnt := mockable.ExperimentOrchestraClient{
 		MockableFetchPsiphonConfigResult: []byte(`{}`),
 	}
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableOrchestraClient: clnt,
 	}
 	tunnel, err := psiphonx.Start(context.Background(), sess, psiphonx.Config{

--- a/internal/sessiontunnel/sessiontunnel_test.go
+++ b/internal/sessiontunnel/sessiontunnel_test.go
@@ -15,7 +15,7 @@ func TestNoTunnel(t *testing.T) {
 	cancel()
 	tunnel, err := sessiontunnel.Start(ctx, sessiontunnel.Config{
 		Name: "",
-		Session: &mockable.ExperimentSession{
+		Session: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 	})
@@ -32,7 +32,7 @@ func TestPsiphonTunnel(t *testing.T) {
 	cancel()
 	tunnel, err := sessiontunnel.Start(ctx, sessiontunnel.Config{
 		Name: "psiphon",
-		Session: &mockable.ExperimentSession{
+		Session: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 	})
@@ -49,7 +49,7 @@ func TestTorTunnel(t *testing.T) {
 	cancel()
 	tunnel, err := sessiontunnel.Start(ctx, sessiontunnel.Config{
 		Name: "tor",
-		Session: &mockable.ExperimentSession{
+		Session: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 	})
@@ -66,7 +66,7 @@ func TestInvalidTunnel(t *testing.T) {
 	cancel()
 	tunnel, err := sessiontunnel.Start(ctx, sessiontunnel.Config{
 		Name: "antani",
-		Session: &mockable.ExperimentSession{
+		Session: &mockable.Session{
 			MockableLogger: log.Log,
 		},
 	})

--- a/internal/torx/torx_test.go
+++ b/internal/torx/torx_test.go
@@ -51,7 +51,7 @@ func TestTunnelNil(t *testing.T) {
 func TestStartWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	tun, err := torx.Start(ctx, &mockable.ExperimentSession{})
+	tun, err := torx.Start(ctx, &mockable.Session{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
 	}
@@ -64,7 +64,7 @@ func TestStartWithConfigStartFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	ctx := context.Background()
 	tun, err := torx.StartWithConfig(ctx, torx.StartConfig{
-		Sess: &mockable.ExperimentSession{},
+		Sess: &mockable.Session{},
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
 			return nil, expected
 		},
@@ -81,7 +81,7 @@ func TestStartWithConfigEnableNetworkFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	ctx := context.Background()
 	tun, err := torx.StartWithConfig(ctx, torx.StartConfig{
-		Sess: &mockable.ExperimentSession{},
+		Sess: &mockable.Session{},
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
 			return &tor.Tor{}, nil
 		},
@@ -101,7 +101,7 @@ func TestStartWithConfigGetInfoFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	ctx := context.Background()
 	tun, err := torx.StartWithConfig(ctx, torx.StartConfig{
-		Sess: &mockable.ExperimentSession{},
+		Sess: &mockable.Session{},
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
 			return &tor.Tor{}, nil
 		},
@@ -123,7 +123,7 @@ func TestStartWithConfigGetInfoFailure(t *testing.T) {
 func TestStartWithConfigGetInfoInvalidNumberOfKeys(t *testing.T) {
 	ctx := context.Background()
 	tun, err := torx.StartWithConfig(ctx, torx.StartConfig{
-		Sess: &mockable.ExperimentSession{},
+		Sess: &mockable.Session{},
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
 			return &tor.Tor{}, nil
 		},
@@ -145,7 +145,7 @@ func TestStartWithConfigGetInfoInvalidNumberOfKeys(t *testing.T) {
 func TestStartWithConfigGetInfoInvalidKey(t *testing.T) {
 	ctx := context.Background()
 	tun, err := torx.StartWithConfig(ctx, torx.StartConfig{
-		Sess: &mockable.ExperimentSession{},
+		Sess: &mockable.Session{},
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
 			return &tor.Tor{}, nil
 		},
@@ -167,7 +167,7 @@ func TestStartWithConfigGetInfoInvalidKey(t *testing.T) {
 func TestStartWithConfigGetInfoInvalidProxyType(t *testing.T) {
 	ctx := context.Background()
 	tun, err := torx.StartWithConfig(ctx, torx.StartConfig{
-		Sess: &mockable.ExperimentSession{},
+		Sess: &mockable.Session{},
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
 			return &tor.Tor{}, nil
 		},
@@ -189,7 +189,7 @@ func TestStartWithConfigGetInfoInvalidProxyType(t *testing.T) {
 func TestStartWithConfigSuccess(t *testing.T) {
 	ctx := context.Background()
 	tun, err := torx.StartWithConfig(ctx, torx.StartConfig{
-		Sess: &mockable.ExperimentSession{},
+		Sess: &mockable.Session{},
 		Start: func(ctx context.Context, conf *tor.StartConf) (*tor.Tor, error) {
 			return &tor.Tor{}, nil
 		},

--- a/model/experiment.go
+++ b/model/experiment.go
@@ -20,21 +20,14 @@ type ExperimentOrchestraClient interface {
 // ExperimentSession is the experiment's view of a session.
 type ExperimentSession interface {
 	ASNDatabasePath() string
-	CABundlePath() string
 	GetTestHelpersByName(name string) ([]Service, bool)
 	DefaultHTTPClient() *http.Client
 	Logger() Logger
 	MaybeStartTunnel(ctx context.Context, name string) error
 	NewOrchestraClient(ctx context.Context) (ExperimentOrchestraClient, error)
-	KeyValueStore() KeyValueStore
-	ProbeASNString() string
 	ProbeCC() string
-	ProbeIP() string
-	ProbeNetworkName() string
 	ProxyURL() *url.URL
 	ResolverIP() string
-	SoftwareName() string
-	SoftwareVersion() string
 	TempDir() string
 	TunnelBootstrapTime() time.Duration
 	UserAgent() string

--- a/probeservices/probeservices_test.go
+++ b/probeservices/probeservices_test.go
@@ -21,7 +21,7 @@ import (
 
 func newclient() *probeservices.Client {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{
+		&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		},
@@ -38,7 +38,7 @@ func newclient() *probeservices.Client {
 
 func TestNewClientHTTPS(t *testing.T) {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "https://x.org",
 			Type:    "https",
 		})
@@ -52,7 +52,7 @@ func TestNewClientHTTPS(t *testing.T) {
 
 func TestNewClientUnsupportedEndpoint(t *testing.T) {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "https://x.org",
 			Type:    "onion",
 		})
@@ -66,7 +66,7 @@ func TestNewClientUnsupportedEndpoint(t *testing.T) {
 
 func TestNewClientCloudfrontInvalidURL(t *testing.T) {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "\t\t\t",
 			Type:    "cloudfront",
 		})
@@ -80,7 +80,7 @@ func TestNewClientCloudfrontInvalidURL(t *testing.T) {
 
 func TestNewClientCloudfrontInvalidURLScheme(t *testing.T) {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "http://x.org",
 			Type:    "cloudfront",
 		})
@@ -94,7 +94,7 @@ func TestNewClientCloudfrontInvalidURLScheme(t *testing.T) {
 
 func TestNewClientCloudfrontInvalidURLWithPort(t *testing.T) {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "https://x.org:54321",
 			Type:    "cloudfront",
 		})
@@ -108,7 +108,7 @@ func TestNewClientCloudfrontInvalidURLWithPort(t *testing.T) {
 
 func TestNewClientCloudfrontInvalidFront(t *testing.T) {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "https://x.org",
 			Type:    "cloudfront",
 			Front:   "\t\t\t",
@@ -123,7 +123,7 @@ func TestNewClientCloudfrontInvalidFront(t *testing.T) {
 
 func TestNewClientCloudfrontGood(t *testing.T) {
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "https://x.org",
 			Type:    "cloudfront",
 			Front:   "google.com",
@@ -144,7 +144,7 @@ func TestIntegrationCloudfront(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 	client, err := probeservices.NewClient(
-		&mockable.ExperimentSession{}, model.Service{
+		&mockable.Session{}, model.Service{
 			Address: "https://meek.azureedge.net",
 			Type:    "cloudfront",
 			Front:   "ajax.aspnetcdn.com",
@@ -179,7 +179,7 @@ func TestDefaultProbeServicesWorkAsIntended(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 	for _, e := range probeservices.Default() {
-		client, err := probeservices.NewClient(&mockable.ExperimentSession{
+		client, err := probeservices.NewClient(&mockable.Session{
 			MockableHTTPClient: http.DefaultClient,
 			MockableLogger:     log.Log,
 		}, e)
@@ -316,7 +316,7 @@ func TestTryAllCanceledContext(t *testing.T) {
 	}}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel and cause every attempt to fail
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 	}
@@ -418,7 +418,7 @@ func TestTryAllIntegrationWeRaceForFastestHTTPS(t *testing.T) {
 		Type:    "https",
 		Address: "https://ps3.ooni.io",
 	}}
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 	}
@@ -489,7 +489,7 @@ func TestTryAllIntegrationWeFallback(t *testing.T) {
 		Type:    "https",
 		Address: "https://mia-ps2-nonexistent.ooni.nu",
 	}}
-	sess := &mockable.ExperimentSession{
+	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
 		MockableLogger:     log.Log,
 	}


### PR DESCRIPTION
This concludes our initial yak shaving journey. Now the view of a Session that
experiments have is significantly simpler than before.

I see this diff as a preliminary change aimed at facilitating investigating
https://github.com/ooni/explorer/issues/495 in the probe context.