### PR TITLE
webconnectivity: we can now safely omit client resolver IP

### DIFF
--- a/experiment/webconnectivity/webconnectivity.go
+++ b/experiment/webconnectivity/webconnectivity.go
@@ -102,7 +102,7 @@ func (m Measurer) Run(
 	tk := new(TestKeys)
 	measurement.TestKeys = tk
 	tk.Agent = "redirect"
-	tk.ClientResolver = sess.ResolverIP()
+	tk.ClientResolver = sess.MaybeResolverIP()
 	if measurement.Input == "" {
 		return ErrNoInput
 	}

--- a/experiment/webconnectivity/webconnectivity_test.go
+++ b/experiment/webconnectivity/webconnectivity_test.go
@@ -37,7 +37,9 @@ func TestIntegrationSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 	tk := measurement.TestKeys.(*webconnectivity.TestKeys)
-	if tk.ClientResolver == "" || tk.ClientResolver == model.DefaultResolverIP {
+	// By default we don't want to publish the IP of the client resolver
+	// because now we have already its ASN and CC.
+	if tk.ClientResolver != model.DefaultResolverIP {
 		t.Fatal("unexpected client_resolver")
 	}
 	if tk.ControlFailure != nil {
@@ -65,7 +67,9 @@ func TestMeasureWithCancelledContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	tk := measurement.TestKeys.(*webconnectivity.TestKeys)
-	if tk.ClientResolver == "" || tk.ClientResolver == model.DefaultResolverIP {
+	// By default we don't want to publish the IP of the client resolver
+	// because now we have already its ASN and CC.
+	if tk.ClientResolver != model.DefaultResolverIP {
 		t.Fatal("unexpected client_resolver")
 	}
 	if *tk.ControlFailure != errorx.FailureInterrupted {
@@ -93,7 +97,9 @@ func TestMeasureWithNoInput(t *testing.T) {
 		t.Fatal(err)
 	}
 	tk := measurement.TestKeys.(*webconnectivity.TestKeys)
-	if tk.ClientResolver == "" || tk.ClientResolver == model.DefaultResolverIP {
+	// By default we don't want to publish the IP of the client resolver
+	// because now we have already its ASN and CC.
+	if tk.ClientResolver != model.DefaultResolverIP {
 		t.Fatal("unexpected client_resolver")
 	}
 	if tk.ControlFailure != nil {
@@ -121,7 +127,9 @@ func TestMeasureWithInputNotBeingAnURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	tk := measurement.TestKeys.(*webconnectivity.TestKeys)
-	if tk.ClientResolver == "" || tk.ClientResolver == model.DefaultResolverIP {
+	// By default we don't want to publish the IP of the client resolver
+	// because now we have already its ASN and CC.
+	if tk.ClientResolver != model.DefaultResolverIP {
 		t.Fatal("unexpected client_resolver")
 	}
 	if tk.ControlFailure != nil {
@@ -149,7 +157,9 @@ func TestMeasureWithUnsupportedInput(t *testing.T) {
 		t.Fatal(err)
 	}
 	tk := measurement.TestKeys.(*webconnectivity.TestKeys)
-	if tk.ClientResolver == "" || tk.ClientResolver == model.DefaultResolverIP {
+	// By default we don't want to publish the IP of the client resolver
+	// because now we have already its ASN and CC.
+	if tk.ClientResolver != model.DefaultResolverIP {
 		t.Fatal("unexpected client_resolver")
 	}
 	if tk.ControlFailure != nil {
@@ -177,7 +187,9 @@ func TestMeasureWithNoAvailableTestHelpers(t *testing.T) {
 		t.Fatal(err)
 	}
 	tk := measurement.TestKeys.(*webconnectivity.TestKeys)
-	if tk.ClientResolver == "" || tk.ClientResolver == model.DefaultResolverIP {
+	// By default we don't want to publish the IP of the client resolver
+	// because now we have already its ASN and CC.
+	if tk.ClientResolver != model.DefaultResolverIP {
 		t.Fatal("unexpected client_resolver")
 	}
 	if tk.ControlFailure != nil {

--- a/internal/mockable/mockable.go
+++ b/internal/mockable/mockable.go
@@ -24,6 +24,7 @@ type Session struct {
 	MockableTestHelpers          map[string][]model.Service
 	MockableHTTPClient           *http.Client
 	MockableLogger               model.Logger
+	MockableMaybeResolverIP      string
 	MockableMaybeStartTunnelErr  error
 	MockableOrchestraClient      model.ExperimentOrchestraClient
 	MockableOrchestraClientError error
@@ -71,6 +72,11 @@ func (sess *Session) KeyValueStore() model.KeyValueStore {
 // Logger implements ExperimentSession.Logger
 func (sess *Session) Logger() model.Logger {
 	return sess.MockableLogger
+}
+
+// MaybeResolverIP implements ExperimentSession.MaybeResolverIP.
+func (sess *Session) MaybeResolverIP() string {
+	return sess.MockableMaybeResolverIP
 }
 
 // MaybeStartTunnel implements ExperimentSession.MaybeStartTunnel

--- a/model/experiment.go
+++ b/model/experiment.go
@@ -27,7 +27,7 @@ type ExperimentSession interface {
 	NewOrchestraClient(ctx context.Context) (ExperimentOrchestraClient, error)
 	ProbeCC() string
 	ProxyURL() *url.URL
-	ResolverIP() string
+	MaybeResolverIP() string
 	TempDir() string
 	TunnelBootstrapTime() time.Duration
 	UserAgent() string

--- a/session.go
+++ b/session.go
@@ -193,6 +193,16 @@ func (s *Session) MaybeLookupBackends() error {
 	return s.maybeLookupBackends(context.Background())
 }
 
+// MaybeResolverIP returns the resolver IP, if we have been given the
+// permission to share IPs. Otherwise it returns a canary value.
+func (s *Session) MaybeResolverIP() string {
+	ip := model.DefaultResolverIP
+	if s.privacySettings.IncludeIP {
+		ip = s.ResolverIP()
+	}
+	return ip
+}
+
 // ErrAlreadyUsingProxy indicates that we cannot create a tunnel with
 // a specific name because we already configured a proxy.
 var ErrAlreadyUsingProxy = errors.New(

--- a/session_test.go
+++ b/session_test.go
@@ -591,3 +591,20 @@ func TestNewOrchestraClientProbeServicesNewClientFailure(t *testing.T) {
 		t.Fatal("expected nil client here")
 	}
 }
+
+func TestMaybeResolverIPWithSharingDisabled(t *testing.T) {
+	sess := newSessionForTesting(t)
+	ip := sess.MaybeResolverIP()
+	if ip != model.DefaultResolverIP {
+		t.Fatal("not the IP we expected")
+	}
+}
+
+func TestMaybeResolverIPWithSharingEnabled(t *testing.T) {
+	sess := newSessionForTesting(t)
+	sess.privacySettings.IncludeIP = true
+	ip := sess.MaybeResolverIP()
+	if ip != sess.ResolverIP() {
+		t.Fatal("not the IP we expected")
+	}
+}


### PR DESCRIPTION
Since this experiment has been rewritten in Go, we can safely omit the
IP address of the client resolver. The new implementation, in fact,
performs a geolookup of such an IP address.

Not strictly and directly related with the issue I am working on
(https://github.com/ooni/explorer/issues/495). Yet, working on such
an issue and reading the code is a useful mindset to reason about
simplifications around what we submit to our backends.