### PR TITLE
refactor(generate_*): better names for tests

### DIFF
--- a/experiment_generated_test.go
+++ b/experiment_generated_test.go
@@ -10,7 +10,7 @@ import (
 
 //go:generate go run generate_experiment.go
 
-func TestExperimentNewMeasurementProbeIPWorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurementIncludeIPWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ProbeIP: "8.8.8.8",
 	}}
@@ -39,7 +39,7 @@ func TestExperimentNewMeasurementProbeIPWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestExperimentNewMeasurementProbeASNStringWorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurementIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ASN: 30722,
 	}}
@@ -68,7 +68,7 @@ func TestExperimentNewMeasurementProbeASNStringWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestExperimentOpenReportProbeASNStringWorksAsIntended(t *testing.T) {
+func TestExperimentOpenReportIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ASN: 30722,
 	}}
@@ -97,7 +97,7 @@ func TestExperimentOpenReportProbeASNStringWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestExperimentNewMeasurementProbeCCWorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurementIncludeCountryWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		CountryCode: "IT",
 	}}
@@ -126,7 +126,7 @@ func TestExperimentNewMeasurementProbeCCWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestExperimentOpenReportProbeCCWorksAsIntended(t *testing.T) {
+func TestExperimentOpenReportIncludeCountryWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		CountryCode: "IT",
 	}}
@@ -155,7 +155,7 @@ func TestExperimentOpenReportProbeCCWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestExperimentNewMeasurementProbeNetworkNameWorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurementIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		NetworkName: "Vodafone Italia",
 	}}
@@ -184,7 +184,7 @@ func TestExperimentNewMeasurementProbeNetworkNameWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestExperimentNewMeasurementResolverIPWorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurementIncludeIPWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ResolverIP: "9.9.9.9",
 	}}
@@ -213,7 +213,7 @@ func TestExperimentNewMeasurementResolverIPWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestExperimentNewMeasurementResolverASNStringWorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurementIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ResolverASN: 44,
 	}}
@@ -242,7 +242,7 @@ func TestExperimentNewMeasurementResolverASNStringWorksAsIntended(t *testing.T) 
 	})
 }
 
-func TestExperimentNewMeasurementResolverNetworkNameWorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurementIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ResolverNetworkName: "Google LLC",
 	}}

--- a/generate_experiment.go
+++ b/generate_experiment.go
@@ -9,7 +9,7 @@ import (
 )
 
 var newMeasurementTemplate = template.Must(template.New("open_report").Parse(`
-func TestExperimentNewMeasurement{{ .Name }}WorksAsIntended(t *testing.T) {
+func TestExperimentNewMeasurement{{ .Setting }}WorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		{{ .LocationInfoName }}: {{ .LocationInfoValue }},
 	}}
@@ -39,7 +39,7 @@ func TestExperimentNewMeasurement{{ .Name }}WorksAsIntended(t *testing.T) {
 }`))
 
 var openReportTemplate = template.Must(template.New("new_measurement").Parse(`
-func TestExperimentOpenReport{{ .Name }}WorksAsIntended(t *testing.T) {
+func TestExperimentOpenReport{{ .Setting }}WorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		{{ .LocationInfoName }}: {{ .LocationInfoValue }},
 	}}

--- a/generate_session.go
+++ b/generate_session.go
@@ -21,7 +21,7 @@ func (s *Session) Maybe{{ .Name }}() {{ .Type }} {
 }`))
 
 var sessionTestTemplate = template.Must(template.New("test").Parse(`
-func TestSession{{ .Name }}WorksAsIntended(t *testing.T) {
+func TestSession{{ .Setting }}WorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		{{ .LocationInfoName }}: {{ .LocationInfoValue }},
 	}}

--- a/session_generated_test.go
+++ b/session_generated_test.go
@@ -10,7 +10,7 @@ import (
 
 //go:generate go run generate_session.go
 
-func TestSessionProbeIPWorksAsIntended(t *testing.T) {
+func TestSessionIncludeIPWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ProbeIP: "8.8.8.8",
 	}}
@@ -30,7 +30,7 @@ func TestSessionProbeIPWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionProbeASNWorksAsIntended(t *testing.T) {
+func TestSessionIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ASN: 30722,
 	}}
@@ -50,7 +50,7 @@ func TestSessionProbeASNWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionProbeASNStringWorksAsIntended(t *testing.T) {
+func TestSessionIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ASN: 30722,
 	}}
@@ -70,7 +70,7 @@ func TestSessionProbeASNStringWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionProbeCCWorksAsIntended(t *testing.T) {
+func TestSessionIncludeCountryWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		CountryCode: "IT",
 	}}
@@ -90,7 +90,7 @@ func TestSessionProbeCCWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionProbeNetworkNameWorksAsIntended(t *testing.T) {
+func TestSessionIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		NetworkName: "Vodafone Italia",
 	}}
@@ -110,7 +110,7 @@ func TestSessionProbeNetworkNameWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionResolverIPWorksAsIntended(t *testing.T) {
+func TestSessionIncludeIPWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ResolverIP: "9.9.9.9",
 	}}
@@ -130,7 +130,7 @@ func TestSessionResolverIPWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionResolverASNWorksAsIntended(t *testing.T) {
+func TestSessionIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ResolverASN: 44,
 	}}
@@ -150,7 +150,7 @@ func TestSessionResolverASNWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionResolverASNStringWorksAsIntended(t *testing.T) {
+func TestSessionIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ResolverASN: 44,
 	}}
@@ -170,7 +170,7 @@ func TestSessionResolverASNStringWorksAsIntended(t *testing.T) {
 	})
 }
 
-func TestSessionResolverNetworkNameWorksAsIntended(t *testing.T) {
+func TestSessionIncludeASNWorksAsIntended(t *testing.T) {
 	sess := &Session{location: &model.LocationInfo{
 		ResolverNetworkName: "Google LLC",
 	}}


### PR DESCRIPTION
This is refactoring after we have addressed the main issue that
was causing https://github.com/ooni/explorer/issues/495.