### PR TITLE
fix(model): make sure we honour sharing settings

### DIFF
--- a/model/privacysettings.go
+++ b/model/privacysettings.go
@@ -24,12 +24,16 @@ type PrivacySettings struct {
 func (ps PrivacySettings) Apply(m *Measurement, probeIP string) (err error) {
 	if ps.IncludeASN == false {
 		m.ProbeASN = DefaultProbeASNString
+		m.ResolverNetworkName = DefaultResolverNetworkName
+		m.ProbeNetworkName = DefaultProbeNetworkName
+		m.ResolverASN = DefaultResolverASNString
 	}
 	if ps.IncludeCountry == false {
 		m.ProbeCC = DefaultProbeCC
 	}
 	if ps.IncludeIP == false {
 		m.ProbeIP = DefaultProbeIP
+		m.ResolverIP = DefaultResolverIP
 		err = ps.MaybeRewriteTestKeys(m, probeIP, json.Marshal)
 	}
 	return


### PR DESCRIPTION
With https://github.com/ooni/probe-engine/pull/966 and this change
together we have a more in depth mechanism for enforcing that we're
doing the right thing in terms of honouring sharing settings.

Yet, my instinct is that we should push for removing this vestigial
options that increase complexity and reduce the quality of data we
receive, in the mid term. Shall discuss this with the rest of the team.