### PR TITLE
build-ios.bash: remove workaround required by ObjectiveC++

### DIFF
--- a/build-ios.bash
+++ b/build-ios.bash
@@ -9,8 +9,3 @@ gomobile init
 export GO111MODULE=on
 output=MOBILE/ios/oonimkall.framework
 gomobile bind -target=ios -o $output -ldflags="-s -w" ./oonimkall
-# See https://github.com/ooni/probe-engine/issues/668
-for header in $output/Headers/*.objc.h; do
-  cat $header | sed 's|^@import Foundation;|#import <Foundation/Foundation.h>|g' > $header.new
-  mv $header.new $header
-done


### PR DESCRIPTION
Part of https://github.com/ooni/probe-engine/issues/668