### PR TITLE
dns: set dot to ALPN

### DIFF
--- a/netx/netx.go
+++ b/netx/netx.go
@@ -277,9 +277,7 @@ func NewDNSClientWithOverrides(config Config, URL, hostOverride, SNIOverride str
 	if err != nil {
 		return c, err
 	}
-	if SNIOverride != "" {
-		config.TLSConfig = &tls.Config{ServerName: SNIOverride}
-	}
+	config.TLSConfig = &tls.Config{ServerName: SNIOverride}
 	switch resolverURL.Scheme {
 	case "system":
 		c.Resolver = resolver.SystemResolver{}
@@ -308,6 +306,7 @@ func NewDNSClientWithOverrides(config Config, URL, hostOverride, SNIOverride str
 		c.Resolver = resolver.NewSerialResolver(txp)
 		return c, nil
 	case "dot":
+		config.TLSConfig.NextProtos = []string{"dot"}
 		tlsDialer := NewTLSDialer(config)
 		endpoint, err := makeEndpointForDoT(resolverURL)
 		if err != nil {


### PR DESCRIPTION
Fix #657
`$ ./miniooni -i dot://1.0.0.1 dnscheck` :
![image](https://user-images.githubusercontent.com/12384263/95869076-a96fab00-0d73-11eb-94c3-c2d750d30fd1.png)
