### PR TITLE
fix: only run short tests

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           go-version: "1.14"
       - uses: actions/checkout@v2
-      - run: go test -race -tags shaping -coverprofile=probe-engine.cov -coverpkg=./... ./...
+      - run: go test -short -race -tags shaping -coverprofile=probe-engine.cov -coverpkg=./... ./...
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: probe-engine.cov

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           go-version: "1.14"
       - uses: actions/checkout@v2
-      - run: go test -short -race -tags shaping -coverprofile=probe-engine.cov -coverpkg=./... ./...
+      - run: go test -short -race -tags shaping -coverprofile=probe-engine.cov ./...
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: probe-engine.cov

--- a/experiment/example/example.go
+++ b/experiment/example/example.go
@@ -52,6 +52,10 @@ func (m Measurer) ExperimentVersion() string {
 	return testVersion
 }
 
+// ErrFailure is the error returned when you set the
+// config.ReturnError field to true.
+var ErrFailure = errors.New("mocked error")
+
 // Run implements model.ExperimentMeasurer.Run.
 func (m Measurer) Run(
 	ctx context.Context, sess model.ExperimentSession,
@@ -59,7 +63,7 @@ func (m Measurer) Run(
 ) error {
 	var err error
 	if m.config.ReturnError {
-		err = errors.New("mocked error")
+		err = ErrFailure
 	}
 	testkeys := &TestKeys{Success: err == nil}
 	measurement.TestKeys = testkeys

--- a/experiment/example/example_test.go
+++ b/experiment/example/example_test.go
@@ -2,6 +2,7 @@ package example_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -13,12 +14,16 @@ import (
 
 func TestIntegrationSuccess(t *testing.T) {
 	m := example.NewExperimentMeasurer(example.Config{
-		SleepTime: int64(2 * time.Second),
+		SleepTime: int64(2 * time.Millisecond),
 	}, "example")
-	ctx := context.Background()
-	sess := &mockable.Session{
-		MockableLogger: log.Log,
+	if m.ExperimentName() != "example" {
+		t.Fatal("invalid ExperimentName")
 	}
+	if m.ExperimentVersion() != "0.0.1" {
+		t.Fatal("invalid ExperimentVersion")
+	}
+	ctx := context.Background()
+	sess := &mockable.Session{MockableLogger: log.Log}
 	callbacks := model.NewPrinterCallbacks(sess.Logger())
 	err := m.Run(ctx, sess, new(model.Measurement), callbacks)
 	if err != nil {
@@ -28,16 +33,14 @@ func TestIntegrationSuccess(t *testing.T) {
 
 func TestIntegrationFailure(t *testing.T) {
 	m := example.NewExperimentMeasurer(example.Config{
-		SleepTime:   int64(2 * time.Second),
+		SleepTime:   int64(2 * time.Millisecond),
 		ReturnError: true,
 	}, "example")
 	ctx := context.Background()
-	sess := &mockable.Session{
-		MockableLogger: log.Log,
-	}
+	sess := &mockable.Session{MockableLogger: log.Log}
 	callbacks := model.NewPrinterCallbacks(sess.Logger())
 	err := m.Run(ctx, sess, new(model.Measurement), callbacks)
-	if err == nil {
+	if !errors.Is(err, example.ErrFailure) {
 		t.Fatal("expected an error here")
 	}
 }

--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -9,6 +9,7 @@ import (
 	engine "github.com/ooni/probe-engine"
 	"github.com/ooni/probe-engine/experiment/fbmessenger"
 	"github.com/ooni/probe-engine/experiment/urlgetter"
+	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
 	"github.com/ooni/probe-engine/netx/archival"
 	"github.com/ooni/probe-engine/netx/errorx"
@@ -27,7 +28,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 func TestIntegrationSuccess(t *testing.T) {
 	measurer := fbmessenger.NewExperimentMeasurer(fbmessenger.Config{})
 	ctx := context.Background()
-	// we need a real session because we need to ASN database
+	// we need a real session because we need the ASN database
 	sess := newsession(t)
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
@@ -90,7 +91,7 @@ func TestIntegrationWithCancelledContext(t *testing.T) {
 	measurer := fbmessenger.NewExperimentMeasurer(fbmessenger.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // so we fail immediately
-	sess := newsession(t)
+	sess := &mockable.Session{MockableLogger: log.Log}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)

--- a/experiment/hhfm/hhfm_test.go
+++ b/experiment/hhfm/hhfm_test.go
@@ -35,8 +35,15 @@ func TestNewExperimentMeasurer(t *testing.T) {
 func TestIntegrationSuccess(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx := context.Background()
-	// we need a real session because we need the tcp-echo helper
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"http-return-json-headers": []model.Service{{
+				Address: "http://37.218.241.94:80",
+				Type:    "legacy",
+			}},
+		},
+	}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)
@@ -139,8 +146,15 @@ func TestIntegrationCancelledContext(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	// we need a real session because we need the tcp-echo helper
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"http-return-json-headers": []model.Service{{
+				Address: "http://37.218.241.94:80",
+				Type:    "legacy",
+			}},
+		},
+	}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)

--- a/experiment/hirl/hirl_test.go
+++ b/experiment/hirl/hirl_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	engine "github.com/ooni/probe-engine"
 	"github.com/ooni/probe-engine/experiment/hirl"
 	"github.com/ooni/probe-engine/internal/mockable"
 	"github.com/ooni/probe-engine/model"
@@ -29,8 +28,15 @@ func TestNewExperimentMeasurer(t *testing.T) {
 func TestIntegrationSuccess(t *testing.T) {
 	measurer := hirl.NewExperimentMeasurer(hirl.Config{})
 	ctx := context.Background()
-	// we need a real session because we need the tcp-echo helper
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"tcp-echo": []model.Service{{
+				Address: "37.218.241.93",
+				Type:    "legacy",
+			}},
+		},
+	}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)
@@ -71,8 +77,15 @@ func TestIntegrationCancelledContext(t *testing.T) {
 	measurer := hirl.NewExperimentMeasurer(hirl.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	// we need a real session because we need the tcp-echo helper
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"tcp-echo": []model.Service{{
+				Address: "37.218.241.93",
+				Type:    "legacy",
+			}},
+		},
+	}
 	measurement := new(model.Measurement)
 	callbacks := model.NewPrinterCallbacks(log.Log)
 	err := measurer.Run(ctx, sess, measurement, callbacks)
@@ -346,7 +359,15 @@ func TestWrongTestHelperType(t *testing.T) {
 }
 
 func TestRunMethodDialFailure(t *testing.T) {
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"tcp-echo": []model.Service{{
+				Address: "37.218.241.93",
+				Type:    "legacy",
+			}},
+		},
+	}
 	helpers, ok := sess.GetTestHelpersByName("tcp-echo")
 	if len(helpers) < 1 || !ok {
 		t.Fatal("cannot get helper")
@@ -385,7 +406,15 @@ func TestRunMethodDialFailure(t *testing.T) {
 }
 
 func TestRunMethodSetDeadlineFailure(t *testing.T) {
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"tcp-echo": []model.Service{{
+				Address: "37.218.241.93",
+				Type:    "legacy",
+			}},
+		},
+	}
 	helpers, ok := sess.GetTestHelpersByName("tcp-echo")
 	if len(helpers) < 1 || !ok {
 		t.Fatal("cannot get helper")
@@ -426,7 +455,15 @@ func TestRunMethodSetDeadlineFailure(t *testing.T) {
 }
 
 func TestRunMethodWriteFailure(t *testing.T) {
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"tcp-echo": []model.Service{{
+				Address: "37.218.241.93",
+				Type:    "legacy",
+			}},
+		},
+	}
 	helpers, ok := sess.GetTestHelpersByName("tcp-echo")
 	if len(helpers) < 1 || !ok {
 		t.Fatal("cannot get helper")
@@ -467,7 +504,15 @@ func TestRunMethodWriteFailure(t *testing.T) {
 }
 
 func TestRunMethodReadEOFWithWrongData(t *testing.T) {
-	sess := newsession(t)
+	sess := &mockable.Session{
+		MockableLogger: log.Log,
+		MockableTestHelpers: map[string][]model.Service{
+			"tcp-echo": []model.Service{{
+				Address: "37.218.241.93",
+				Type:    "legacy",
+			}},
+		},
+	}
 	helpers, ok := sess.GetTestHelpersByName("tcp-echo")
 	if len(helpers) < 1 || !ok {
 		t.Fatal("cannot get helper")
@@ -504,29 +549,4 @@ func TestRunMethodReadEOFWithWrongData(t *testing.T) {
 	if result.Tampering != true {
 		t.Fatal("unexpected Tampering")
 	}
-}
-
-func newsession(t *testing.T) model.ExperimentSession {
-	sess, err := engine.NewSession(engine.SessionConfig{
-		AssetsDir: "../../testdata",
-		AvailableProbeServices: []model.Service{{
-			Address: "https://ams-pg.ooni.org",
-			Type:    "https",
-		}},
-		Logger: log.Log,
-		PrivacySettings: model.PrivacySettings{
-			IncludeASN:     true,
-			IncludeCountry: true,
-			IncludeIP:      false,
-		},
-		SoftwareName:    "ooniprobe-engine",
-		SoftwareVersion: "0.0.1",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := sess.MaybeLookupBackends(); err != nil {
-		t.Fatal(err)
-	}
-	return sess
 }

--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -24,7 +24,9 @@ const (
 
 // Config contains the experiment settings
 type Config struct {
-	Tunnel string `ooni:"Run experiment over a tunnel, e.g. psiphon"`
+	Tunnel     string `ooni:"Run experiment over a tunnel, e.g. psiphon"`
+	noDownload bool
+	noUpload   bool
 }
 
 // Summary is the measurement summary
@@ -122,6 +124,9 @@ func (m *Measurer) doDownload(
 	callbacks model.ExperimentCallbacks, tk *TestKeys,
 	URL string,
 ) error {
+	if m.config.noDownload == true {
+		return nil // useful to make tests faster
+	}
 	conn, err := newDialManager(URL, sess.ProxyURL(),
 		sess.Logger(), sess.UserAgent()).dialDownload(ctx)
 	if err != nil {
@@ -189,6 +194,9 @@ func (m *Measurer) doUpload(
 	callbacks model.ExperimentCallbacks, tk *TestKeys,
 	URL string,
 ) error {
+	if m.config.noUpload == true {
+		return nil // useful to make tests faster
+	}
 	conn, err := newDialManager(URL, sess.ProxyURL(),
 		sess.Logger(), sess.UserAgent()).dialUpload(ctx)
 	if err != nil {

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -138,6 +138,9 @@ func TestUnitRunWithProxyURL(t *testing.T) {
 }
 
 func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	measurer := NewExperimentMeasurer(Config{})
 	err := measurer.Run(
 		context.Background(),
@@ -177,7 +180,7 @@ func TestIntegrationFailDownload(t *testing.T) {
 func TestIntegrationFailUpload(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	measurer := NewExperimentMeasurer(Config{}).(*Measurer)
+	measurer := NewExperimentMeasurer(Config{noDownload: true}).(*Measurer)
 	measurer.preUploadHook = func() {
 		cancel()
 	}
@@ -196,7 +199,7 @@ func TestIntegrationFailUpload(t *testing.T) {
 }
 
 func TestIntegrationDownloadJSONUnmarshalFail(t *testing.T) {
-	measurer := NewExperimentMeasurer(Config{}).(*Measurer)
+	measurer := NewExperimentMeasurer(Config{noUpload: true}).(*Measurer)
 	var seenError bool
 	expected := errors.New("expected error")
 	measurer.jsonUnmarshal = func(data []byte, v interface{}) error {

--- a/experiment/stunreachability/stunreachability_test.go
+++ b/experiment/stunreachability/stunreachability_test.go
@@ -184,6 +184,9 @@ func TestStartFailure(t *testing.T) {
 }
 
 func TestReadFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	config := &stunreachability.Config{}
 	expected := errors.New("mocked error")
 	config.SetDialContext(

--- a/experiment/webconnectivity/connects_test.go
+++ b/experiment/webconnectivity/connects_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestConnectsSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	ctx := context.Background()
 	r := webconnectivity.Connects(ctx, webconnectivity.ConnectsConfig{
 		Session:   newsession(t, false),
@@ -31,6 +34,9 @@ func TestConnectsSuccess(t *testing.T) {
 }
 
 func TestConnectsNoInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	ctx := context.Background()
 	r := webconnectivity.Connects(ctx, webconnectivity.ConnectsConfig{
 		Session:       newsession(t, false),

--- a/experiment/webconnectivity/dnslookup_test.go
+++ b/experiment/webconnectivity/dnslookup_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestDNSLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	config := webconnectivity.DNSLookupConfig{
 		Session: newsession(t, true),
 		URL:     &url.URL{Host: "dns.google"},

--- a/experiment/webconnectivity/httpget_test.go
+++ b/experiment/webconnectivity/httpget_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestHTTPGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	ctx := context.Background()
 	r := webconnectivity.HTTPGet(ctx, webconnectivity.HTTPGetConfig{
 		Addresses: []string{"104.16.249.249", "104.16.248.249"},

--- a/experiment/webconnectivity/webconnectivity_test.go
+++ b/experiment/webconnectivity/webconnectivity_test.go
@@ -26,9 +26,13 @@ func TestNewExperimentMeasurer(t *testing.T) {
 }
 
 func TestIntegrationSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx := context.Background()
 	// we need a real session because we need the web-connectivity helper
+	// as well as the ASN database
 	sess := newsession(t, true)
 	measurement := &model.Measurement{Input: "http://www.example.com"}
 	callbacks := model.NewPrinterCallbacks(log.Log)
@@ -55,6 +59,9 @@ func TestIntegrationSuccess(t *testing.T) {
 }
 
 func TestMeasureWithCancelledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -85,6 +92,9 @@ func TestMeasureWithCancelledContext(t *testing.T) {
 }
 
 func TestMeasureWithNoInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -115,6 +125,9 @@ func TestMeasureWithNoInput(t *testing.T) {
 }
 
 func TestMeasureWithInputNotBeingAnURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -145,6 +158,9 @@ func TestMeasureWithInputNotBeingAnURL(t *testing.T) {
 }
 
 func TestMeasureWithUnsupportedInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -175,6 +191,9 @@ func TestMeasureWithUnsupportedInput(t *testing.T) {
 }
 
 func TestMeasureWithNoAvailableTestHelpers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
For pull requests (and possibly also for master) we generally want to run
short tests because this allows for faster feedback cycles.

To this end, this PR strives to flag as "long" tests that take too much time
and also cuts the time consumed by tests that can be easily optimised.

Part of https://github.com/ooni/probe-engine/issues/1005.