### PR TITLE
fature: run comprehensive tests every day

### DIFF
--- a/.github/ISSUE_TEMPLATE/routine-sprint-releases.md
+++ b/.github/ISSUE_TEMPLATE/routine-sprint-releases.md
@@ -12,6 +12,7 @@ assignees: bassosimone
 - [ ] engine: update version.go
 - [ ] engine: update resources/assets.go
 - [ ] engine: update bundled certs (using `go generate ./...`)
+- [ ] engine: make sure all workflows are green
 - [ ] engine: tag a new version
 - [ ] engine: update again version.go to be alpha
 - [ ] engine: create release at GitHub

--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -1,6 +1,5 @@
 name: alltests
 on:
-  push:
   schedule:
     - cron: "0 7 * * */1"
 jobs:

--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -1,5 +1,6 @@
 name: alltests
 on:
+  push:
   schedule:
     - cron: "0 7 * * */1"
 jobs:

--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -1,0 +1,13 @@
+name: alltests
+on:
+  schedule:
+    - cron: "0 7 * * */1"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - uses: actions/checkout@v2
+      - run: go test -race -tags shaping ./...

--- a/.github/workflows/shorttests.yml
+++ b/.github/workflows/shorttests.yml
@@ -1,9 +1,7 @@
-name: golang
+name: shorttests
 on:
   pull_request:
   push:
-  schedule:
-    - cron: "14 17 * * 3"
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OONI probe measurement engine
 
-[![GoDoc](https://godoc.org/github.com/ooni/probe-engine?status.svg)](https://godoc.org/github.com/ooni/probe-engine) ![Tests Status](https://github.com/ooni/probe-engine/workflows/shorttests/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/ooni/probe-engine/badge.svg?branch=master)](https://coveralls.io/github/ooni/probe-engine?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/ooni/probe-engine)](https://goreportcard.com/report/github.com/ooni/probe-engine)
+[![GoDoc](https://godoc.org/github.com/ooni/probe-engine?status.svg)](https://godoc.org/github.com/ooni/probe-engine) ![Short Tests Status](https://github.com/ooni/probe-engine/workflows/shorttests/badge.svg) ![All Tests Status](https://github.com/ooni/probe-engine/workflows/alltests/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/ooni/probe-engine/badge.svg?branch=master)](https://coveralls.io/github/ooni/probe-engine?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/ooni/probe-engine)](https://goreportcard.com/report/github.com/ooni/probe-engine)
 
 This repository contains OONI probe's [measurement engine](
 https://github.com/ooni/spec/tree/master/probe#engine). That is, the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OONI probe measurement engine
 
-[![GoDoc](https://godoc.org/github.com/ooni/probe-engine?status.svg)](https://godoc.org/github.com/ooni/probe-engine) ![Golang Status](https://github.com/ooni/probe-engine/workflows/golang/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/ooni/probe-engine/badge.svg?branch=master)](https://coveralls.io/github/ooni/probe-engine?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/ooni/probe-engine)](https://goreportcard.com/report/github.com/ooni/probe-engine)
+[![GoDoc](https://godoc.org/github.com/ooni/probe-engine?status.svg)](https://godoc.org/github.com/ooni/probe-engine) ![Tests Status](https://github.com/ooni/probe-engine/workflows/shorttests/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/ooni/probe-engine/badge.svg?branch=master)](https://coveralls.io/github/ooni/probe-engine?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/ooni/probe-engine)](https://goreportcard.com/report/github.com/ooni/probe-engine)
 
 This repository contains OONI probe's [measurement engine](
 https://github.com/ooni/spec/tree/master/probe#engine). That is, the


### PR DESCRIPTION
Rename golang.yml as shorttests.yml and update README.md to point
to this new workflow for showing users a badge.

Write a new alltests.yml workflow that runs daily and includes all
tests, including the ones that are currently failing now.

See https://github.com/ooni/probe-engine/issues/1005.