### PR TITLE
fix(sessionresolver): use dns.quad9.net

### DIFF
--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -1,6 +1,5 @@
 name: alltests
 on:
-  push:
   schedule:
     - cron: "0 7 * * */1"
 jobs:

--- a/.github/workflows/alltests.yml
+++ b/.github/workflows/alltests.yml
@@ -1,5 +1,6 @@
 name: alltests
 on:
+  push:
   schedule:
     - cron: "0 7 * * */1"
 jobs:

--- a/internal/sessionresolver/sessionresolver.go
+++ b/internal/sessionresolver/sessionresolver.go
@@ -5,6 +5,7 @@ package sessionresolver
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/ooni/probe-engine/atomicx"
@@ -16,21 +17,25 @@ import (
 type Resolver struct {
 	Primary         netx.DNSClient
 	PrimaryFailure  *atomicx.Int64
+	PrimaryQuery    *atomicx.Int64
 	Fallback        netx.DNSClient
 	FallbackFailure *atomicx.Int64
+	FallbackQuery   *atomicx.Int64
 }
 
 // New creates a new session resolver.
 func New(config netx.Config) *Resolver {
-	primary, err := netx.NewDNSClient(config, "doh://powerdns")
+	primary, err := netx.NewDNSClient(config, "https://dns.quad9.net/dns-query")
 	runtimex.PanicOnError(err, "cannot create dns over https resolver")
 	fallback, err := netx.NewDNSClient(config, "system:///")
 	runtimex.PanicOnError(err, "cannot create system resolver")
 	return &Resolver{
 		Primary:         primary,
 		PrimaryFailure:  atomicx.NewInt64(),
+		PrimaryQuery:    atomicx.NewInt64(),
 		Fallback:        fallback,
 		FallbackFailure: atomicx.NewInt64(),
+		FallbackQuery:   atomicx.NewInt64(),
 	}
 }
 
@@ -40,17 +45,26 @@ func (r *Resolver) CloseIdleConnections() {
 	r.Fallback.CloseIdleConnections()
 }
 
+// Stats returns stats about the session resolver.
+func (r *Resolver) Stats() string {
+	return fmt.Sprintf("sessionresolver: failure rate: primary: %d/%d; fallback: %d/%d",
+		r.PrimaryFailure.Load(), r.PrimaryQuery.Load(),
+		r.FallbackFailure.Load(), r.FallbackQuery.Load())
+}
+
 // LookupHost implements Resolver.LookupHost
 func (r *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	// Algorithm similar to Firefox TRR2 mode. See:
 	// https://wiki.mozilla.org/Trusted_Recursive_Resolver#DNS-over-HTTPS_Prefs_in_Firefox
 	// We use a higher timeout than Firefox's timeout (1.5s) to be on the safe side
 	// and therefore see to use DoH more often.
+	r.PrimaryQuery.Add(1)
 	trr2, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
 	addrs, err := r.Primary.LookupHost(trr2, hostname)
 	if err != nil {
 		r.PrimaryFailure.Add(1)
+		r.FallbackQuery.Add(1)
 		addrs, err = r.Fallback.LookupHost(ctx, hostname)
 		if err != nil {
 			r.FallbackFailure.Add(1)

--- a/internal/sessionresolver/sessionresolver_test.go
+++ b/internal/sessionresolver/sessionresolver_test.go
@@ -9,10 +9,7 @@ import (
 	"github.com/ooni/probe-engine/netx"
 )
 
-func TestIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
+func TestIntegrationFallbackWorks(t *testing.T) {
 	reso := sessionresolver.New(netx.Config{})
 	defer reso.CloseIdleConnections()
 	if reso.Network() != "sessionresolver" {

--- a/session.go
+++ b/session.go
@@ -145,6 +145,7 @@ func (s *Session) KibiBytesSent() float64 {
 func (s *Session) Close() error {
 	s.httpDefaultTransport.CloseIdleConnections()
 	s.resolver.CloseIdleConnections()
+	s.logger.Infof("%s", s.resolver.Stats())
 	if s.tunnel != nil {
 		s.tunnel.Stop()
 	}


### PR DESCRIPTION
See https://github.com/ooni/probe-engine/issues/1005