### PR TITLE
fix(all): remove the integration tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,10 @@ request that modifies existing functionality should not decrease the
 existing code coverage.
 
 Long-running tests should be skipped when running tests in short mode
-using `go test -short`. (Long-running) integration tests should be
-in a separate `foo_integration_test.go` file that is only builds when
-the `-tags integration` command line tag is specified.
+using `go test -short`. We prefer external testing to internal
+testing. We generally have a file called `foo_test.go` with tests
+for every `foo.go` file. Sometimes we separate long running
+integration tests in a `foo_integration_test.go` file.
 
 If there is a top-level DESIGN.md document, make sure such document is
 kept in sync with code changes you have applied.

--- a/atomicx/atomicx_test.go
+++ b/atomicx/atomicx_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ooni/probe-engine/atomicx"
 )
 
-func TestIntegrationInt64(t *testing.T) {
+func TestInt64(t *testing.T) {
 	// TODO(bassosimone): how to write tests with race conditions
 	// and be confident that they're WAI? Here I hope this test is
 	// run with `-race` and I'm doing something that AFAICT will
@@ -28,7 +28,7 @@ func TestIntegrationInt64(t *testing.T) {
 	}
 }
 
-func TestIntegrationFloat64(t *testing.T) {
+func TestFloat64(t *testing.T) {
 	// TODO(bassosimone): how to write tests with race conditions
 	// and be confident that they're WAI? Here I hope this test is
 	// run with `-race` and I'm doing something that AFAICT will

--- a/cmd/jafar/badproxy/badproxy_test.go
+++ b/cmd/jafar/badproxy/badproxy_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/google/martian/v3/mitm"
 )
 
-func TestIntegrationCleartext(t *testing.T) {
+func TestCleartext(t *testing.T) {
 	listener := newproxy(t)
 	checkdial(t, listener.Addr().String(), nil, net.Dial)
 	killproxy(t, listener)
 }
 
-func TestIntegrationTLS(t *testing.T) {
+func TestTLS(t *testing.T) {
 	listener := newproxytls(t)
 	checkdial(t, listener.Addr().String(), nil,
 		func(network, address string) (net.Conn, error) {
@@ -38,7 +38,7 @@ func TestIntegrationTLS(t *testing.T) {
 	killproxy(t, listener)
 }
 
-func TestIntegrationListenError(t *testing.T) {
+func TestListenError(t *testing.T) {
 	proxy := NewCensoringProxy()
 	listener, err := proxy.Start("8.8.8.8:80")
 	if err == nil {
@@ -49,7 +49,7 @@ func TestIntegrationListenError(t *testing.T) {
 	}
 }
 
-func TestUnitStarTLS(t *testing.T) {
+func TestStarTLS(t *testing.T) {
 	expected := errors.New("mocked error")
 
 	t.Run("when we cannot create a new authority", func(t *testing.T) {

--- a/cmd/jafar/httpproxy/httpproxy_test.go
+++ b/cmd/jafar/httpproxy/httpproxy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/probe-engine/cmd/jafar/uncensored"
 )
 
-func TestIntegrationPass(t *testing.T) {
+func TestPass(t *testing.T) {
 	server, addr := newproxy(t, "ooni.io")
 	// We're filtering ooni.io, so we expect example.com to pass
 	// through the proxy with 200 and we also expect to see the
@@ -20,7 +20,7 @@ func TestIntegrationPass(t *testing.T) {
 	killproxy(t, server)
 }
 
-func TestIntegrationBlock(t *testing.T) {
+func TestBlock(t *testing.T) {
 	server, addr := newproxy(t, "ooni.io")
 	// Here we're filtering any domain containing ooni.io, so we
 	// expect the proxy to send 451 without actually proxing, thus
@@ -29,7 +29,7 @@ func TestIntegrationBlock(t *testing.T) {
 	killproxy(t, server)
 }
 
-func TestIntegrationLoop(t *testing.T) {
+func TestLoop(t *testing.T) {
 	server, addr := newproxy(t, "ooni.io")
 	// Here we're forcing the proxy to connect to itself. It does
 	// does that and recognizes itself because of the Via header
@@ -41,7 +41,7 @@ func TestIntegrationLoop(t *testing.T) {
 	killproxy(t, server)
 }
 
-func TestIntegrationListenError(t *testing.T) {
+func TestListenError(t *testing.T) {
 	proxy := NewCensoringProxy([]string{""}, uncensored.DefaultClient)
 	server, addr, err := proxy.Start("8.8.8.8:80")
 	if err == nil {

--- a/cmd/jafar/iptables/iptables_integration_test.go
+++ b/cmd/jafar/iptables/iptables_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package iptables
 
 import (
@@ -31,9 +29,12 @@ func newCensoringPolicy() *CensoringPolicy {
 	return policy
 }
 
-func TestUnitCannotApplyPolicy(t *testing.T) {
+func TestCannotApplyPolicy(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	policy.DropIPs = []string{"antani"}
@@ -43,9 +44,12 @@ func TestUnitCannotApplyPolicy(t *testing.T) {
 	defer policy.Waive()
 }
 
-func TestUnitCreateChainsError(t *testing.T) {
+func TestCreateChainsError(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	if err := policy.Apply(); err != nil {
@@ -59,9 +63,12 @@ func TestUnitCreateChainsError(t *testing.T) {
 	}
 }
 
-func TestIntegrationDropIP(t *testing.T) {
+func TestDropIP(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	policy.DropIPs = []string{"1.1.1.1"}
@@ -83,9 +90,12 @@ func TestIntegrationDropIP(t *testing.T) {
 	}
 }
 
-func TestIntegrationDropKeyword(t *testing.T) {
+func TestDropKeyword(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	policy.DropKeywords = []string{"ooni.io"}
@@ -111,9 +121,12 @@ func TestIntegrationDropKeyword(t *testing.T) {
 	}
 }
 
-func TestIntegrationDropKeywordHex(t *testing.T) {
+func TestDropKeywordHex(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	policy.DropKeywordsHex = []string{"|6f 6f 6e 69|"}
@@ -142,9 +155,12 @@ func TestIntegrationDropKeywordHex(t *testing.T) {
 	}
 }
 
-func TestIntegrationResetIP(t *testing.T) {
+func TestResetIP(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	policy.ResetIPs = []string{"1.1.1.1"}
@@ -164,9 +180,12 @@ func TestIntegrationResetIP(t *testing.T) {
 	}
 }
 
-func TestIntegrationResetKeyword(t *testing.T) {
+func TestResetKeyword(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	policy.ResetKeywords = []string{"ooni.io"}
@@ -186,9 +205,12 @@ func TestIntegrationResetKeyword(t *testing.T) {
 	}
 }
 
-func TestIntegrationResetKeywordHex(t *testing.T) {
+func TestResetKeywordHex(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
 	policy.ResetKeywordsHex = []string{"|6f 6f 6e 69|"}
@@ -208,9 +230,12 @@ func TestIntegrationResetKeywordHex(t *testing.T) {
 	}
 }
 
-func TestIntegrationHijackDNS(t *testing.T) {
+func TestHijackDNS(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	resolver := resolver.NewCensoringResolver(
 		[]string{"ooni.io"}, nil, nil,
@@ -239,9 +264,12 @@ func TestIntegrationHijackDNS(t *testing.T) {
 	}
 }
 
-func TestIntegrationHijackHTTP(t *testing.T) {
+func TestHijackHTTP(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	// Implementation note: this test is complicated by the fact
 	// that we are running as root and so we're whitelisted.
@@ -275,9 +303,12 @@ func TestIntegrationHijackHTTP(t *testing.T) {
 	}
 }
 
-func TestIntegrationHijackHTTPS(t *testing.T) {
+func TestHijackHTTPS(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("not implemented on this platform")
+	}
+	if testing.Short() {
+		t.Skip("skip test in short mode")
 	}
 	// Implementation note: this test is complicated by the fact
 	// that we are running as root and so we're whitelisted.

--- a/cmd/jafar/main_test.go
+++ b/cmd/jafar/main_test.go
@@ -14,9 +14,9 @@ func ensureWeStartOverWithIPTables() {
 	iptables.NewCensoringPolicy().Waive()
 }
 
-func TestIntegrationNoCommand(t *testing.T) {
+func TestNoCommand(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non Linux systems")
+		t.Skip("skip test on non Linux systems")
 	}
 	ensureWeStartOverWithIPTables()
 	*dnsProxyAddress = "127.0.0.1:0"
@@ -28,9 +28,9 @@ func TestIntegrationNoCommand(t *testing.T) {
 	main()
 }
 
-func TestIntegrationWithCommand(t *testing.T) {
+func TestWithCommand(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non Linux systems")
+		t.Skip("skip test on non Linux systems")
 	}
 	ensureWeStartOverWithIPTables()
 	*dnsProxyAddress = "127.0.0.1:0"

--- a/cmd/jafar/resolver/resolver_test.go
+++ b/cmd/jafar/resolver/resolver_test.go
@@ -8,32 +8,32 @@ import (
 	"github.com/ooni/probe-engine/cmd/jafar/uncensored"
 )
 
-func TestIntegrationPass(t *testing.T) {
+func TestPass(t *testing.T) {
 	server := newresolver(t, []string{"ooni.io"}, []string{"ooni.nu"}, nil)
 	checkrequest(t, server, "example.com", "success", nil)
 	killserver(t, server)
 }
 
-func TestIntegrationBlock(t *testing.T) {
+func TestBlock(t *testing.T) {
 	server := newresolver(t, []string{"ooni.io"}, []string{"ooni.nu"}, nil)
 	checkrequest(t, server, "mia-ps.ooni.io", "blocked", nil)
 	killserver(t, server)
 }
 
-func TestIntegrationRedirect(t *testing.T) {
+func TestRedirect(t *testing.T) {
 	server := newresolver(t, []string{"ooni.io"}, []string{"ooni.nu"}, nil)
 	checkrequest(t, server, "hkgmetadb.ooni.nu", "hijacked", nil)
 	killserver(t, server)
 }
 
-func TestIntegrationIgnore(t *testing.T) {
+func TestIgnore(t *testing.T) {
 	server := newresolver(t, nil, nil, []string{"ooni.nu"})
 	iotimeout := "i/o timeout"
 	checkrequest(t, server, "hkgmetadb.ooni.nu", "hijacked", &iotimeout)
 	killserver(t, server)
 }
 
-func TestIntegrationLookupFailure(t *testing.T) {
+func TestLookupFailure(t *testing.T) {
 	server := newresolver(t, nil, nil, nil)
 	// we should receive same response as when we're blocked
 	checkrequest(t, server, "example.antani", "blocked", nil)

--- a/cmd/jafar/shellx/shellx_test.go
+++ b/cmd/jafar/shellx/shellx_test.go
@@ -2,7 +2,7 @@ package shellx
 
 import "testing"
 
-func TestIntegrationRun(t *testing.T) {
+func TestRun(t *testing.T) {
 	if err := Run("whoami"); err != nil {
 		t.Fatal(err)
 	}
@@ -11,7 +11,7 @@ func TestIntegrationRun(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunCommandline(t *testing.T) {
+func TestRunCommandline(t *testing.T) {
 	t.Run("when the command does not parse", func(t *testing.T) {
 		if err := RunCommandline(`"foobar`); err == nil {
 			t.Fatal("expected an error here")

--- a/cmd/jafar/tlsproxy/tlsproxy_test.go
+++ b/cmd/jafar/tlsproxy/tlsproxy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-engine/cmd/jafar/uncensored"
 )
 
-func TestIntegrationPass(t *testing.T) {
+func TestPass(t *testing.T) {
 	listener := newproxy(t, "ooni.io")
 	checkdialtls(t, listener.Addr().String(), true, &tls.Config{
 		ServerName: "example.com",
@@ -18,7 +18,7 @@ func TestIntegrationPass(t *testing.T) {
 	killproxy(t, listener)
 }
 
-func TestIntegrationBlock(t *testing.T) {
+func TestBlock(t *testing.T) {
 	listener := newproxy(t, "ooni.io")
 	checkdialtls(t, listener.Addr().String(), false, &tls.Config{
 		ServerName: "mia-ps.ooni.io",
@@ -26,7 +26,7 @@ func TestIntegrationBlock(t *testing.T) {
 	killproxy(t, listener)
 }
 
-func TestIntegrationNoSNI(t *testing.T) {
+func TestNoSNI(t *testing.T) {
 	listener := newproxy(t, "ooni.io")
 	checkdialtls(t, listener.Addr().String(), false, &tls.Config{
 		ServerName: "",
@@ -34,7 +34,7 @@ func TestIntegrationNoSNI(t *testing.T) {
 	killproxy(t, listener)
 }
 
-func TestIntegrationInvalidDomain(t *testing.T) {
+func TestInvalidDomain(t *testing.T) {
 	listener := newproxy(t, "ooni.io")
 	checkdialtls(t, listener.Addr().String(), false, &tls.Config{
 		ServerName: "antani.local",
@@ -42,7 +42,7 @@ func TestIntegrationInvalidDomain(t *testing.T) {
 	killproxy(t, listener)
 }
 
-func TestIntegrationFailHandshake(t *testing.T) {
+func TestFailHandshake(t *testing.T) {
 	listener := newproxy(t, "ooni.io")
 	checkdialtls(t, listener.Addr().String(), false, &tls.Config{
 		ServerName: "expired.badssl.com",
@@ -92,7 +92,7 @@ func TestFailWriteAfterConnect(t *testing.T) {
 	killproxy(t, listener)
 }
 
-func TestIntegrationListenError(t *testing.T) {
+func TestListenError(t *testing.T) {
 	proxy := NewCensoringProxy(
 		[]string{""}, uncensored.DefaultClient,
 	)

--- a/cmd/jafar/uncensored/uncensored_test.go
+++ b/cmd/jafar/uncensored/uncensored_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	client, err := NewClient("dot://1.1.1.1:853")
 	if err != nil {
 		t.Fatal(err)

--- a/experiment/dash/collect_test.go
+++ b/experiment/dash/collect_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func TestUnitCollectJSONMarshalError(t *testing.T) {
+func TestCollectJSONMarshalError(t *testing.T) {
 	expected := errors.New("mocked error")
 	deps := FakeDeps{jsonMarshalErr: expected}
 	err := collect(context.Background(), "", "", nil, deps)
@@ -20,7 +20,7 @@ func TestUnitCollectJSONMarshalError(t *testing.T) {
 	}
 }
 
-func TestUnitCollectNewHTTPRequestFailure(t *testing.T) {
+func TestCollectNewHTTPRequestFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	deps := FakeDeps{newHTTPRequestErr: expected}
 	err := collect(context.Background(), "", "", nil, deps)
@@ -29,7 +29,7 @@ func TestUnitCollectNewHTTPRequestFailure(t *testing.T) {
 	}
 }
 
-func TestUnitCollectHTTPClientDoFailure(t *testing.T) {
+func TestCollectHTTPClientDoFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{err: expected}
 	deps := FakeDeps{httpTransport: txp, newHTTPRequestResult: &http.Request{
@@ -42,7 +42,7 @@ func TestUnitCollectHTTPClientDoFailure(t *testing.T) {
 	}
 }
 
-func TestUnitCollectInternalError(t *testing.T) {
+func TestCollectInternalError(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{StatusCode: 500}}
 	deps := FakeDeps{httpTransport: txp, newHTTPRequestResult: &http.Request{
 		Header: http.Header{},
@@ -54,7 +54,7 @@ func TestUnitCollectInternalError(t *testing.T) {
 	}
 }
 
-func TestUnitCollectReadAllFailure(t *testing.T) {
+func TestCollectReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
@@ -74,7 +74,7 @@ func TestUnitCollectReadAllFailure(t *testing.T) {
 	}
 }
 
-func TestUnitCollectInvalidJSON(t *testing.T) {
+func TestCollectInvalidJSON(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
@@ -93,7 +93,7 @@ func TestUnitCollectInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestUnitCollectSuccess(t *testing.T) {
+func TestCollectSuccess(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,

--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
-func TestUnitRunnerLoopLocateFailure(t *testing.T) {
+func TestRunnerLoopLocateFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	r := runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
@@ -39,7 +39,7 @@ func TestUnitRunnerLoopLocateFailure(t *testing.T) {
 	}
 }
 
-func TestUnitRunnerLoopNegotiateFailure(t *testing.T) {
+func TestRunnerLoopNegotiateFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	r := runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
@@ -69,7 +69,7 @@ func TestUnitRunnerLoopNegotiateFailure(t *testing.T) {
 	}
 }
 
-func TestUnitRunnerLoopMeasureFailure(t *testing.T) {
+func TestRunnerLoopMeasureFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	r := runner{
 		callbacks: model.NewPrinterCallbacks(log.Log),
@@ -106,7 +106,7 @@ func TestUnitRunnerLoopMeasureFailure(t *testing.T) {
 	}
 }
 
-func TestUnitRunnerLoopCollectFailure(t *testing.T) {
+func TestRunnerLoopCollectFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := new(trace.Saver)
 	saver.Write(trace.Event{Name: errorx.ConnectOperation, Duration: 150 * time.Millisecond})
@@ -151,7 +151,7 @@ func TestUnitRunnerLoopCollectFailure(t *testing.T) {
 	}
 }
 
-func TestUnitRunnerLoopSuccess(t *testing.T) {
+func TestRunnerLoopSuccess(t *testing.T) {
 	saver := new(trace.Saver)
 	saver.Write(trace.Event{Name: errorx.ConnectOperation, Duration: 150 * time.Millisecond})
 	r := runner{
@@ -200,7 +200,7 @@ func TestUnitRunnerLoopSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitTestKeysAnalyzeWithNoData(t *testing.T) {
+func TestTestKeysAnalyzeWithNoData(t *testing.T) {
 	tk := &TestKeys{}
 	err := tk.analyze()
 	if !errors.Is(err, stats.EmptyInputErr) {
@@ -208,7 +208,7 @@ func TestUnitTestKeysAnalyzeWithNoData(t *testing.T) {
 	}
 }
 
-func TestUnitTestKeysAnalyzeMedian(t *testing.T) {
+func TestTestKeysAnalyzeMedian(t *testing.T) {
 	tk := &TestKeys{
 		ReceiverData: []clientResults{
 			{
@@ -231,7 +231,7 @@ func TestUnitTestKeysAnalyzeMedian(t *testing.T) {
 	}
 }
 
-func TestUnitTestKeysAnalyzeMinPlayoutDelay(t *testing.T) {
+func TestTestKeysAnalyzeMinPlayoutDelay(t *testing.T) {
 	tk := &TestKeys{
 		ReceiverData: []clientResults{
 			{
@@ -257,7 +257,7 @@ func TestUnitTestKeysAnalyzeMinPlayoutDelay(t *testing.T) {
 	}
 }
 
-func TestUnitNewExperimentMeasurer(t *testing.T) {
+func TestNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	if measurer.ExperimentName() != "dash" {
 		t.Fatal("unexpected name")
@@ -267,7 +267,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestUnitMeasureWithCancelledContext(t *testing.T) {
+func TestMeasureWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cause failure
 	m := &Measurer{}
@@ -285,7 +285,7 @@ func TestUnitMeasureWithCancelledContext(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMaybeStartTunnelFailure(t *testing.T) {
+func TestMeasurerMaybeStartTunnelFailure(t *testing.T) {
 	m := &Measurer{config: Config{
 		Tunnel: "psiphon",
 	}}
@@ -305,7 +305,7 @@ func TestUnitMeasurerMaybeStartTunnelFailure(t *testing.T) {
 	}
 }
 
-func TestUnitMeasureWithProxyURL(t *testing.T) {
+func TestMeasureWithProxyURL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cause failure
 	m := &Measurer{}

--- a/experiment/dash/download_test.go
+++ b/experiment/dash/download_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestUnitDownloadNewHTTPRequestFailure(t *testing.T) {
+func TestDownloadNewHTTPRequestFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	_, err := download(context.Background(), downloadConfig{
 		deps: FakeDeps{newHTTPRequestErr: expected},
@@ -20,7 +20,7 @@ func TestUnitDownloadNewHTTPRequestFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDownloadHTTPClientDoFailure(t *testing.T) {
+func TestDownloadHTTPClientDoFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{err: expected}
 	_, err := download(context.Background(), downloadConfig{
@@ -34,7 +34,7 @@ func TestUnitDownloadHTTPClientDoFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDownloadInternalError(t *testing.T) {
+func TestDownloadInternalError(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{StatusCode: 500}}
 	_, err := download(context.Background(), downloadConfig{
 		deps: FakeDeps{httpTransport: txp, newHTTPRequestResult: &http.Request{
@@ -47,7 +47,7 @@ func TestUnitDownloadInternalError(t *testing.T) {
 	}
 }
 
-func TestUnitDownloadReadAllFailure(t *testing.T) {
+func TestDownloadReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
@@ -68,7 +68,7 @@ func TestUnitDownloadReadAllFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDownloadSuccess(t *testing.T) {
+func TestDownloadSuccess(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,

--- a/experiment/dash/negotiate_test.go
+++ b/experiment/dash/negotiate_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func TestUnitNegotiateJSONMarshalError(t *testing.T) {
+func TestNegotiateJSONMarshalError(t *testing.T) {
 	expected := errors.New("mocked error")
 	deps := FakeDeps{jsonMarshalErr: expected}
 	result, err := negotiate(context.Background(), "", deps)
@@ -23,7 +23,7 @@ func TestUnitNegotiateJSONMarshalError(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateNewHTTPRequestFailure(t *testing.T) {
+func TestNegotiateNewHTTPRequestFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	deps := FakeDeps{newHTTPRequestErr: expected}
 	result, err := negotiate(context.Background(), "", deps)
@@ -35,7 +35,7 @@ func TestUnitNegotiateNewHTTPRequestFailure(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateHTTPClientDoFailure(t *testing.T) {
+func TestNegotiateHTTPClientDoFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{err: expected}
 	deps := FakeDeps{httpTransport: txp, newHTTPRequestResult: &http.Request{
@@ -51,7 +51,7 @@ func TestUnitNegotiateHTTPClientDoFailure(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateInternalError(t *testing.T) {
+func TestNegotiateInternalError(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{StatusCode: 500}}
 	deps := FakeDeps{httpTransport: txp, newHTTPRequestResult: &http.Request{
 		Header: http.Header{},
@@ -66,7 +66,7 @@ func TestUnitNegotiateInternalError(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateReadAllFailure(t *testing.T) {
+func TestNegotiateReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
@@ -89,7 +89,7 @@ func TestUnitNegotiateReadAllFailure(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateInvalidJSON(t *testing.T) {
+func TestNegotiateInvalidJSON(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
@@ -111,7 +111,7 @@ func TestUnitNegotiateInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateServerBusyFirstCase(t *testing.T) {
+func TestNegotiateServerBusyFirstCase(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
@@ -133,7 +133,7 @@ func TestUnitNegotiateServerBusyFirstCase(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateServerBusyThirdCase(t *testing.T) {
+func TestNegotiateServerBusyThirdCase(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,
@@ -155,7 +155,7 @@ func TestUnitNegotiateServerBusyThirdCase(t *testing.T) {
 	}
 }
 
-func TestUnitNegotiateSuccess(t *testing.T) {
+func TestNegotiateSuccess(t *testing.T) {
 	txp := FakeHTTPTransport{resp: &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
 		StatusCode: 200,

--- a/experiment/example/example_test.go
+++ b/experiment/example/example_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	m := example.NewExperimentMeasurer(example.Config{
 		SleepTime: int64(2 * time.Millisecond),
 	}, "example")
@@ -31,7 +31,7 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationFailure(t *testing.T) {
+func TestFailure(t *testing.T) {
 	m := example.NewExperimentMeasurer(example.Config{
 		SleepTime:   int64(2 * time.Millisecond),
 		ReturnError: true,

--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -25,9 +25,9 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := fbmessenger.NewExperimentMeasurer(fbmessenger.Config{})
 	ctx := context.Background()
@@ -90,7 +90,7 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationWithCancelledContext(t *testing.T) {
+func TestWithCancelledContext(t *testing.T) {
 	measurer := fbmessenger.NewExperimentMeasurer(fbmessenger.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // so we fail immediately

--- a/experiment/hhfm/hhfm_test.go
+++ b/experiment/hhfm/hhfm_test.go
@@ -32,7 +32,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx := context.Background()
 	sess := &mockable.Session{
@@ -142,7 +142,7 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationCancelledContext(t *testing.T) {
+func TestCancelledContext(t *testing.T) {
 	measurer := hhfm.NewExperimentMeasurer(hhfm.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/experiment/hirl/hirl_test.go
+++ b/experiment/hirl/hirl_test.go
@@ -25,7 +25,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	measurer := hirl.NewExperimentMeasurer(hirl.Config{})
 	ctx := context.Background()
 	sess := &mockable.Session{
@@ -73,7 +73,7 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationCancelledContext(t *testing.T) {
+func TestCancelledContext(t *testing.T) {
 	measurer := hirl.NewExperimentMeasurer(hirl.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/experiment/ndt7/download_test.go
+++ b/experiment/ndt7/download_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func TestUnitDownloadSetReadDeadlineFailure(t *testing.T) {
+func TestDownloadSetReadDeadlineFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newDownloadManager(
 		&mockableConnMock{
@@ -27,7 +27,7 @@ func TestUnitDownloadSetReadDeadlineFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDownloadNextReaderFailure(t *testing.T) {
+func TestDownloadNextReaderFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newDownloadManager(
 		&mockableConnMock{
@@ -42,7 +42,7 @@ func TestUnitDownloadNextReaderFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDownloadTextMessageReadAllFailure(t *testing.T) {
+func TestDownloadTextMessageReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newDownloadManager(
 		&mockableConnMock{
@@ -70,7 +70,7 @@ func (r *alwaysFailingReader) Read(p []byte) (int, error) {
 	return 0, r.Err
 }
 
-func TestUnitDownloadBinaryMessageReadAllFailure(t *testing.T) {
+func TestDownloadBinaryMessageReadAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newDownloadManager(
 		&mockableConnMock{
@@ -90,7 +90,7 @@ func TestUnitDownloadBinaryMessageReadAllFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDownloadOnJSONCallbackError(t *testing.T) {
+func TestDownloadOnJSONCallbackError(t *testing.T) {
 	mgr := newDownloadManager(
 		&mockableConnMock{
 			NextReaderMsgType: websocket.TextMessage,
@@ -116,7 +116,7 @@ func (r *invalidJSONReader) Read(p []byte) (int, error) {
 	return copy(p, []byte(`{`)), io.EOF
 }
 
-func TestUnitDownloadOnJSONLoop(t *testing.T) {
+func TestDownloadOnJSONLoop(t *testing.T) {
 	mgr := newDownloadManager(
 		&mockableConnMock{
 			NextReaderMsgType: websocket.TextMessage,

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-func TestUnitNewExperimentMeasurer(t *testing.T) {
+func TestNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	if measurer.ExperimentName() != "ndt" {
 		t.Fatal("unexpected name")
@@ -23,7 +23,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestUnitDiscoverCancelledContext(t *testing.T) {
+func TestDiscoverCancelledContext(t *testing.T) {
 	m := new(Measurer)
 	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
@@ -52,7 +52,7 @@ func (txp *verifyRequestTransport) RoundTrip(req *http.Request) (*http.Response,
 	return nil, txp.ExpectedError
 }
 
-func TestUnitDoDownloadWithCancelledContext(t *testing.T) {
+func TestDoDownloadWithCancelledContext(t *testing.T) {
 	m := new(Measurer)
 	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
@@ -69,7 +69,7 @@ func TestUnitDoDownloadWithCancelledContext(t *testing.T) {
 	}
 }
 
-func TestUnitDoUploadWithCancelledContext(t *testing.T) {
+func TestDoUploadWithCancelledContext(t *testing.T) {
 	m := new(Measurer)
 	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
@@ -86,7 +86,7 @@ func TestUnitDoUploadWithCancelledContext(t *testing.T) {
 	}
 }
 
-func TestUnitRunWithCancelledContext(t *testing.T) {
+func TestRunWithCancelledContext(t *testing.T) {
 	m := new(Measurer)
 	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
@@ -101,7 +101,7 @@ func TestUnitRunWithCancelledContext(t *testing.T) {
 	}
 }
 
-func TestUnitRunWithMaybeStartTunnelFailure(t *testing.T) {
+func TestRunWithMaybeStartTunnelFailure(t *testing.T) {
 	m := new(Measurer)
 	expected := errors.New("mocked error")
 	sess := &mockable.Session{
@@ -117,7 +117,7 @@ func TestUnitRunWithMaybeStartTunnelFailure(t *testing.T) {
 	}
 }
 
-func TestUnitRunWithProxyURL(t *testing.T) {
+func TestRunWithProxyURL(t *testing.T) {
 	m := new(Measurer)
 	sess := &mockable.Session{
 		MockableHTTPClient: http.DefaultClient,
@@ -137,9 +137,9 @@ func TestUnitRunWithProxyURL(t *testing.T) {
 	}
 }
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := NewExperimentMeasurer(Config{})
 	err := measurer.Run(
@@ -156,7 +156,7 @@ func TestIntegration(t *testing.T) {
 	}
 }
 
-func TestIntegrationFailDownload(t *testing.T) {
+func TestFailDownload(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	measurer := NewExperimentMeasurer(Config{}).(*Measurer)
@@ -177,7 +177,7 @@ func TestIntegrationFailDownload(t *testing.T) {
 	}
 }
 
-func TestIntegrationFailUpload(t *testing.T) {
+func TestFailUpload(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	measurer := NewExperimentMeasurer(Config{noDownload: true}).(*Measurer)
@@ -198,7 +198,7 @@ func TestIntegrationFailUpload(t *testing.T) {
 	}
 }
 
-func TestIntegrationDownloadJSONUnmarshalFail(t *testing.T) {
+func TestDownloadJSONUnmarshalFail(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{noUpload: true}).(*Measurer)
 	var seenError bool
 	expected := errors.New("expected error")

--- a/experiment/ndt7/upload_test.go
+++ b/experiment/ndt7/upload_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func TestUnitUploadSetWriteDeadlineFailure(t *testing.T) {
+func TestUploadSetWriteDeadlineFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newUploadManager(
 		&mockableConnMock{
@@ -23,7 +23,7 @@ func TestUnitUploadSetWriteDeadlineFailure(t *testing.T) {
 	}
 }
 
-func TestUnitUploadNewMessageFailure(t *testing.T) {
+func TestUploadNewMessageFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newUploadManager(
 		&mockableConnMock{},
@@ -38,7 +38,7 @@ func TestUnitUploadNewMessageFailure(t *testing.T) {
 	}
 }
 
-func TestUnitUploadWritePreparedMessageFailure(t *testing.T) {
+func TestUploadWritePreparedMessageFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newUploadManager(
 		&mockableConnMock{
@@ -52,7 +52,7 @@ func TestUnitUploadWritePreparedMessageFailure(t *testing.T) {
 	}
 }
 
-func TestUnitUploadWritePreparedMessageSubsequentFailure(t *testing.T) {
+func TestUploadWritePreparedMessageSubsequentFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	mgr := newUploadManager(
 		&mockableConnMock{},
@@ -72,7 +72,7 @@ func TestUnitUploadWritePreparedMessageSubsequentFailure(t *testing.T) {
 	}
 }
 
-func TestUnitUploadLoop(t *testing.T) {
+func TestUploadLoop(t *testing.T) {
 	mgr := newUploadManager(
 		&mockableConnMock{},
 		defaultCallbackPerformance,

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -17,7 +17,7 @@ const (
 	softwareVersion = "0.0.1"
 )
 
-func TestUnitTestKeysClassify(t *testing.T) {
+func TestTestKeysClassify(t *testing.T) {
 	asStringPtr := func(s string) *string {
 		return &s
 	}
@@ -100,7 +100,7 @@ func TestUnitTestKeysClassify(t *testing.T) {
 	})
 }
 
-func TestUnitNewExperimentMeasurer(t *testing.T) {
+func TestNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	if measurer.ExperimentName() != "sni_blocking" {
 		t.Fatal("unexpected name")
@@ -110,7 +110,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureNoControlSNI(t *testing.T) {
+func TestMeasurerMeasureNoControlSNI(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	err := measurer.Run(
 		context.Background(),
@@ -123,7 +123,7 @@ func TestUnitMeasurerMeasureNoControlSNI(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureNoMeasurementInput(t *testing.T) {
+func TestMeasurerMeasureNoMeasurementInput(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{
 		ControlSNI: "example.com",
 	})
@@ -138,7 +138,7 @@ func TestUnitMeasurerMeasureNoMeasurementInput(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureWithInvalidInput(t *testing.T) {
+func TestMeasurerMeasureWithInvalidInput(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel the context
 	measurer := NewExperimentMeasurer(Config{
@@ -158,7 +158,7 @@ func TestUnitMeasurerMeasureWithInvalidInput(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureWithCancelledContext(t *testing.T) {
+func TestMeasurerMeasureWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel the context
 	measurer := NewExperimentMeasurer(Config{
@@ -178,7 +178,7 @@ func TestUnitMeasurerMeasureWithCancelledContext(t *testing.T) {
 	}
 }
 
-func TestUnitMeasureoneCancelledContext(t *testing.T) {
+func TestMeasureoneCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancel the context
 	result := new(Measurer).measureone(
@@ -232,7 +232,7 @@ func TestUnitMeasureoneCancelledContext(t *testing.T) {
 	}
 }
 
-func TestUnitMeasureoneWithPreMeasurementFailure(t *testing.T) {
+func TestMeasureoneWithPreMeasurementFailure(t *testing.T) {
 	result := new(Measurer).measureone(
 		context.Background(),
 		&mockable.Session{MockableLogger: log.Log},
@@ -284,7 +284,7 @@ func TestUnitMeasureoneWithPreMeasurementFailure(t *testing.T) {
 	}
 }
 
-func TestUnitMeasureoneSuccess(t *testing.T) {
+func TestMeasureoneSuccess(t *testing.T) {
 	result := new(Measurer).measureone(
 		context.Background(),
 		&mockable.Session{MockableLogger: log.Log},
@@ -336,7 +336,7 @@ func TestUnitMeasureoneSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitMeasureonewithcacheWorks(t *testing.T) {
+func TestMeasureonewithcacheWorks(t *testing.T) {
 	measurer := &Measurer{cache: make(map[string]Subresult)}
 	output := make(chan Subresult, 2)
 	for i := 0; i < 2; i++ {
@@ -363,7 +363,7 @@ func TestUnitMeasureonewithcacheWorks(t *testing.T) {
 	}
 }
 
-func TestUnitProcessallPanicsIfInvalidSNI(t *testing.T) {
+func TestProcessallPanicsIfInvalidSNI(t *testing.T) {
 	defer func() {
 		panicdata := recover()
 		if panicdata == nil {
@@ -392,7 +392,7 @@ func TestUnitProcessallPanicsIfInvalidSNI(t *testing.T) {
 	)
 }
 
-func TestUnitMaybeURLToSNI(t *testing.T) {
+func TestMaybeURLToSNI(t *testing.T) {
 	t.Run("for invalid URL", func(t *testing.T) {
 		parsed, err := maybeURLToSNI("\t")
 		if err == nil {

--- a/experiment/stunreachability/stunreachability_test.go
+++ b/experiment/stunreachability/stunreachability_test.go
@@ -26,7 +26,7 @@ func TestMeasurerExperimentNameVersion(t *testing.T) {
 	}
 }
 
-func TestIntegrationRun(t *testing.T) {
+func TestRun(t *testing.T) {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		// See https://github.com/ooni/probe-engine/issues/874#issuecomment-679850652
 		t.Skip("skipping broken test on GitHub Actions")
@@ -57,7 +57,7 @@ func TestIntegrationRun(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunCustomInput(t *testing.T) {
+func TestRunCustomInput(t *testing.T) {
 	input := "stun.ekiga.net:3478"
 	measurer := stunreachability.NewExperimentMeasurer(stunreachability.Config{})
 	measurement := new(model.Measurement)
@@ -185,7 +185,7 @@ func TestStartFailure(t *testing.T) {
 
 func TestReadFailure(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	config := &stunreachability.Config{}
 	expected := errors.New("mocked error")

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -23,7 +23,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	measurer := telegram.NewExperimentMeasurer(telegram.Config{})
 	measurement := new(model.Measurement)
 	err := measurer.Run(

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ooni/probe-engine/probeservices"
 )
 
-func TestUnitNewExperimentMeasurer(t *testing.T) {
+func TestNewExperimentMeasurer(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{})
 	if measurer.ExperimentName() != "tor" {
 		t.Fatal("unexpected name")
@@ -31,7 +31,7 @@ func TestUnitNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureNewOrchestraClientError(t *testing.T) {
+func TestMeasurerMeasureNewOrchestraClientError(t *testing.T) {
 	measurer := NewMeasurer(Config{})
 	expected := errors.New("mocked error")
 	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
@@ -50,7 +50,7 @@ func TestUnitMeasurerMeasureNewOrchestraClientError(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureFetchTorTargetsError(t *testing.T) {
+func TestMeasurerMeasureFetchTorTargetsError(t *testing.T) {
 	measurer := NewMeasurer(Config{})
 	expected := errors.New("mocked error")
 	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
@@ -72,7 +72,7 @@ func TestUnitMeasurerMeasureFetchTorTargetsError(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureFetchTorTargetsEmptyList(t *testing.T) {
+func TestMeasurerMeasureFetchTorTargetsEmptyList(t *testing.T) {
 	measurer := NewMeasurer(Config{})
 	measurer.newOrchestraClient = func(ctx context.Context, sess model.ExperimentSession) (model.ExperimentOrchestraClient, error) {
 		return new(probeservices.Client), nil
@@ -98,7 +98,7 @@ func TestUnitMeasurerMeasureFetchTorTargetsEmptyList(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureGood(t *testing.T) {
+func TestMeasurerMeasureGoodWithMockedOrchestra(t *testing.T) {
 	// This test mocks orchestra to return a nil list of targets, so the code runs
 	// but we don't perform any actualy network actions.
 	measurer := NewMeasurer(Config{})
@@ -123,7 +123,7 @@ func TestUnitMeasurerMeasureGood(t *testing.T) {
 
 func TestMeasurerMeasureGood(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := NewMeasurer(Config{})
 	sess := newsession()
@@ -154,7 +154,7 @@ var staticPrivateTestingTarget = model.TorTarget{
 
 func TestMeasurerMeasureSanitiseOutput(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := NewMeasurer(Config{})
 	sess := newsession()
@@ -219,7 +219,7 @@ var staticTestingTargets = []model.TorTarget{
 	},
 }
 
-func TestUnitMeasurerMeasureTargetsNoInput(t *testing.T) {
+func TestMeasurerMeasureTargetsNoInput(t *testing.T) {
 	var measurement model.Measurement
 	measurer := new(Measurer)
 	measurer.measureTargets(
@@ -236,7 +236,7 @@ func TestUnitMeasurerMeasureTargetsNoInput(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurerMeasureTargetsCanceledContext(t *testing.T) {
+func TestMeasurerMeasureTargetsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // so we don't actually do anything
 	var measurement model.Measurement
@@ -272,7 +272,7 @@ func wrapTestingTarget(tt model.TorTarget) keytarget {
 	}
 }
 
-func TestUnitResultsCollectorMeasureSingleTargetGood(t *testing.T) {
+func TestResultsCollectorMeasureSingleTargetGood(t *testing.T) {
 	rc := newResultsCollector(
 		&mockable.Session{
 			MockableLogger: log.Log,
@@ -306,7 +306,7 @@ func TestUnitResultsCollectorMeasureSingleTargetGood(t *testing.T) {
 	}
 }
 
-func TestUnitResultsCollectorMeasureSingleTargetWithFailure(t *testing.T) {
+func TestResultsCollectorMeasureSingleTargetWithFailure(t *testing.T) {
 	rc := newResultsCollector(
 		&mockable.Session{
 			MockableLogger: log.Log,
@@ -343,7 +343,7 @@ func TestUnitResultsCollectorMeasureSingleTargetWithFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDefautFlexibleConnectDirPort(t *testing.T) {
+func TestDefautFlexibleConnectDirPort(t *testing.T) {
 	rc := newResultsCollector(
 		&mockable.Session{
 			MockableLogger: log.Log,
@@ -365,7 +365,7 @@ func TestUnitDefautFlexibleConnectDirPort(t *testing.T) {
 	}
 }
 
-func TestUnitDefautFlexibleConnectOrPort(t *testing.T) {
+func TestDefautFlexibleConnectOrPort(t *testing.T) {
 	rc := newResultsCollector(
 		&mockable.Session{
 			MockableLogger: log.Log,
@@ -390,7 +390,7 @@ func TestUnitDefautFlexibleConnectOrPort(t *testing.T) {
 	}
 }
 
-func TestUnitDefautFlexibleConnectOBFS4(t *testing.T) {
+func TestDefautFlexibleConnectOBFS4(t *testing.T) {
 	rc := newResultsCollector(
 		&mockable.Session{
 			MockableLogger: log.Log,
@@ -415,7 +415,7 @@ func TestUnitDefautFlexibleConnectOBFS4(t *testing.T) {
 	}
 }
 
-func TestUnitDefautFlexibleConnectDefault(t *testing.T) {
+func TestDefautFlexibleConnectDefault(t *testing.T) {
 	rc := newResultsCollector(
 		&mockable.Session{
 			MockableLogger: log.Log,
@@ -437,7 +437,7 @@ func TestUnitDefautFlexibleConnectDefault(t *testing.T) {
 	}
 }
 
-func TestUnitErrString(t *testing.T) {
+func TestErrString(t *testing.T) {
 	if errString(nil) != "success" {
 		t.Fatal("not working with nil")
 	}
@@ -446,7 +446,7 @@ func TestUnitErrString(t *testing.T) {
 	}
 }
 
-func TestUnitSummary(t *testing.T) {
+func TestSummary(t *testing.T) {
 	t.Run("without any piece of data", func(t *testing.T) {
 		tr := new(TargetResults)
 		tr.fillSummary()
@@ -538,7 +538,7 @@ func TestUnitSummary(t *testing.T) {
 	})
 }
 
-func TestUnitFillToplevelKeys(t *testing.T) {
+func TestFillToplevelKeys(t *testing.T) {
 	var tr TargetResults
 	tr.TargetProtocol = "or_port"
 	tk := new(TestKeys)

--- a/experiment/urlgetter/runner_test.go
+++ b/experiment/urlgetter/runner_test.go
@@ -78,9 +78,9 @@ func TestRunnerWithEmptyHostname(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerTLSHandshakeSuccess(t *testing.T) {
+func TestRunnerTLSHandshakeSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	r := urlgetter.Runner{Target: "tlshandshake://www.google.com:443"}
 	err := r.Run(context.Background())
@@ -89,9 +89,9 @@ func TestIntegrationRunnerTLSHandshakeSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerTCPConnectSuccess(t *testing.T) {
+func TestRunnerTCPConnectSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	r := urlgetter.Runner{Target: "tcpconnect://www.google.com:443"}
 	err := r.Run(context.Background())
@@ -100,9 +100,9 @@ func TestIntegrationRunnerTCPConnectSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerDNSLookupSuccess(t *testing.T) {
+func TestRunnerDNSLookupSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	r := urlgetter.Runner{Target: "dnslookup://www.google.com"}
 	err := r.Run(context.Background())
@@ -111,9 +111,9 @@ func TestIntegrationRunnerDNSLookupSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerHTTPSSuccess(t *testing.T) {
+func TestRunnerHTTPSSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	r := urlgetter.Runner{Target: "https://www.google.com"}
 	err := r.Run(context.Background())

--- a/experiment/webconnectivity/connects_test.go
+++ b/experiment/webconnectivity/connects_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConnectsSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	ctx := context.Background()
 	r := webconnectivity.Connects(ctx, webconnectivity.ConnectsConfig{
@@ -35,7 +35,7 @@ func TestConnectsSuccess(t *testing.T) {
 
 func TestConnectsNoInput(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	ctx := context.Background()
 	r := webconnectivity.Connects(ctx, webconnectivity.ConnectsConfig{

--- a/experiment/webconnectivity/dnslookup_test.go
+++ b/experiment/webconnectivity/dnslookup_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDNSLookup(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	config := webconnectivity.DNSLookupConfig{
 		Session: newsession(t, true),

--- a/experiment/webconnectivity/httpget_test.go
+++ b/experiment/webconnectivity/httpget_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestHTTPGet(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	ctx := context.Background()
 	r := webconnectivity.HTTPGet(ctx, webconnectivity.HTTPGetConfig{

--- a/experiment/webconnectivity/webconnectivity_test.go
+++ b/experiment/webconnectivity/webconnectivity_test.go
@@ -25,9 +25,9 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx := context.Background()
@@ -60,7 +60,7 @@ func TestIntegrationSuccess(t *testing.T) {
 
 func TestMeasureWithCancelledContext(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -93,7 +93,7 @@ func TestMeasureWithCancelledContext(t *testing.T) {
 
 func TestMeasureWithNoInput(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -126,7 +126,7 @@ func TestMeasureWithNoInput(t *testing.T) {
 
 func TestMeasureWithInputNotBeingAnURL(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -159,7 +159,7 @@ func TestMeasureWithInputNotBeingAnURL(t *testing.T) {
 
 func TestMeasureWithUnsupportedInput(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -192,7 +192,7 @@ func TestMeasureWithUnsupportedInput(t *testing.T) {
 
 func TestMeasureWithNoAvailableTestHelpers(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	measurer := webconnectivity.NewExperimentMeasurer(webconnectivity.Config{})
 	ctx, cancel := context.WithCancel(context.Background())

--- a/experiment/whatsapp/whatsapp_test.go
+++ b/experiment/whatsapp/whatsapp_test.go
@@ -26,7 +26,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	measurer := whatsapp.NewExperimentMeasurer(whatsapp.Config{})
 	ctx := context.Background()
 	sess := &mockable.Session{MockableLogger: log.Log}
@@ -60,7 +60,7 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationFailureAllEndpoints(t *testing.T) {
+func TestFailureAllEndpoints(t *testing.T) {
 	measurer := whatsapp.NewExperimentMeasurer(whatsapp.Config{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/experiment_integration_test.go
+++ b/experiment_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package engine
 
 import (
@@ -20,6 +18,9 @@ import (
 )
 
 func TestCreateAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	for _, name := range AllExperiments() {
@@ -36,6 +37,9 @@ func TestCreateAll(t *testing.T) {
 }
 
 func TestRunDASH(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("dash")
@@ -49,6 +53,9 @@ func TestRunDASH(t *testing.T) {
 }
 
 func TestRunExample(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -59,6 +66,9 @@ func TestRunExample(t *testing.T) {
 }
 
 func TestRunNdt7(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("ndt7")
@@ -72,6 +82,9 @@ func TestRunNdt7(t *testing.T) {
 }
 
 func TestRunPsiphon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("psiphon")
@@ -82,6 +95,9 @@ func TestRunPsiphon(t *testing.T) {
 }
 
 func TestRunSNIBlocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("sni_blocking")
@@ -92,6 +108,9 @@ func TestRunSNIBlocking(t *testing.T) {
 }
 
 func TestRunTelegram(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("telegram")
@@ -102,6 +121,9 @@ func TestRunTelegram(t *testing.T) {
 }
 
 func TestRunTor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("tor")
@@ -112,6 +134,9 @@ func TestRunTor(t *testing.T) {
 }
 
 func TestNeedsInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("web_connectivity")
@@ -124,6 +149,9 @@ func TestNeedsInput(t *testing.T) {
 }
 
 func TestSetCallbacks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -156,6 +184,9 @@ func (c *registerCallbacksCalled) OnProgress(percentage float64, message string)
 }
 
 func TestCreateInvalidExperiment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("antani")
@@ -168,6 +199,9 @@ func TestCreateInvalidExperiment(t *testing.T) {
 }
 
 func TestMeasurementFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -190,6 +224,9 @@ func TestMeasurementFailure(t *testing.T) {
 }
 
 func TestUseOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -269,6 +306,9 @@ func TestUseOptions(t *testing.T) {
 }
 
 func TestRunHHFM(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("http_header_field_manipulation")
@@ -322,6 +362,9 @@ func runexperimentflow(t *testing.T, experiment *Experiment, input string) {
 }
 
 func TestOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	t.Run("when config is not a pointer", func(t *testing.T) {
 		b := &ExperimentBuilder{
 			config: 17,
@@ -350,6 +393,9 @@ func TestOptions(t *testing.T) {
 }
 
 func TestSetOption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	t.Run("when config is not a pointer", func(t *testing.T) {
 		b := &ExperimentBuilder{
 			config: 17,
@@ -418,6 +464,9 @@ func TestSetOption(t *testing.T) {
 }
 
 func TestLoadMeasurement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -471,6 +520,9 @@ func TestLoadMeasurement(t *testing.T) {
 }
 
 func TestSaveMeasurementErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -517,6 +569,9 @@ func TestSaveMeasurementErrors(t *testing.T) {
 }
 
 func TestOpenReportIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -549,6 +604,9 @@ func TestOpenReportIdempotent(t *testing.T) {
 }
 
 func TestOpenReportFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(500)
@@ -573,6 +631,9 @@ func TestOpenReportFailure(t *testing.T) {
 }
 
 func TestOpenReportNewClientFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoBackendsLookup(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -591,6 +652,9 @@ func TestOpenReportNewClientFailure(t *testing.T) {
 }
 
 func TestSubmitAndUpdateMeasurementWithClosedReport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	builder, err := sess.NewExperimentBuilder("example")
@@ -606,6 +670,9 @@ func TestSubmitAndUpdateMeasurementWithClosedReport(t *testing.T) {
 }
 
 func TestMeasureLookupLocationFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	exp := NewExperiment(sess, new(antaniMeasurer))
@@ -617,6 +684,9 @@ func TestMeasureLookupLocationFailure(t *testing.T) {
 }
 
 func TestOpenReportNonHTTPS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	sess.availableProbeServices = []model.Service{

--- a/internal/httpx/jsonapi_test.go
+++ b/internal/httpx/jsonapi_test.go
@@ -215,7 +215,7 @@ type httpbinheaders struct {
 	Headers map[string]string `json:"headers"`
 }
 
-func TestIntegrationReadJSONSuccess(t *testing.T) {
+func TestReadJSONSuccess(t *testing.T) {
 	var headers httpbinheaders
 	err := newClient().GetJSON(context.Background(), "/headers", &headers)
 	if err != nil {
@@ -233,7 +233,7 @@ type httpbinpost struct {
 	Data string `json:"data"`
 }
 
-func TestIntegrationCreateJSONSuccess(t *testing.T) {
+func TestCreateJSONSuccess(t *testing.T) {
 	headers := httpbinheaders{
 		Headers: map[string]string{
 			"Foo": "bar",
@@ -253,7 +253,7 @@ type httpbinput struct {
 	Data string `json:"data"`
 }
 
-func TestIntegrationUpdateJSONSuccess(t *testing.T) {
+func TestUpdateJSONSuccess(t *testing.T) {
 	headers := httpbinheaders{
 		Headers: map[string]string{
 			"Foo": "bar",
@@ -269,7 +269,7 @@ func TestIntegrationUpdateJSONSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitReadJSONFailure(t *testing.T) {
+func TestReadJSONFailure(t *testing.T) {
 	var headers httpbinheaders
 	client := newClient()
 	client.BaseURL = "\t\t\t\t"
@@ -279,7 +279,7 @@ func TestUnitReadJSONFailure(t *testing.T) {
 	}
 }
 
-func TestUnitCreateJSONFailure(t *testing.T) {
+func TestCreateJSONFailure(t *testing.T) {
 	var headers httpbinheaders
 	client := newClient()
 	client.BaseURL = "\t\t\t\t"
@@ -289,7 +289,7 @@ func TestUnitCreateJSONFailure(t *testing.T) {
 	}
 }
 
-func TestUnitUpdateJSONFailure(t *testing.T) {
+func TestUpdateJSONFailure(t *testing.T) {
 	var headers httpbinheaders
 	client := newClient()
 	client.BaseURL = "\t\t\t\t"

--- a/internal/humanizex/humanizex_test.go
+++ b/internal/humanizex/humanizex_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ooni/probe-engine/internal/humanizex"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	if humanizex.SI(128, "bit/s") != "128  bit/s" {
 		t.Fatal("unexpected result")
 	}

--- a/internal/kvstore/kvstore_test.go
+++ b/internal/kvstore/kvstore_test.go
@@ -2,7 +2,7 @@ package kvstore
 
 import "testing"
 
-func TestUnitNoSuchKey(t *testing.T) {
+func TestNoSuchKey(t *testing.T) {
 	kvs := NewMemoryKeyValueStore()
 	value, err := kvs.Get("nonexistent")
 	if err == nil {
@@ -13,7 +13,7 @@ func TestUnitNoSuchKey(t *testing.T) {
 	}
 }
 
-func TestUnitExistingKey(t *testing.T) {
+func TestExistingKey(t *testing.T) {
 	kvs := NewMemoryKeyValueStore()
 	if err := kvs.Set("antani", []byte("mascetti")); err != nil {
 		t.Fatal(err)

--- a/internal/mlablocate/mlablocate_test.go
+++ b/internal/mlablocate/mlablocate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/internal/mlablocate"
 )
 
-func TestIntegrationWithoutProxy(t *testing.T) {
+func TestWithoutProxy(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,
 		log.Log,
@@ -27,7 +27,7 @@ func TestIntegrationWithoutProxy(t *testing.T) {
 	}
 }
 
-func TestIntegration404Response(t *testing.T) {
+func Test404Response(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,
 		log.Log,
@@ -42,7 +42,7 @@ func TestIntegration404Response(t *testing.T) {
 	}
 }
 
-func TestUnitNewRequestFailure(t *testing.T) {
+func TestNewRequestFailure(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,
 		log.Log,
@@ -58,7 +58,7 @@ func TestUnitNewRequestFailure(t *testing.T) {
 	}
 }
 
-func TestUnitHTTPClientDoFailure(t *testing.T) {
+func TestHTTPClientDoFailure(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,
 		log.Log,
@@ -85,7 +85,7 @@ func (txp *roundTripFails) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, txp.Error
 }
 
-func TestUnitCannotReadBody(t *testing.T) {
+func TestCannotReadBody(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,
 		log.Log,
@@ -127,7 +127,7 @@ func (b *readingBodyFailsBody) Close() error {
 	return nil
 }
 
-func TestUnitInvalidJSON(t *testing.T) {
+func TestInvalidJSON(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,
 		log.Log,
@@ -168,7 +168,7 @@ func (b *invalidJSONBody) Close() error {
 	return nil
 }
 
-func TestUnitEmptyFQDN(t *testing.T) {
+func TestEmptyFQDN(t *testing.T) {
 	client := mlablocate.NewClient(
 		http.DefaultClient,
 		log.Log,

--- a/internal/mlablocatev2/mlablocatev2_test.go
+++ b/internal/mlablocatev2/mlablocatev2_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/internal/mlablocatev2"
 )
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
@@ -47,7 +47,7 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegration404Response(t *testing.T) {
+func Test404Response(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip test in short mode")
 	}
@@ -61,7 +61,7 @@ func TestIntegration404Response(t *testing.T) {
 	}
 }
 
-func TestUnitNewRequestFailure(t *testing.T) {
+func TestNewRequestFailure(t *testing.T) {
 	client := mlablocatev2.NewClient(http.DefaultClient, log.Log, "miniooni/0.1.0-dev")
 	client.Hostname = "\t"
 	result, err := client.Query(context.Background(), "nonexistent")
@@ -73,7 +73,7 @@ func TestUnitNewRequestFailure(t *testing.T) {
 	}
 }
 
-func TestUnitHTTPClientDoFailure(t *testing.T) {
+func TestHTTPClientDoFailure(t *testing.T) {
 	client := mlablocatev2.NewClient(http.DefaultClient, log.Log, "miniooni/0.1.0-dev")
 	expected := errors.New("mocked error")
 	client.HTTPClient = &http.Client{
@@ -88,7 +88,7 @@ func TestUnitHTTPClientDoFailure(t *testing.T) {
 	}
 }
 
-func TestUnitCannotReadBody(t *testing.T) {
+func TestCannotReadBody(t *testing.T) {
 	client := mlablocatev2.NewClient(http.DefaultClient, log.Log, "miniooni/0.1.0-dev")
 	expected := errors.New("mocked error")
 	client.HTTPClient = &http.Client{
@@ -110,7 +110,7 @@ func TestUnitCannotReadBody(t *testing.T) {
 	}
 }
 
-func TestUnitInvalidJSON(t *testing.T) {
+func TestInvalidJSON(t *testing.T) {
 	client := mlablocatev2.NewClient(http.DefaultClient, log.Log, "miniooni/0.1.0-dev")
 	client.HTTPClient = &http.Client{
 		Transport: mlablocatev2.FakeTransport{
@@ -132,7 +132,7 @@ func TestUnitInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestUnitEmptyResponse(t *testing.T) {
+func TestEmptyResponse(t *testing.T) {
 	client := mlablocatev2.NewClient(http.DefaultClient, log.Log, "miniooni/0.1.0-dev")
 	client.HTTPClient = &http.Client{
 		Transport: mlablocatev2.FakeTransport{
@@ -154,7 +154,7 @@ func TestUnitEmptyResponse(t *testing.T) {
 	}
 }
 
-func TestUnitNDT7QueryFails(t *testing.T) {
+func TestNDT7QueryFails(t *testing.T) {
 	client := mlablocatev2.NewClient(http.DefaultClient, log.Log, "miniooni/0.1.0-dev")
 	client.HTTPClient = &http.Client{
 		Transport: mlablocatev2.FakeTransport{
@@ -173,7 +173,7 @@ func TestUnitNDT7QueryFails(t *testing.T) {
 	}
 }
 
-func TestUnitNDT7InvalidURLs(t *testing.T) {
+func TestNDT7InvalidURLs(t *testing.T) {
 	client := mlablocatev2.NewClient(http.DefaultClient, log.Log, "miniooni/0.1.0-dev")
 	client.HTTPClient = &http.Client{
 		Transport: mlablocatev2.FakeTransport{
@@ -196,7 +196,7 @@ func TestUnitNDT7InvalidURLs(t *testing.T) {
 	}
 }
 
-func TestUnitEntryRecordSite(t *testing.T) {
+func TestEntryRecordSite(t *testing.T) {
 	type fields struct {
 		Machine string
 		URLs    map[string]string

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	var expected bool
 	switch Name() {
 	case "android", "ios", "linux", "macos", "windows":
@@ -16,7 +16,7 @@ func TestIntegration(t *testing.T) {
 	}
 }
 
-func TestUnitPuregoname(t *testing.T) {
+func TestPuregoname(t *testing.T) {
 	var runtimevariables = []struct {
 		expected string
 		goarch   string

--- a/internal/psiphonx/psiphonx_test.go
+++ b/internal/psiphonx/psiphonx_test.go
@@ -34,9 +34,9 @@ func TestStartWithCancelledContext(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartStop(t *testing.T) {
+func TestStartStop(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	sess, err := engine.NewSession(engine.SessionConfig{
 		AssetsDir:       "../../testdata",
@@ -60,7 +60,7 @@ func TestIntegrationStartStop(t *testing.T) {
 	tunnel.Stop()
 }
 
-func TestUnitNewOrchestraClientFailure(t *testing.T) {
+func TestNewOrchestraClientFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	sess := &mockable.Session{
 		MockableOrchestraClientError: expected,
@@ -74,7 +74,7 @@ func TestUnitNewOrchestraClientFailure(t *testing.T) {
 	}
 }
 
-func TestUnitFetchPsiphonConfigFailure(t *testing.T) {
+func TestFetchPsiphonConfigFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	clnt := mockable.ExperimentOrchestraClient{
 		MockableFetchPsiphonConfigErr: expected,
@@ -91,7 +91,7 @@ func TestUnitFetchPsiphonConfigFailure(t *testing.T) {
 	}
 }
 
-func TestUnitMakeMkdirAllFailure(t *testing.T) {
+func TestMakeMkdirAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	dependencies := FakeDependencies{
 		MkdirAllErr: expected,
@@ -113,7 +113,7 @@ func TestUnitMakeMkdirAllFailure(t *testing.T) {
 	}
 }
 
-func TestUnitMakeRemoveAllFailure(t *testing.T) {
+func TestMakeRemoveAllFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	dependencies := FakeDependencies{
 		RemoveAllErr: expected,
@@ -135,7 +135,7 @@ func TestUnitMakeRemoveAllFailure(t *testing.T) {
 	}
 }
 
-func TestUnitMakeStartFailure(t *testing.T) {
+func TestMakeStartFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	dependencies := FakeDependencies{
 		StartErr: expected,
@@ -157,7 +157,7 @@ func TestUnitMakeStartFailure(t *testing.T) {
 	}
 }
 
-func TestUnitNilTunnel(t *testing.T) {
+func TestNilTunnel(t *testing.T) {
 	var tunnel *psiphonx.Tunnel
 	if tunnel.BootstrapTime() != 0 {
 		t.Fatal("expected zero bootstrap time")

--- a/internal/sessionresolver/sessionresolver_test.go
+++ b/internal/sessionresolver/sessionresolver_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ooni/probe-engine/netx"
 )
 
-func TestIntegrationFallbackWorks(t *testing.T) {
+func TestFallbackWorks(t *testing.T) {
 	reso := sessionresolver.New(netx.Config{})
 	defer reso.CloseIdleConnections()
 	if reso.Network() != "sessionresolver" {

--- a/legacy/netx/connid/connid_test.go
+++ b/legacy/netx/connid/connid_test.go
@@ -2,77 +2,77 @@ package connid
 
 import "testing"
 
-func TestIntegrationTCP(t *testing.T) {
+func TestTCP(t *testing.T) {
 	num := Compute("tcp", "1.2.3.4:6789")
 	if num != 6789 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationTCP4(t *testing.T) {
+func TestTCP4(t *testing.T) {
 	num := Compute("tcp4", "130.192.91.211:34566")
 	if num != 34566 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationTCP6(t *testing.T) {
+func TestTCP6(t *testing.T) {
 	num := Compute("tcp4", "[::1]:4444")
 	if num != 4444 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationUDP(t *testing.T) {
+func TestUDP(t *testing.T) {
 	num := Compute("udp", "1.2.3.4:6789")
 	if num != -6789 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationUDP4(t *testing.T) {
+func TestUDP4(t *testing.T) {
 	num := Compute("udp4", "130.192.91.211:34566")
 	if num != -34566 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationUDP6(t *testing.T) {
+func TestUDP6(t *testing.T) {
 	num := Compute("udp6", "[::1]:4444")
 	if num != -4444 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationInvalidAddress(t *testing.T) {
+func TestInvalidAddress(t *testing.T) {
 	num := Compute("udp6", "[::1]")
 	if num != 0 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationInvalidPort(t *testing.T) {
+func TestInvalidPort(t *testing.T) {
 	num := Compute("udp6", "[::1]:antani")
 	if num != 0 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationNegativePort(t *testing.T) {
+func TestNegativePort(t *testing.T) {
 	num := Compute("udp6", "[::1]:-1")
 	if num != 0 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationLargePort(t *testing.T) {
+func TestLargePort(t *testing.T) {
 	num := Compute("udp6", "[::1]:65536")
 	if num != 0 {
 		t.Fatal("unexpected result")
 	}
 }
 
-func TestIntegrationInvalidNetwork(t *testing.T) {
+func TestInvalidNetwork(t *testing.T) {
 	num := Compute("unix", "[::1]:65531")
 	if num != 0 {
 		t.Fatal("unexpected result")

--- a/legacy/netx/dialer_test.go
+++ b/legacy/netx/dialer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx"
 )
 
-func TestIntegrationDialerDial(t *testing.T) {
+func TestDialerDial(t *testing.T) {
 	dialer := netx.NewDialer()
 	conn, err := dialer.Dial("tcp", "www.google.com:80")
 	if err != nil {
@@ -17,7 +17,7 @@ func TestIntegrationDialerDial(t *testing.T) {
 	conn.Close()
 }
 
-func TestIntegrationDialerDialWithCustomResolver(t *testing.T) {
+func TestDialerDialWithCustomResolver(t *testing.T) {
 	dialer := netx.NewDialer()
 	resolver, err := netx.NewResolver("tcp", "1.1.1.1:53")
 	if err != nil {
@@ -31,7 +31,7 @@ func TestIntegrationDialerDialWithCustomResolver(t *testing.T) {
 	conn.Close()
 }
 
-func TestIntegrationDialerDialWithConfigureDNS(t *testing.T) {
+func TestDialerDialWithConfigureDNS(t *testing.T) {
 	dialer := netx.NewDialer()
 	err := dialer.ConfigureDNS("tcp", "1.1.1.1:53")
 	if err != nil {
@@ -44,7 +44,7 @@ func TestIntegrationDialerDialWithConfigureDNS(t *testing.T) {
 	conn.Close()
 }
 
-func TestIntegrationDialerDialTLS(t *testing.T) {
+func TestDialerDialTLS(t *testing.T) {
 	dialer := netx.NewDialer()
 	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
 	if err != nil {
@@ -53,7 +53,7 @@ func TestIntegrationDialerDialTLS(t *testing.T) {
 	conn.Close()
 }
 
-func TestIntegrationDialerDialTLSForceSkipVerify(t *testing.T) {
+func TestDialerDialTLSForceSkipVerify(t *testing.T) {
 	dialer := netx.NewDialer()
 	dialer.ForceSkipVerify()
 	conn, err := dialer.DialTLS("tcp", "self-signed.badssl.com:443")
@@ -63,7 +63,7 @@ func TestIntegrationDialerDialTLSForceSkipVerify(t *testing.T) {
 	conn.Close()
 }
 
-func TestIntegrationDialerSetCABundleNonexisting(t *testing.T) {
+func TestDialerSetCABundleNonexisting(t *testing.T) {
 	dialer := netx.NewDialer()
 	err := dialer.SetCABundle("testdata/cacert-nonexistent.pem")
 	if err == nil {
@@ -71,7 +71,7 @@ func TestIntegrationDialerSetCABundleNonexisting(t *testing.T) {
 	}
 }
 
-func TestIntegrationDialerSetCABundleInvalid(t *testing.T) {
+func TestDialerSetCABundleInvalid(t *testing.T) {
 	dialer := netx.NewDialer()
 	err := dialer.SetCABundle("testdata/cacert-invalid.pem")
 	if err == nil {
@@ -79,7 +79,7 @@ func TestIntegrationDialerSetCABundleInvalid(t *testing.T) {
 	}
 }
 
-func TestIntegrationDialerSetCABundleWAI(t *testing.T) {
+func TestDialerSetCABundleWAI(t *testing.T) {
 	dialer := netx.NewDialer()
 	err := dialer.SetCABundle("testdata/cacert.pem")
 	if err != nil {
@@ -98,7 +98,7 @@ func TestIntegrationDialerSetCABundleWAI(t *testing.T) {
 	}
 }
 
-func TestIntegrationDialerForceSpecificSNI(t *testing.T) {
+func TestDialerForceSpecificSNI(t *testing.T) {
 	dialer := netx.NewDialer()
 	err := dialer.ForceSpecificSNI("www.facebook.com")
 	conn, err := dialer.DialTLS("tcp", "www.google.com:443")

--- a/legacy/netx/dialid/dialid_test.go
+++ b/legacy/netx/dialid/dialid_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	ctx := context.Background()
 	id := ContextDialID(ctx)
 	if id != 0 {

--- a/legacy/netx/handlers/handlers_test.go
+++ b/legacy/netx/handlers/handlers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	handlers.NoHandler.OnMeasurement(modelx.Measurement{})
 	handlers.StdoutHandler.OnMeasurement(modelx.Measurement{})
 	saver := handlers.SavingHandler{}

--- a/legacy/netx/http_test.go
+++ b/legacy/netx/http_test.go
@@ -30,18 +30,18 @@ func dowithclient(t *testing.T, client *netx.HTTPClient) {
 	}
 }
 
-func TestIntegrationHTTPClient(t *testing.T) {
+func TestHTTPClient(t *testing.T) {
 	client := netx.NewHTTPClient()
 	dowithclient(t, client)
 }
 
-func TestIntegrationHTTPClientAndTransport(t *testing.T) {
+func TestHTTPClientAndTransport(t *testing.T) {
 	client := netx.NewHTTPClient()
 	client.Transport = netx.NewHTTPTransport()
 	dowithclient(t, client)
 }
 
-func TestIntegrationHTTPClientConfigureDNS(t *testing.T) {
+func TestHTTPClientConfigureDNS(t *testing.T) {
 	client := netx.NewHTTPClientWithoutProxy()
 	err := client.ConfigureDNS("udp", "1.1.1.1:53")
 	if err != nil {
@@ -50,13 +50,13 @@ func TestIntegrationHTTPClientConfigureDNS(t *testing.T) {
 	dowithclient(t, client)
 }
 
-func TestIntegrationHTTPClientSetResolver(t *testing.T) {
+func TestHTTPClientSetResolver(t *testing.T) {
 	client := netx.NewHTTPClientWithoutProxy()
 	client.SetResolver(new(net.Resolver))
 	dowithclient(t, client)
 }
 
-func TestIntegrationHTTPClientSetCABundle(t *testing.T) {
+func TestHTTPClientSetCABundle(t *testing.T) {
 	client := netx.NewHTTPClientWithoutProxy()
 	err := client.SetCABundle("testdata/cacert.pem")
 	if err != nil {
@@ -72,7 +72,7 @@ func TestIntegrationHTTPClientSetCABundle(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPClientForceSpecificSNI(t *testing.T) {
+func TestHTTPClientForceSpecificSNI(t *testing.T) {
 	client := netx.NewHTTPClientWithoutProxy()
 	err := client.ForceSpecificSNI("www.facebook.com")
 	if err != nil {
@@ -88,7 +88,7 @@ func TestIntegrationHTTPClientForceSpecificSNI(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPClientForceSkipVerify(t *testing.T) {
+func TestHTTPClientForceSkipVerify(t *testing.T) {
 	client := netx.NewHTTPClientWithoutProxy()
 	client.ForceSkipVerify()
 	resp, err := client.HTTPClient.Get("https://self-signed.badssl.com/")
@@ -135,7 +135,7 @@ func httpProxyTestMain(t *testing.T, client *http.Client, expect int) {
 	}
 }
 
-func TestIntegrationHTTPTransportTimeout(t *testing.T) {
+func TestHTTPTransportTimeout(t *testing.T) {
 	client := &http.Client{Transport: netx.NewHTTPTransport()}
 	req, err := http.NewRequest("GET", "https://www.google.com", nil)
 	if err != nil {
@@ -156,7 +156,7 @@ func TestIntegrationHTTPTransportTimeout(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPTransportFailure(t *testing.T) {
+func TestHTTPTransportFailure(t *testing.T) {
 	client := &http.Client{Transport: netx.NewHTTPTransport()}
 	// This fails the request because we attempt to speak cleartext HTTP with
 	// a server that instead is expecting TLS.

--- a/legacy/netx/modelx/modelx_test.go
+++ b/legacy/netx/modelx/modelx_test.go
@@ -73,7 +73,7 @@ func TestErrWrapperPublicAPI(t *testing.T) {
 	}
 }
 
-func TestUnitComputeBodySnapSize(t *testing.T) {
+func TestComputeBodySnapSize(t *testing.T) {
 	if ComputeBodySnapSize(-1) != math.MaxInt64 {
 		t.Fatal("unexpected result")
 	}

--- a/legacy/netx/oldhttptransport/bodytracer_test.go
+++ b/legacy/netx/oldhttptransport/bodytracer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestIntegrationBodyTracerSuccess(t *testing.T) {
+func TestBodyTracerSuccess(t *testing.T) {
 	client := &http.Client{
 		Transport: NewBodyTracer(http.DefaultTransport),
 	}
@@ -22,7 +22,7 @@ func TestIntegrationBodyTracerSuccess(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationBodyTracerFailure(t *testing.T) {
+func TestBodyTracerFailure(t *testing.T) {
 	client := &http.Client{
 		Transport: NewBodyTracer(http.DefaultTransport),
 	}

--- a/legacy/netx/oldhttptransport/httptransport_test.go
+++ b/legacy/netx/oldhttptransport/httptransport_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	client := &http.Client{
 		Transport: New(http.DefaultTransport),
 	}
@@ -22,7 +22,7 @@ func TestIntegration(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationFailure(t *testing.T) {
+func TestFailure(t *testing.T) {
 	client := &http.Client{
 		Transport: New(http.DefaultTransport),
 	}

--- a/legacy/netx/oldhttptransport/tracetripper_test.go
+++ b/legacy/netx/oldhttptransport/tracetripper_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
-func TestIntegrationTraceTripperSuccess(t *testing.T) {
+func TestTraceTripperSuccess(t *testing.T) {
 	client := &http.Client{
 		Transport: NewTraceTripper(http.DefaultTransport),
 	}
@@ -45,7 +45,7 @@ func (h *roundTripHandler) OnMeasurement(m modelx.Measurement) {
 	}
 }
 
-func TestIntegrationTraceTripperReadAllFailure(t *testing.T) {
+func TestTraceTripperReadAllFailure(t *testing.T) {
 	transport := NewTraceTripper(http.DefaultTransport)
 	transport.readAll = func(r io.Reader) ([]byte, error) {
 		return nil, io.EOF
@@ -67,7 +67,7 @@ func TestIntegrationTraceTripperReadAllFailure(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationTraceTripperFailure(t *testing.T) {
+func TestTraceTripperFailure(t *testing.T) {
 	client := &http.Client{
 		Transport: NewTraceTripper(http.DefaultTransport),
 	}
@@ -83,7 +83,7 @@ func TestIntegrationTraceTripperFailure(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationTraceTripperWithClientTrace(t *testing.T) {
+func TestTraceTripperWithClientTrace(t *testing.T) {
 	client := &http.Client{
 		Transport: NewTraceTripper(http.DefaultTransport),
 	}
@@ -105,7 +105,7 @@ func TestIntegrationTraceTripperWithClientTrace(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationTraceTripperWithCorrectSnaps(t *testing.T) {
+func TestTraceTripperWithCorrectSnaps(t *testing.T) {
 	// Prepare a DNS query for dns.google.com A, for which we
 	// know the answer in terms of well know IP addresses
 	query := new(dns.Msg)
@@ -209,7 +209,7 @@ func TestIntegrationTraceTripperWithCorrectSnaps(t *testing.T) {
 	}
 }
 
-func TestIntegrationTraceTripperWithReadAllFailingForBody(t *testing.T) {
+func TestTraceTripperWithReadAllFailingForBody(t *testing.T) {
 	// Prepare a DNS query for dns.google.com A, for which we
 	// know the answer in terms of well know IP addresses
 	query := new(dns.Msg)

--- a/legacy/netx/oldhttptransport/transactioner_test.go
+++ b/legacy/netx/oldhttptransport/transactioner_test.go
@@ -21,7 +21,7 @@ func (t *transactionerCheckTransactionID) RoundTrip(req *http.Request) (*http.Re
 	return t.roundTripper.RoundTrip(req)
 }
 
-func TestIntegrationTransactionerSuccess(t *testing.T) {
+func TestTransactionerSuccess(t *testing.T) {
 	client := &http.Client{
 		Transport: NewTransactioner(&transactionerCheckTransactionID{
 			roundTripper: http.DefaultTransport,
@@ -40,7 +40,7 @@ func TestIntegrationTransactionerSuccess(t *testing.T) {
 	client.CloseIdleConnections()
 }
 
-func TestIntegrationTransactionerFailure(t *testing.T) {
+func TestTransactionerFailure(t *testing.T) {
 	client := &http.Client{
 		Transport: NewTransactioner(http.DefaultTransport),
 	}

--- a/legacy/netx/resolver_test.go
+++ b/legacy/netx/resolver_test.go
@@ -38,75 +38,75 @@ func testresolverquick(t *testing.T, network, address string) {
 	}
 }
 
-func TestIntegrationNewResolverUDPAddress(t *testing.T) {
+func TestNewResolverUDPAddress(t *testing.T) {
 	testresolverquick(t, "udp", "8.8.8.8:53")
 }
 
-func TestIntegrationNewResolverUDPAddressNoPort(t *testing.T) {
+func TestNewResolverUDPAddressNoPort(t *testing.T) {
 	testresolverquick(t, "udp", "8.8.8.8")
 }
 
-func TestIntegrationNewResolverUDPDomain(t *testing.T) {
+func TestNewResolverUDPDomain(t *testing.T) {
 	testresolverquick(t, "udp", "dns.google.com:53")
 }
 
-func TestIntegrationNewResolverUDPDomainNoPort(t *testing.T) {
+func TestNewResolverUDPDomainNoPort(t *testing.T) {
 	testresolverquick(t, "udp", "dns.google.com")
 }
 
-func TestIntegrationNewResolverSystem(t *testing.T) {
+func TestNewResolverSystem(t *testing.T) {
 	testresolverquick(t, "system", "")
 }
 
-func TestIntegrationNewResolverTCPAddress(t *testing.T) {
+func TestNewResolverTCPAddress(t *testing.T) {
 	testresolverquick(t, "tcp", "8.8.8.8:53")
 }
 
-func TestIntegrationNewResolverTCPAddressNoPort(t *testing.T) {
+func TestNewResolverTCPAddressNoPort(t *testing.T) {
 	testresolverquick(t, "tcp", "8.8.8.8")
 }
 
-func TestIntegrationNewResolverTCPDomain(t *testing.T) {
+func TestNewResolverTCPDomain(t *testing.T) {
 	testresolverquick(t, "tcp", "dns.google.com:53")
 }
 
-func TestIntegrationNewResolverTCPDomainNoPort(t *testing.T) {
+func TestNewResolverTCPDomainNoPort(t *testing.T) {
 	testresolverquick(t, "tcp", "dns.google.com")
 }
 
-func TestIntegrationNewResolverDoTAddress(t *testing.T) {
+func TestNewResolverDoTAddress(t *testing.T) {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		t.Skip("this test is not reliable in GitHub actions")
 	}
 	testresolverquick(t, "dot", "9.9.9.9:853")
 }
 
-func TestIntegrationNewResolverDoTAddressNoPort(t *testing.T) {
+func TestNewResolverDoTAddressNoPort(t *testing.T) {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		t.Skip("this test is not reliable in GitHub actions")
 	}
 	testresolverquick(t, "dot", "9.9.9.9")
 }
 
-func TestIntegrationNewResolverDoTDomain(t *testing.T) {
+func TestNewResolverDoTDomain(t *testing.T) {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		t.Skip("this test is not reliable in GitHub actions")
 	}
 	testresolverquick(t, "dot", "dns.quad9.net:853")
 }
 
-func TestIntegrationNewResolverDoTDomainNoPort(t *testing.T) {
+func TestNewResolverDoTDomainNoPort(t *testing.T) {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		t.Skip("this test is not reliable in GitHub actions")
 	}
 	testresolverquick(t, "dot", "dns.quad9.net")
 }
 
-func TestIntegrationNewResolverDoH(t *testing.T) {
+func TestNewResolverDoH(t *testing.T) {
 	testresolverquick(t, "doh", "https://cloudflare-dns.com/dns-query")
 }
 
-func TestIntegrationNewResolverInvalid(t *testing.T) {
+func TestNewResolverInvalid(t *testing.T) {
 	resolver, err := netx.NewResolver(
 		"antani", "https://cloudflare-dns.com/dns-query",
 	)
@@ -124,7 +124,7 @@ func (failingResolver) LookupHost(ctx context.Context, hostname string) ([]strin
 	return nil, io.EOF
 }
 
-func TestIntegrationChainResolvers(t *testing.T) {
+func TestChainResolvers(t *testing.T) {
 	fallback, err := netx.NewResolver("udp", "1.1.1.1:53")
 	if err != nil {
 		t.Fatal(err)
@@ -139,7 +139,7 @@ func TestIntegrationChainResolvers(t *testing.T) {
 	defer conn.Close()
 }
 
-func TestUnitNewHTTPClientForDoH(t *testing.T) {
+func TestNewHTTPClientForDoH(t *testing.T) {
 	first := netx.NewHTTPClientForDoH(
 		time.Now(), handlers.NoHandler,
 	)
@@ -157,7 +157,7 @@ func TestUnitNewHTTPClientForDoH(t *testing.T) {
 	}
 }
 
-func TestUnitChainWrapperResolver(t *testing.T) {
+func TestChainWrapperResolver(t *testing.T) {
 	r := netx.ChainWrapperResolver{}
 	if r.Address() != "" {
 		t.Fatal("invalid Address")

--- a/legacy/netx/transactionid/transactionid_test.go
+++ b/legacy/netx/transactionid/transactionid_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	ctx := context.Background()
 	id := ContextTransactionID(ctx)
 	if id != 0 {

--- a/legacy/netxlogger/netxlogger_test.go
+++ b/legacy/netxlogger/netxlogger_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/legacy/netx/modelx"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	log.SetHandler(discard.Default)
 	client := netx.NewHTTPClient()
 	client.ConfigureDNS("udp", "dns.google.com:53")

--- a/legacy/oonidatamodel/oonidatamodel_test.go
+++ b/legacy/oonidatamodel/oonidatamodel_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/ooni/probe-engine/netx/errorx"
 )
 
-func TestUnitNewTCPConnectListEmpty(t *testing.T) {
+func TestNewTCPConnectListEmpty(t *testing.T) {
 	out := NewTCPConnectList(oonitemplates.Results{})
 	if len(out) != 0 {
 		t.Fatal("unexpected output length")
 	}
 }
 
-func TestUnitNewTCPConnectListSuccess(t *testing.T) {
+func TestNewTCPConnectListSuccess(t *testing.T) {
 	out := NewTCPConnectList(oonitemplates.Results{
 		Connects: []*modelx.ConnectEvent{
 			{
@@ -62,7 +62,7 @@ func TestUnitNewTCPConnectListSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitNewTCPConnectListFailure(t *testing.T) {
+func TestNewTCPConnectListFailure(t *testing.T) {
 	out := NewTCPConnectList(oonitemplates.Results{
 		Connects: []*modelx.ConnectEvent{
 			{
@@ -88,7 +88,7 @@ func TestUnitNewTCPConnectListFailure(t *testing.T) {
 	}
 }
 
-func TestUnitNewTCPConnectListInvalidInput(t *testing.T) {
+func TestNewTCPConnectListInvalidInput(t *testing.T) {
 	out := NewTCPConnectList(oonitemplates.Results{
 		Connects: []*modelx.ConnectEvent{
 			{
@@ -114,14 +114,14 @@ func TestUnitNewTCPConnectListInvalidInput(t *testing.T) {
 	}
 }
 
-func TestUnitNewRequestsListEmptyList(t *testing.T) {
+func TestNewRequestsListEmptyList(t *testing.T) {
 	out := NewRequestList(oonitemplates.Results{})
 	if len(out) != 0 {
 		t.Fatal("unexpected output length")
 	}
 }
 
-func TestUnitNewRequestsListGood(t *testing.T) {
+func TestNewRequestsListGood(t *testing.T) {
 	out := NewRequestList(oonitemplates.Results{
 		HTTPRequests: []*modelx.HTTPRoundTripDoneEvent{
 			// need two requests to test that order is inverted
@@ -326,7 +326,7 @@ func TestUnitNewRequestsListGood(t *testing.T) {
 	}
 }
 
-func TestUnitNewRequestsSnaps(t *testing.T) {
+func TestNewRequestsSnaps(t *testing.T) {
 	out := NewRequestList(oonitemplates.Results{
 		HTTPRequests: []*modelx.HTTPRoundTripDoneEvent{
 			{
@@ -401,7 +401,7 @@ func TestMarshalUnmarshalHTTPBodyBinary(t *testing.T) {
 	}
 }
 
-func TestUnitMaybeBinaryValueUnmarshalJSON(t *testing.T) {
+func TestMaybeBinaryValueUnmarshalJSON(t *testing.T) {
 	t.Run("when the code is not a map or string", func(t *testing.T) {
 		var (
 			mbv   MaybeBinaryValue
@@ -529,7 +529,7 @@ func TestMarshalUnmarshalHTTPHeaderBinary(t *testing.T) {
 	}
 }
 
-func TestUnitHTTPHeaderUnmarshalJSON(t *testing.T) {
+func TestHTTPHeaderUnmarshalJSON(t *testing.T) {
 	t.Run("when the code is not a list", func(t *testing.T) {
 		var (
 			hh    HTTPHeader
@@ -631,14 +631,14 @@ func TestUnitHTTPHeaderUnmarshalJSON(t *testing.T) {
 	})
 }
 
-func TestUnitNewDNSQueriesListEmpty(t *testing.T) {
+func TestNewDNSQueriesListEmpty(t *testing.T) {
 	out := NewDNSQueriesList(oonitemplates.Results{})
 	if len(out) != 0 {
 		t.Fatal("unexpected output length")
 	}
 }
 
-func TestUnitNewDNSQueriesListSuccess(t *testing.T) {
+func TestNewDNSQueriesListSuccess(t *testing.T) {
 	out := NewDNSQueriesList(oonitemplates.Results{
 		Resolves: []*modelx.ResolveDoneEvent{
 			{
@@ -791,21 +791,21 @@ func dnscheckbad(e DNSQueryEntry) error {
 	return nil
 }
 
-func TestUnitDNSQueryTypeIPOfType(t *testing.T) {
+func TestDNSQueryTypeIPOfType(t *testing.T) {
 	qtype := dnsQueryType("ANTANI")
 	if qtype.ipoftype("8.8.8.8") == true {
 		t.Fatal("ipoftype misbehaving")
 	}
 }
 
-func TestUnitNewNetworkEventsListEmpty(t *testing.T) {
+func TestNewNetworkEventsListEmpty(t *testing.T) {
 	out := NewNetworkEventsList(oonitemplates.Results{})
 	if len(out) != 0 {
 		t.Fatal("unexpected output length")
 	}
 }
 
-func TestUnitNewNetworkEventsListNoSuitableEvents(t *testing.T) {
+func TestNewNetworkEventsListNoSuitableEvents(t *testing.T) {
 	out := NewNetworkEventsList(oonitemplates.Results{
 		NetworkEvents: []*modelx.Measurement{
 			{},
@@ -818,7 +818,7 @@ func TestUnitNewNetworkEventsListNoSuitableEvents(t *testing.T) {
 	}
 }
 
-func TestUnitNewNetworkEventsListGood(t *testing.T) {
+func TestNewNetworkEventsListGood(t *testing.T) {
 	out := NewNetworkEventsList(oonitemplates.Results{
 		NetworkEvents: []*modelx.Measurement{
 			{
@@ -925,7 +925,7 @@ func TestUnitNewNetworkEventsListGood(t *testing.T) {
 	}
 }
 
-func TestUnitNewNetworkEventsListGoodUDPAndErrors(t *testing.T) {
+func TestNewNetworkEventsListGoodUDPAndErrors(t *testing.T) {
 	out := NewNetworkEventsList(oonitemplates.Results{
 		NetworkEvents: []*modelx.Measurement{
 			{
@@ -1040,14 +1040,14 @@ func floatEquals(a, b float64) bool {
 	return (a-b) < c && (b-a) < c
 }
 
-func TestUnitNewTLSHandshakesListEmpty(t *testing.T) {
+func TestNewTLSHandshakesListEmpty(t *testing.T) {
 	out := NewTLSHandshakesList(oonitemplates.Results{})
 	if len(out) != 0 {
 		t.Fatal("unexpected output length")
 	}
 }
 
-func TestUnitNewTLSHandshakesListSuccess(t *testing.T) {
+func TestNewTLSHandshakesListSuccess(t *testing.T) {
 	out := NewTLSHandshakesList(oonitemplates.Results{
 		TLSHandshakes: []*modelx.TLSHandshakeDoneEvent{
 			{},

--- a/legacy/oonitemplates/oonitemplates_test.go
+++ b/legacy/oonitemplates/oonitemplates_test.go
@@ -16,7 +16,7 @@ import (
 	obfs4base "gitlab.com/yawning/obfs4.git/transports/base"
 )
 
-func TestUnitChannelHandlerWriteLateOnChannel(t *testing.T) {
+func TestChannelHandlerWriteLateOnChannel(t *testing.T) {
 	handler := newChannelHandler(make(chan modelx.Measurement))
 	var waitgroup sync.WaitGroup
 	waitgroup.Add(1)
@@ -31,7 +31,7 @@ func TestUnitChannelHandlerWriteLateOnChannel(t *testing.T) {
 	}
 }
 
-func TestIntegrationDNSLookupGood(t *testing.T) {
+func TestDNSLookupGood(t *testing.T) {
 	ctx := context.Background()
 	results := DNSLookup(ctx, DNSLookupConfig{
 		Hostname: "ooni.io",
@@ -44,7 +44,7 @@ func TestIntegrationDNSLookupGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationDNSLookupCancellation(t *testing.T) {
+func TestDNSLookupCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(), time.Microsecond,
 	)
@@ -63,7 +63,7 @@ func TestIntegrationDNSLookupCancellation(t *testing.T) {
 	}
 }
 
-func TestIntegrationDNSLookupUnknownDNS(t *testing.T) {
+func TestDNSLookupUnknownDNS(t *testing.T) {
 	ctx := context.Background()
 	results := DNSLookup(ctx, DNSLookupConfig{
 		Hostname:      "ooni.io",
@@ -74,7 +74,7 @@ func TestIntegrationDNSLookupUnknownDNS(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPDoGood(t *testing.T) {
+func TestHTTPDoGood(t *testing.T) {
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{
 		Accept:         "*/*",
@@ -95,7 +95,7 @@ func TestIntegrationHTTPDoGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPDoUnknownDNS(t *testing.T) {
+func TestHTTPDoUnknownDNS(t *testing.T) {
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{
 		URL:              "http://ooni.io",
@@ -106,7 +106,7 @@ func TestIntegrationHTTPDoUnknownDNS(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPDoForceSkipVerify(t *testing.T) {
+func TestHTTPDoForceSkipVerify(t *testing.T) {
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{
 		URL:                "https://self-signed.badssl.com/",
@@ -117,7 +117,7 @@ func TestIntegrationHTTPDoForceSkipVerify(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPDoRoundTripError(t *testing.T) {
+func TestHTTPDoRoundTripError(t *testing.T) {
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{
 		URL: "http://ooni.io:443", // 443 with http
@@ -127,7 +127,7 @@ func TestIntegrationHTTPDoRoundTripError(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPDoBadURL(t *testing.T) {
+func TestHTTPDoBadURL(t *testing.T) {
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{
 		URL: "\t",
@@ -137,7 +137,7 @@ func TestIntegrationHTTPDoBadURL(t *testing.T) {
 	}
 }
 
-func TestIntegrationTLSConnectGood(t *testing.T) {
+func TestTLSConnectGood(t *testing.T) {
 	ctx := context.Background()
 	results := TLSConnect(ctx, TLSConnectConfig{
 		Address: "ooni.io:443",
@@ -147,7 +147,7 @@ func TestIntegrationTLSConnectGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationTLSConnectGoodWithDoT(t *testing.T) {
+func TestTLSConnectGoodWithDoT(t *testing.T) {
 	ctx := context.Background()
 	results := TLSConnect(ctx, TLSConnectConfig{
 		Address:          "ooni.io:443",
@@ -159,7 +159,7 @@ func TestIntegrationTLSConnectGoodWithDoT(t *testing.T) {
 	}
 }
 
-func TestIntegrationTLSConnectCancellation(t *testing.T) {
+func TestTLSConnectCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(), time.Microsecond,
 	)
@@ -175,7 +175,7 @@ func TestIntegrationTLSConnectCancellation(t *testing.T) {
 	}
 }
 
-func TestIntegrationTLSConnectUnknownDNS(t *testing.T) {
+func TestTLSConnectUnknownDNS(t *testing.T) {
 	ctx := context.Background()
 	results := TLSConnect(ctx, TLSConnectConfig{
 		Address:          "ooni.io:443",
@@ -186,7 +186,7 @@ func TestIntegrationTLSConnectUnknownDNS(t *testing.T) {
 	}
 }
 
-func TestIntegrationTLSConnectForceSkipVerify(t *testing.T) {
+func TestTLSConnectForceSkipVerify(t *testing.T) {
 	ctx := context.Background()
 	results := TLSConnect(ctx, TLSConnectConfig{
 		Address:            "self-signed.badssl.com:443",
@@ -197,7 +197,7 @@ func TestIntegrationTLSConnectForceSkipVerify(t *testing.T) {
 	}
 }
 
-func TestIntegrationBodySnapSizes(t *testing.T) {
+func TestBodySnapSizes(t *testing.T) {
 	const (
 		maxEventsBodySnapSize   = 1 << 7
 		maxResponseBodySnapSize = 1 << 8
@@ -233,7 +233,7 @@ func TestIntegrationBodySnapSizes(t *testing.T) {
 	}
 }
 
-func TestIntegrationTCPConnectGood(t *testing.T) {
+func TestTCPConnectGood(t *testing.T) {
 	ctx := context.Background()
 	results := TCPConnect(ctx, TCPConnectConfig{
 		Address: "ooni.io:443",
@@ -243,7 +243,7 @@ func TestIntegrationTCPConnectGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationTCPConnectGoodWithDoT(t *testing.T) {
+func TestTCPConnectGoodWithDoT(t *testing.T) {
 	ctx := context.Background()
 	results := TCPConnect(ctx, TCPConnectConfig{
 		Address:          "ooni.io:443",
@@ -255,7 +255,7 @@ func TestIntegrationTCPConnectGoodWithDoT(t *testing.T) {
 	}
 }
 
-func TestIntegrationTCPConnectUnknownDNS(t *testing.T) {
+func TestTCPConnectUnknownDNS(t *testing.T) {
 	ctx := context.Background()
 	results := TCPConnect(ctx, TCPConnectConfig{
 		Address:          "ooni.io:443",
@@ -282,7 +282,7 @@ func obfs4config() OBFS4ConnectConfig {
 	}
 }
 
-func TestIntegrationOBFS4ConnectGood(t *testing.T) {
+func TestOBFS4ConnectGood(t *testing.T) {
 	ctx := context.Background()
 	results := OBFS4Connect(ctx, obfs4config())
 	if results.Error != nil {
@@ -290,7 +290,7 @@ func TestIntegrationOBFS4ConnectGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationOBFS4ConnectGoodWithDoT(t *testing.T) {
+func TestOBFS4ConnectGoodWithDoT(t *testing.T) {
 	ctx := context.Background()
 	config := obfs4config()
 	config.DNSServerNetwork = "dot"
@@ -301,7 +301,7 @@ func TestIntegrationOBFS4ConnectGoodWithDoT(t *testing.T) {
 	}
 }
 
-func TestIntegrationOBFS4ConnectUnknownDNS(t *testing.T) {
+func TestOBFS4ConnectUnknownDNS(t *testing.T) {
 	ctx := context.Background()
 	config := obfs4config()
 	config.DNSServerNetwork = "antani"
@@ -311,7 +311,7 @@ func TestIntegrationOBFS4ConnectUnknownDNS(t *testing.T) {
 	}
 }
 
-func TestIntegrationOBFS4IoutilTempDirError(t *testing.T) {
+func TestOBFS4IoutilTempDirError(t *testing.T) {
 	ctx := context.Background()
 	config := obfs4config()
 	expected := errors.New("mocked error")
@@ -324,7 +324,7 @@ func TestIntegrationOBFS4IoutilTempDirError(t *testing.T) {
 	}
 }
 
-func TestIntegrationOBFS4ClientFactoryError(t *testing.T) {
+func TestOBFS4ClientFactoryError(t *testing.T) {
 	ctx := context.Background()
 	config := obfs4config()
 	config.transportsGet = func(name string) obfs4base.Transport {
@@ -340,7 +340,7 @@ func TestIntegrationOBFS4ClientFactoryError(t *testing.T) {
 	}
 }
 
-func TestIntegrationOBFS4ParseArgsError(t *testing.T) {
+func TestOBFS4ParseArgsError(t *testing.T) {
 	ctx := context.Background()
 	config := obfs4config()
 	config.Params = make(map[string][]string) // cause ParseArgs error
@@ -350,7 +350,7 @@ func TestIntegrationOBFS4ParseArgsError(t *testing.T) {
 	}
 }
 
-func TestIntegrationOBFS4DialContextError(t *testing.T) {
+func TestOBFS4DialContextError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // should cause DialContex to fail
 	config := obfs4config()
@@ -360,7 +360,7 @@ func TestIntegrationOBFS4DialContextError(t *testing.T) {
 	}
 }
 
-func TestIntegrationOBFS4SetDeadlineError(t *testing.T) {
+func TestOBFS4SetDeadlineError(t *testing.T) {
 	ctx := context.Background()
 	config := obfs4config()
 	config.setDeadline = func(net.Conn, time.Time) error {
@@ -388,7 +388,7 @@ func (txp *faketransport) ServerFactory(stateDir string, args *goptlib.Args) (ob
 	return txp.ServerFactory(stateDir, args)
 }
 
-func TestUnitConnmapper(t *testing.T) {
+func TestConnmapper(t *testing.T) {
 	var mapper connmapper
 	if mapper.scramble(-1) >= 0 {
 		t.Fatal("unexpected value for negative input")

--- a/libminiooni/libminiooni_integration_test.go
+++ b/libminiooni/libminiooni_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package libminiooni_test
 
 import (
@@ -8,6 +6,9 @@ import (
 	"github.com/ooni/probe-engine/libminiooni"
 )
 
-func TestIntegrationSimple(t *testing.T) {
+func TestSimple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	libminiooni.MainWithConfiguration("example", libminiooni.Options{})
 }

--- a/libooniffi/ooniffi_test.go
+++ b/libooniffi/ooniffi_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 )
 
-func TestUnitTaskStartNullPointer(t *testing.T) {
+func TestTaskStartNullPointer(t *testing.T) {
 	if ooniffi_task_start_(nil) != nil {
 		t.Fatal("expected nil result here")
 	}
 }
 
-func TestUnitTaskStartInvalidJSON(t *testing.T) {
+func TestTaskStartInvalidJSON(t *testing.T) {
 	settings := cstring("{")
 	defer freestring(settings)
 	if ooniffi_task_start_(settings) != nil {
@@ -18,7 +18,7 @@ func TestUnitTaskStartInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestUnitTaskStartIdxWrapping(t *testing.T) {
+func TestTaskStartIdxWrapping(t *testing.T) {
 	settings := cstring(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -42,37 +42,37 @@ func TestUnitTaskStartIdxWrapping(t *testing.T) {
 	restoreidx(o)
 }
 
-func TestUnitTaskWaitForNextEventNullPointer(t *testing.T) {
+func TestTaskWaitForNextEventNullPointer(t *testing.T) {
 	if ooniffi_task_wait_for_next_event(nil) != nil {
 		t.Fatal("expected nil result here")
 	}
 }
 
-func TestUnitTaskIsDoneNullPointer(t *testing.T) {
+func TestTaskIsDoneNullPointer(t *testing.T) {
 	if ooniffi_task_is_done(nil) == 0 {
 		t.Fatal("expected true-ish result here")
 	}
 }
 
-func TestUnitTaskInterruptNullPointer(t *testing.T) {
+func TestTaskInterruptNullPointer(t *testing.T) {
 	ooniffi_task_interrupt(nil) // mainly: we don't crash :^)
 }
 
-func TestUnitEventSerializationNullPointer(t *testing.T) {
+func TestEventSerializationNullPointer(t *testing.T) {
 	if ooniffi_event_serialization_(nil) != nil {
 		t.Fatal("expected nil result here")
 	}
 }
 
-func TestUnitEventDestroyNullPointer(t *testing.T) {
+func TestEventDestroyNullPointer(t *testing.T) {
 	ooniffi_event_destroy(nil) // mainly: we don't crash
 }
 
-func TestUnitTaskDestroyNullPointer(t *testing.T) {
+func TestTaskDestroyNullPointer(t *testing.T) {
 	ooniffi_task_destroy(nil) // mainly: we don't crash
 }
 
-func TestIntegrationExampleNormalUsage(t *testing.T) {
+func TestExampleNormalUsage(t *testing.T) {
 	settings := cstring(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -97,7 +97,7 @@ func TestIntegrationExampleNormalUsage(t *testing.T) {
 	ooniffi_task_destroy(task)
 }
 
-func TestIntegrationExampleInterruptAndDestroy(t *testing.T) {
+func TestExampleInterruptAndDestroy(t *testing.T) {
 	settings := cstring(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -118,7 +118,7 @@ func TestIntegrationExampleInterruptAndDestroy(t *testing.T) {
 	ooniffi_task_destroy(task)
 }
 
-func TestIntegrationExampleDestroyImmediately(t *testing.T) {
+func TestExampleDestroyImmediately(t *testing.T) {
 	settings := cstring(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-func TestUnitMeasurementTargetMarshalJSON(t *testing.T) {
+func TestMeasurementTargetMarshalJSON(t *testing.T) {
 	var mt model.MeasurementTarget
 	data, err := json.Marshal(mt)
 	if err != nil {

--- a/netx/bytecounter/bytecounter_test.go
+++ b/netx/bytecounter/bytecounter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ooni/probe-engine/netx/bytecounter"
 )
 
-func TestUnit(t *testing.T) {
+func TestGood(t *testing.T) {
 	counter := bytecounter.New()
 	counter.CountBytesReceived(16384)
 	counter.CountKibiBytesReceived(10)

--- a/netx/dialer/bytecounter_test.go
+++ b/netx/dialer/bytecounter_test.go
@@ -33,9 +33,9 @@ func dorequest(ctx context.Context, url string) error {
 	return resp.Body.Close()
 }
 
-func TestIntegrationByteCounterNormalUsage(t *testing.T) {
+func TestByteCounterNormalUsage(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	sess := bytecounter.New()
 	ctx := context.Background()
@@ -56,9 +56,9 @@ func TestIntegrationByteCounterNormalUsage(t *testing.T) {
 	}
 }
 
-func TestIntegrationByteCounterNoHandlers(t *testing.T) {
+func TestByteCounterNoHandlers(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	ctx := context.Background()
 	if err := dorequest(ctx, "http://www.google.com"); err != nil {
@@ -69,7 +69,7 @@ func TestIntegrationByteCounterNoHandlers(t *testing.T) {
 	}
 }
 
-func TestUnitByteCounterConnectFailure(t *testing.T) {
+func TestByteCounterConnectFailure(t *testing.T) {
 	dialer := dialer.ByteCounterDialer{Dialer: dialer.EOFDialer{}}
 	conn, err := dialer.DialContext(context.Background(), "tcp", "www.google.com:80")
 	if !errors.Is(err, io.EOF) {

--- a/netx/dialer/dns_test.go
+++ b/netx/dialer/dns_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ooni/probe-engine/netx/errorx"
 )
 
-func TestUnitDNSDialerNoPort(t *testing.T) {
+func TestDNSDialerNoPort(t *testing.T) {
 	dialer := dialer.DNSDialer{Dialer: new(net.Dialer), Resolver: new(net.Resolver)}
 	conn, err := dialer.DialContext(context.Background(), "tcp", "antani.ooni.nu")
 	if err == nil {
@@ -25,7 +25,7 @@ func TestUnitDNSDialerNoPort(t *testing.T) {
 	}
 }
 
-func TestUnitDNSDialerLookupHostAddress(t *testing.T) {
+func TestDNSDialerLookupHostAddress(t *testing.T) {
 	dialer := dialer.DNSDialer{Dialer: new(net.Dialer), Resolver: MockableResolver{
 		Err: errors.New("mocked error"),
 	}}
@@ -38,7 +38,7 @@ func TestUnitDNSDialerLookupHostAddress(t *testing.T) {
 	}
 }
 
-func TestUnitDNSDialerLookupHostFailure(t *testing.T) {
+func TestDNSDialerLookupHostFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	dialer := dialer.DNSDialer{Dialer: new(net.Dialer), Resolver: MockableResolver{
 		Err: expected,
@@ -61,7 +61,7 @@ func (r MockableResolver) LookupHost(ctx context.Context, host string) ([]string
 	return r.Addresses, r.Err
 }
 
-func TestUnitDNSDialerDialForSingleIPFails(t *testing.T) {
+func TestDNSDialerDialForSingleIPFails(t *testing.T) {
 	dialer := dialer.DNSDialer{Dialer: dialer.EOFDialer{}, Resolver: new(net.Resolver)}
 	conn, err := dialer.DialContext(context.Background(), "tcp", "1.1.1.1:853")
 	if !errors.Is(err, io.EOF) {
@@ -72,7 +72,7 @@ func TestUnitDNSDialerDialForSingleIPFails(t *testing.T) {
 	}
 }
 
-func TestUnitDNSDialerDialForManyIPFails(t *testing.T) {
+func TestDNSDialerDialForManyIPFails(t *testing.T) {
 	dialer := dialer.DNSDialer{Dialer: dialer.EOFDialer{}, Resolver: MockableResolver{
 		Addresses: []string{"1.1.1.1", "8.8.8.8"},
 	}}
@@ -85,7 +85,7 @@ func TestUnitDNSDialerDialForManyIPFails(t *testing.T) {
 	}
 }
 
-func TestUnitDNSDialerDialForManyIPSuccess(t *testing.T) {
+func TestDNSDialerDialForManyIPSuccess(t *testing.T) {
 	dialer := dialer.DNSDialer{Dialer: dialer.EOFConnDialer{}, Resolver: MockableResolver{
 		Addresses: []string{"1.1.1.1", "8.8.8.8"},
 	}}
@@ -99,7 +99,7 @@ func TestUnitDNSDialerDialForManyIPSuccess(t *testing.T) {
 	conn.Close()
 }
 
-func TestUnitDNSDialerDialSetsDialID(t *testing.T) {
+func TestDNSDialerDialSetsDialID(t *testing.T) {
 	saver := &handlers.SavingHandler{}
 	ctx := modelx.WithMeasurementRoot(context.Background(), &modelx.MeasurementRoot{
 		Beginning: time.Now(),
@@ -129,7 +129,7 @@ func TestUnitDNSDialerDialSetsDialID(t *testing.T) {
 	}
 }
 
-func TestUnitReduceErrors(t *testing.T) {
+func TestReduceErrors(t *testing.T) {
 	t.Run("no errors", func(t *testing.T) {
 		result := dialer.ReduceErrors(nil)
 		if result != nil {

--- a/netx/dialer/integration_test.go
+++ b/netx/dialer/integration_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
-func TestIntegrationTLSDialerSuccess(t *testing.T) {
+func TestTLSDialerSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	log.SetLevel(log.DebugLevel)
 	dialer := dialer.TLSDialer{Dialer: new(net.Dialer),
@@ -35,9 +35,9 @@ func TestIntegrationTLSDialerSuccess(t *testing.T) {
 	resp.Body.Close()
 }
 
-func TestIntegrationDNSDialerSuccess(t *testing.T) {
+func TestDNSDialerSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	log.SetLevel(log.DebugLevel)
 	dialer := dialer.DNSDialer{

--- a/netx/dialer/logging_test.go
+++ b/netx/dialer/logging_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
-func TestUnitLoggingDialerFailure(t *testing.T) {
+func TestLoggingDialerFailure(t *testing.T) {
 	d := dialer.LoggingDialer{
 		Dialer: dialer.EOFDialer{},
 		Logger: log.Log,
@@ -25,7 +25,7 @@ func TestUnitLoggingDialerFailure(t *testing.T) {
 	}
 }
 
-func TestUnitLoggingTLSHandshakerFailure(t *testing.T) {
+func TestLoggingTLSHandshakerFailure(t *testing.T) {
 	h := dialer.LoggingTLSHandshaker{
 		TLSHandshaker: dialer.EOFTLSHandshaker{},
 		Logger:        log.Log,

--- a/netx/dialer/proxy_test.go
+++ b/netx/dialer/proxy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
-func TestUnitProxyDialerDialContextNoProxyURL(t *testing.T) {
+func TestProxyDialerDialContextNoProxyURL(t *testing.T) {
 	expected := errors.New("mocked error")
 	d := dialer.ProxyDialer{
 		Dialer: dialer.FakeDialer{Err: expected},
@@ -24,7 +24,7 @@ func TestUnitProxyDialerDialContextNoProxyURL(t *testing.T) {
 	}
 }
 
-func TestUnitProxyDialerContextTakesPrecedence(t *testing.T) {
+func TestProxyDialerContextTakesPrecedence(t *testing.T) {
 	expected := errors.New("mocked error")
 	d := dialer.ProxyDialer{
 		Dialer:   dialer.FakeDialer{Err: expected},
@@ -41,7 +41,7 @@ func TestUnitProxyDialerContextTakesPrecedence(t *testing.T) {
 	}
 }
 
-func TestUnitProxyDialerDialContextInvalidScheme(t *testing.T) {
+func TestProxyDialerDialContextInvalidScheme(t *testing.T) {
 	d := dialer.ProxyDialer{
 		Dialer:   dialer.FakeDialer{},
 		ProxyURL: &url.URL{Scheme: "antani"},
@@ -55,7 +55,7 @@ func TestUnitProxyDialerDialContextInvalidScheme(t *testing.T) {
 	}
 }
 
-func TestUnitProxyDialerDialContextWithEOF(t *testing.T) {
+func TestProxyDialerDialContextWithEOF(t *testing.T) {
 	d := dialer.ProxyDialer{
 		Dialer: dialer.FakeDialer{
 			Err: io.EOF,
@@ -71,7 +71,7 @@ func TestUnitProxyDialerDialContextWithEOF(t *testing.T) {
 	}
 }
 
-func TestUnitProxyDialerDialContextWithContextCanceled(t *testing.T) {
+func TestProxyDialerDialContextWithContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately fail
 	d := dialer.ProxyDialer{
@@ -89,7 +89,7 @@ func TestUnitProxyDialerDialContextWithContextCanceled(t *testing.T) {
 	}
 }
 
-func TestUnitProxyDialerDialContextWithDialerSuccess(t *testing.T) {
+func TestProxyDialerDialContextWithDialerSuccess(t *testing.T) {
 	d := dialer.ProxyDialer{
 		Dialer: dialer.FakeDialer{
 			Conn: &dialer.FakeConn{
@@ -109,7 +109,7 @@ func TestUnitProxyDialerDialContextWithDialerSuccess(t *testing.T) {
 	conn.Close()
 }
 
-func TestUnitProxyDialerDialContextWithDialerCanceledContext(t *testing.T) {
+func TestProxyDialerDialContextWithDialerCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Stop immediately. The FakeDialer sleeps for some microseconds so
 	// it is much more likely we immediately exit with done context. The
@@ -136,7 +136,7 @@ func TestUnitProxyDialerDialContextWithDialerCanceledContext(t *testing.T) {
 	}
 }
 
-func TestUnitProxyDialerWrapper(t *testing.T) {
+func TestProxyDialerWrapper(t *testing.T) {
 	d := dialer.ProxyDialerWrapper{
 		Dialer: dialer.FakeDialer{
 			Err: io.EOF,

--- a/netx/dialer/saver_test.go
+++ b/netx/dialer/saver_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
-func TestUnitSaverDialerFailure(t *testing.T) {
+func TestSaverDialerFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
 	dlr := dialer.SaverDialer{
@@ -54,7 +54,7 @@ func TestUnitSaverDialerFailure(t *testing.T) {
 	}
 }
 
-func TestUnitSaverConnDialerFailure(t *testing.T) {
+func TestSaverConnDialerFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
 	dlr := dialer.SaverConnDialer{
@@ -72,10 +72,10 @@ func TestUnitSaverConnDialerFailure(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
+func TestSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 	// This is the most common use case for collecting reads, writes
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	nextprotos := []string{"h2"}
 	saver := &trace.Saver{}
@@ -169,9 +169,9 @@ func TestIntegrationSaverTLSHandshakerSuccessWithReadWrite(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverTLSHandshakerSuccess(t *testing.T) {
+func TestSaverTLSHandshakerSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	nextprotos := []string{"h2"}
 	saver := &trace.Saver{}
@@ -236,9 +236,9 @@ func TestIntegrationSaverTLSHandshakerSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverTLSHandshakerHostnameError(t *testing.T) {
+func TestSaverTLSHandshakerHostnameError(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
 	tlsdlr := dialer.TLSDialer{
@@ -269,9 +269,9 @@ func TestIntegrationSaverTLSHandshakerHostnameError(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverTLSHandshakerInvalidCertError(t *testing.T) {
+func TestSaverTLSHandshakerInvalidCertError(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
 	tlsdlr := dialer.TLSDialer{
@@ -302,9 +302,9 @@ func TestIntegrationSaverTLSHandshakerInvalidCertError(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverTLSHandshakerAuthorityError(t *testing.T) {
+func TestSaverTLSHandshakerAuthorityError(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
 	tlsdlr := dialer.TLSDialer{
@@ -335,9 +335,9 @@ func TestIntegrationSaverTLSHandshakerAuthorityError(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverTLSHandshakerNoTLSVerify(t *testing.T) {
+func TestSaverTLSHandshakerNoTLSVerify(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
 	tlsdlr := dialer.TLSDialer{

--- a/netx/dialer/shaping_test.go
+++ b/netx/dialer/shaping_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ooni/probe-engine/netx/dialer"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	txp := netx.NewHTTPTransport(netx.Config{
 		Dialer: dialer.ShapingDialer{
 			Dialer: new(net.Dialer),

--- a/netx/dialer/timeout_test.go
+++ b/netx/dialer/timeout_test.go
@@ -22,7 +22,7 @@ func (SlowDialer) DialContext(ctx context.Context, network, address string) (net
 	}
 }
 
-func TestUnitTimeoutDialer(t *testing.T) {
+func TestTimeoutDialer(t *testing.T) {
 	d := dialer.TimeoutDialer{Dialer: SlowDialer{}, ConnectTimeout: time.Second}
 	conn, err := d.DialContext(context.Background(), "tcp", "www.google.com:443")
 	if !errors.Is(err, context.DeadlineExceeded) {

--- a/netx/dialer/tls_test.go
+++ b/netx/dialer/tls_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ooni/probe-engine/netx/errorx"
 )
 
-func TestUnitSystemTLSHandshakerEOFError(t *testing.T) {
+func TestSystemTLSHandshakerEOFError(t *testing.T) {
 	h := dialer.SystemTLSHandshaker{}
 	conn, _, err := h.Handshake(context.Background(), dialer.EOFConn{}, &tls.Config{
 		ServerName: "x.org",
@@ -28,7 +28,7 @@ func TestUnitSystemTLSHandshakerEOFError(t *testing.T) {
 	}
 }
 
-func TestUnitTimeoutTLSHandshakerSetDeadlineError(t *testing.T) {
+func TestTimeoutTLSHandshakerSetDeadlineError(t *testing.T) {
 	h := dialer.TimeoutTLSHandshaker{
 		TLSHandshaker:    dialer.SystemTLSHandshaker{},
 		HandshakeTimeout: 200 * time.Millisecond,
@@ -45,7 +45,7 @@ func TestUnitTimeoutTLSHandshakerSetDeadlineError(t *testing.T) {
 	}
 }
 
-func TestUnitTimeoutTLSHandshakerEOFError(t *testing.T) {
+func TestTimeoutTLSHandshakerEOFError(t *testing.T) {
 	h := dialer.TimeoutTLSHandshaker{
 		TLSHandshaker:    dialer.SystemTLSHandshaker{},
 		HandshakeTimeout: 200 * time.Millisecond,
@@ -60,7 +60,7 @@ func TestUnitTimeoutTLSHandshakerEOFError(t *testing.T) {
 	}
 }
 
-func TestUnitTimeoutTLSHandshakerCallsSetDeadline(t *testing.T) {
+func TestTimeoutTLSHandshakerCallsSetDeadline(t *testing.T) {
 	h := dialer.TimeoutTLSHandshaker{
 		TLSHandshaker:    dialer.SystemTLSHandshaker{},
 		HandshakeTimeout: 200 * time.Millisecond,
@@ -95,7 +95,7 @@ func (c *SetDeadlineConn) SetDeadline(t time.Time) error {
 	return nil
 }
 
-func TestUnitErrorWrapperTLSHandshakerFailure(t *testing.T) {
+func TestErrorWrapperTLSHandshakerFailure(t *testing.T) {
 	h := dialer.ErrorWrapperTLSHandshaker{TLSHandshaker: dialer.EOFTLSHandshaker{}}
 	conn, _, err := h.Handshake(
 		context.Background(), dialer.EOFConn{}, new(tls.Config))
@@ -120,7 +120,7 @@ func TestUnitErrorWrapperTLSHandshakerFailure(t *testing.T) {
 	}
 }
 
-func TestUnitEmitterTLSHandshakerFailure(t *testing.T) {
+func TestEmitterTLSHandshakerFailure(t *testing.T) {
 	saver := &handlers.SavingHandler{}
 	ctx := modelx.WithMeasurementRoot(context.Background(), &modelx.MeasurementRoot{
 		Beginning: time.Now(),
@@ -163,7 +163,7 @@ func TestUnitEmitterTLSHandshakerFailure(t *testing.T) {
 	}
 }
 
-func TestUnitTLSDialerFailureSplitHostPort(t *testing.T) {
+func TestTLSDialerFailureSplitHostPort(t *testing.T) {
 	dialer := dialer.TLSDialer{}
 	conn, err := dialer.DialTLSContext(
 		context.Background(), "tcp", "www.google.com") // missing port
@@ -175,7 +175,7 @@ func TestUnitTLSDialerFailureSplitHostPort(t *testing.T) {
 	}
 }
 
-func TestUnitTLSDialerFailureDialing(t *testing.T) {
+func TestTLSDialerFailureDialing(t *testing.T) {
 	dialer := dialer.TLSDialer{Dialer: dialer.EOFDialer{}}
 	conn, err := dialer.DialTLSContext(
 		context.Background(), "tcp", "www.google.com:443")
@@ -187,7 +187,7 @@ func TestUnitTLSDialerFailureDialing(t *testing.T) {
 	}
 }
 
-func TestUnitTLSDialerFailureHandshaking(t *testing.T) {
+func TestTLSDialerFailureHandshaking(t *testing.T) {
 	rec := &RecorderTLSHandshaker{TLSHandshaker: dialer.SystemTLSHandshaker{}}
 	dialer := dialer.TLSDialer{
 		Dialer:        dialer.EOFConnDialer{},
@@ -206,7 +206,7 @@ func TestUnitTLSDialerFailureHandshaking(t *testing.T) {
 	}
 }
 
-func TestUnitTLSDialerFailureHandshakingOverrideSNI(t *testing.T) {
+func TestTLSDialerFailureHandshakingOverrideSNI(t *testing.T) {
 	rec := &RecorderTLSHandshaker{TLSHandshaker: dialer.SystemTLSHandshaker{}}
 	dialer := dialer.TLSDialer{
 		Config: &tls.Config{
@@ -240,7 +240,7 @@ func (h *RecorderTLSHandshaker) Handshake(
 	return h.TLSHandshaker.Handshake(ctx, conn, config)
 }
 
-func TestIntegrationDialTLSContextGood(t *testing.T) {
+func TestDialTLSContextGood(t *testing.T) {
 	dialer := dialer.TLSDialer{
 		Config:        &tls.Config{ServerName: "google.com"},
 		Dialer:        new(net.Dialer),
@@ -256,7 +256,7 @@ func TestIntegrationDialTLSContextGood(t *testing.T) {
 	conn.Close()
 }
 
-func TestIntegrationDialTLSContextTimeout(t *testing.T) {
+func TestDialTLSContextTimeout(t *testing.T) {
 	dialer := dialer.TLSDialer{
 		Config: &tls.Config{ServerName: "google.com"},
 		Dialer: new(net.Dialer),

--- a/netx/errorx/errorx_test.go
+++ b/netx/errorx/errorx_test.go
@@ -154,7 +154,7 @@ func TestToFailureString(t *testing.T) {
 	})
 }
 
-func TestUnitToOperationString(t *testing.T) {
+func TestToOperationString(t *testing.T) {
 	t.Run("for connect", func(t *testing.T) {
 		// You're doing HTTP and connect fails. You want to know
 		// that connect failed not that HTTP failed.

--- a/netx/httptransport/bytecounter_test.go
+++ b/netx/httptransport/bytecounter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/netx/httptransport"
 )
 
-func TestUnitByteCounterFailure(t *testing.T) {
+func TestByteCounterFailure(t *testing.T) {
 	counter := bytecounter.New()
 	txp := httptransport.ByteCountingTransport{
 		Counter: counter,
@@ -42,7 +42,7 @@ func TestUnitByteCounterFailure(t *testing.T) {
 	}
 }
 
-func TestUnitByteCounterSuccess(t *testing.T) {
+func TestByteCounterSuccess(t *testing.T) {
 	counter := bytecounter.New()
 	txp := httptransport.ByteCountingTransport{
 		Counter: counter,
@@ -84,7 +84,7 @@ func TestUnitByteCounterSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitByteCounterSuccessWithEOF(t *testing.T) {
+func TestByteCounterSuccessWithEOF(t *testing.T) {
 	counter := bytecounter.New()
 	txp := httptransport.ByteCountingTransport{
 		Counter: counter,

--- a/netx/httptransport/logging_test.go
+++ b/netx/httptransport/logging_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/netx/httptransport"
 )
 
-func TestUnitLoggingFailure(t *testing.T) {
+func TestLoggingFailure(t *testing.T) {
 	txp := httptransport.LoggingTransport{
 		Logger: log.Log,
 		RoundTripper: httptransport.FakeTransport{
@@ -30,7 +30,7 @@ func TestUnitLoggingFailure(t *testing.T) {
 	}
 }
 
-func TestUnitLoggingFailureWithNoHostHeader(t *testing.T) {
+func TestLoggingFailureWithNoHostHeader(t *testing.T) {
 	txp := httptransport.LoggingTransport{
 		Logger: log.Log,
 		RoundTripper: httptransport.FakeTransport{
@@ -54,7 +54,7 @@ func TestUnitLoggingFailureWithNoHostHeader(t *testing.T) {
 	}
 }
 
-func TestUnitLoggingSuccess(t *testing.T) {
+func TestLoggingSuccess(t *testing.T) {
 	txp := httptransport.LoggingTransport{
 		Logger: log.Log,
 		RoundTripper: httptransport.FakeTransport{

--- a/netx/httptransport/saver_test.go
+++ b/netx/httptransport/saver_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
-func TestIntegrationSaverPerformanceNoMultipleEvents(t *testing.T) {
+func TestSaverPerformanceNoMultipleEvents(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
 	// register twice - do we see events twice?
@@ -58,9 +58,9 @@ func TestIntegrationSaverPerformanceNoMultipleEvents(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverMetadataSuccess(t *testing.T) {
+func TestSaverMetadataSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
 	txp := httptransport.SaverMetadataHTTPTransport{
@@ -114,7 +114,7 @@ func TestIntegrationSaverMetadataSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitSaverMetadataFailure(t *testing.T) {
+func TestSaverMetadataFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
 	txp := httptransport.SaverMetadataHTTPTransport{
@@ -156,9 +156,9 @@ func TestUnitSaverMetadataFailure(t *testing.T) {
 	}
 }
 
-func TestIntegrationSaverTransactionSuccess(t *testing.T) {
+func TestSaverTransactionSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := &trace.Saver{}
 	txp := httptransport.SaverTransactionHTTPTransport{
@@ -199,7 +199,7 @@ func TestIntegrationSaverTransactionSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitSaverTransactionFailure(t *testing.T) {
+func TestSaverTransactionFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	saver := &trace.Saver{}
 	txp := httptransport.SaverTransactionHTTPTransport{
@@ -240,7 +240,7 @@ func TestUnitSaverTransactionFailure(t *testing.T) {
 	}
 }
 
-func TestUnitSaverBodySuccess(t *testing.T) {
+func TestSaverBodySuccess(t *testing.T) {
 	saver := new(trace.Saver)
 	txp := httptransport.SaverBodyHTTPTransport{
 		RoundTripper: httptransport.FakeTransport{
@@ -311,7 +311,7 @@ func TestUnitSaverBodySuccess(t *testing.T) {
 	}
 }
 
-func TestUnitSaverBodyRequestReadError(t *testing.T) {
+func TestSaverBodyRequestReadError(t *testing.T) {
 	saver := new(trace.Saver)
 	txp := httptransport.SaverBodyHTTPTransport{
 		RoundTripper: httptransport.FakeTransport{
@@ -341,7 +341,7 @@ func TestUnitSaverBodyRequestReadError(t *testing.T) {
 	}
 }
 
-func TestUnitSaverBodyRoundTripError(t *testing.T) {
+func TestSaverBodyRoundTripError(t *testing.T) {
 	saver := new(trace.Saver)
 	expected := errors.New("mocked error")
 	txp := httptransport.SaverBodyHTTPTransport{
@@ -381,7 +381,7 @@ func TestUnitSaverBodyRoundTripError(t *testing.T) {
 	}
 }
 
-func TestUnitSaverBodyResponseReadError(t *testing.T) {
+func TestSaverBodyResponseReadError(t *testing.T) {
 	saver := new(trace.Saver)
 	expected := errors.New("mocked error")
 	txp := httptransport.SaverBodyHTTPTransport{

--- a/netx/httptransport/useragent_test.go
+++ b/netx/httptransport/useragent_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-engine/netx/httptransport"
 )
 
-func TestUnitUserAgentWithDefault(t *testing.T) {
+func TestUserAgentWithDefault(t *testing.T) {
 	txp := httptransport.UserAgentTransport{
 		RoundTripper: httptransport.FakeTransport{
 			Resp: &http.Response{StatusCode: 200},
@@ -29,7 +29,7 @@ func TestUnitUserAgentWithDefault(t *testing.T) {
 	}
 }
 
-func TestUnitUserAgentWithExplicitValue(t *testing.T) {
+func TestUserAgentWithExplicitValue(t *testing.T) {
 	txp := httptransport.UserAgentTransport{
 		RoundTripper: httptransport.FakeTransport{
 			Resp: &http.Response{StatusCode: 200},

--- a/netx/integration_test.go
+++ b/netx/integration_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestSuccess(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	log.SetLevel(log.DebugLevel)
 	counter := bytecounter.New()
@@ -67,9 +67,9 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationBogonResolutionNotBroken(t *testing.T) {
+func TestBogonResolutionNotBroken(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	saver := new(trace.Saver)
 	r := netx.NewResolver(netx.Config{

--- a/netx/resolver/bogon_test.go
+++ b/netx/resolver/bogon_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitResolverIsBogon(t *testing.T) {
+func TestResolverIsBogon(t *testing.T) {
 	if resolver.IsBogon("antani") != true {
 		t.Fatal("unexpected result")
 	}
@@ -24,7 +24,7 @@ func TestUnitResolverIsBogon(t *testing.T) {
 	}
 }
 
-func TestUnitBogonAwareResolverWithBogon(t *testing.T) {
+func TestBogonAwareResolverWithBogon(t *testing.T) {
 	r := resolver.BogonResolver{
 		Resolver: resolver.NewFakeResolverWithResult([]string{"127.0.0.1"}),
 	}
@@ -37,7 +37,7 @@ func TestUnitBogonAwareResolverWithBogon(t *testing.T) {
 	}
 }
 
-func TestUnitBogonAwareResolverWithoutBogon(t *testing.T) {
+func TestBogonAwareResolverWithoutBogon(t *testing.T) {
 	orig := []string{"8.8.8.8"}
 	r := resolver.BogonResolver{
 		Resolver: resolver.NewFakeResolverWithResult(orig),

--- a/netx/resolver/cache_test.go
+++ b/netx/resolver/cache_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitCacheFailure(t *testing.T) {
+func TestCacheFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	var r resolver.Resolver = resolver.FakeResolver{
 		Err: expected,
@@ -26,7 +26,7 @@ func TestUnitCacheFailure(t *testing.T) {
 	}
 }
 
-func TestUnitCacheHitSuccess(t *testing.T) {
+func TestCacheHitSuccess(t *testing.T) {
 	var r resolver.Resolver = resolver.FakeResolver{
 		Err: errors.New("mocked error"),
 	}
@@ -41,7 +41,7 @@ func TestUnitCacheHitSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitCacheMissSuccess(t *testing.T) {
+func TestCacheMissSuccess(t *testing.T) {
 	var r resolver.Resolver = resolver.FakeResolver{
 		Result: []string{"8.8.8.8"},
 	}
@@ -58,7 +58,7 @@ func TestUnitCacheMissSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitCacheReadonlySuccess(t *testing.T) {
+func TestCacheReadonlySuccess(t *testing.T) {
 	var r resolver.Resolver = resolver.FakeResolver{
 		Result: []string{"8.8.8.8"},
 	}

--- a/netx/resolver/decoder_test.go
+++ b/netx/resolver/decoder_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitDecoderUnpackError(t *testing.T) {
+func TestDecoderUnpackError(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(dns.TypeA, nil)
 	if err == nil {
@@ -19,7 +19,7 @@ func TestUnitDecoderUnpackError(t *testing.T) {
 	}
 }
 
-func TestUnitDecoderNXDOMAIN(t *testing.T) {
+func TestDecoderNXDOMAIN(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(dns.TypeA, resolver.GenReplyError(t, dns.RcodeNameError))
 	if err == nil || !strings.HasSuffix(err.Error(), "no such host") {
@@ -30,7 +30,7 @@ func TestUnitDecoderNXDOMAIN(t *testing.T) {
 	}
 }
 
-func TestUnitDecoderOtherError(t *testing.T) {
+func TestDecoderOtherError(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(dns.TypeA, resolver.GenReplyError(t, dns.RcodeRefused))
 	if err == nil || !strings.HasSuffix(err.Error(), "query failed") {
@@ -41,7 +41,7 @@ func TestUnitDecoderOtherError(t *testing.T) {
 	}
 }
 
-func TestUnitDecoderNoAddress(t *testing.T) {
+func TestDecoderNoAddress(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(dns.TypeA, resolver.GenReplySuccess(t, dns.TypeA))
 	if err == nil || !strings.HasSuffix(err.Error(), "no response returned") {
@@ -52,7 +52,7 @@ func TestUnitDecoderNoAddress(t *testing.T) {
 	}
 }
 
-func TestUnitDecoderDecodeA(t *testing.T) {
+func TestDecoderDecodeA(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(
 		dns.TypeA, resolver.GenReplySuccess(t, dns.TypeA, "1.1.1.1", "8.8.8.8"))
@@ -70,7 +70,7 @@ func TestUnitDecoderDecodeA(t *testing.T) {
 	}
 }
 
-func TestUnitDecoderDecodeAAAA(t *testing.T) {
+func TestDecoderDecodeAAAA(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(
 		dns.TypeAAAA, resolver.GenReplySuccess(t, dns.TypeAAAA, "::1", "fe80::1"))
@@ -88,7 +88,7 @@ func TestUnitDecoderDecodeAAAA(t *testing.T) {
 	}
 }
 
-func TestUnitDecoderUnexpectedAReply(t *testing.T) {
+func TestDecoderUnexpectedAReply(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(
 		dns.TypeA, resolver.GenReplySuccess(t, dns.TypeAAAA, "::1", "fe80::1"))
@@ -100,7 +100,7 @@ func TestUnitDecoderUnexpectedAReply(t *testing.T) {
 	}
 }
 
-func TestUnitDecoderUnexpectedAAAAReply(t *testing.T) {
+func TestDecoderUnexpectedAAAAReply(t *testing.T) {
 	d := resolver.MiekgDecoder{}
 	data, err := d.Decode(
 		dns.TypeAAAA, resolver.GenReplySuccess(t, dns.TypeA, "1.1.1.1", "8.8.4.4."))

--- a/netx/resolver/dnsoverhttps_test.go
+++ b/netx/resolver/dnsoverhttps_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitDNSOverHTTPSNewRequestFailure(t *testing.T) {
+func TestDNSOverHTTPSNewRequestFailure(t *testing.T) {
 	const invalidURL = "\t"
 	txp := resolver.NewDNSOverHTTPS(http.DefaultClient, invalidURL)
 	data, err := txp.RoundTrip(context.Background(), nil)
@@ -25,7 +25,7 @@ func TestUnitDNSOverHTTPSNewRequestFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverHTTPSClientDoFailure(t *testing.T) {
+func TestDNSOverHTTPSClientDoFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	txp := resolver.DNSOverHTTPS{
 		Do: func(*http.Request) (*http.Response, error) {
@@ -42,7 +42,7 @@ func TestUnitDNSOverHTTPSClientDoFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverHTTPSHTTPFailure(t *testing.T) {
+func TestDNSOverHTTPSHTTPFailure(t *testing.T) {
 	txp := resolver.DNSOverHTTPS{
 		Do: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -61,7 +61,7 @@ func TestUnitDNSOverHTTPSHTTPFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverHTTPSMissingContentType(t *testing.T) {
+func TestDNSOverHTTPSMissingContentType(t *testing.T) {
 	txp := resolver.DNSOverHTTPS{
 		Do: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -80,7 +80,7 @@ func TestUnitDNSOverHTTPSMissingContentType(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverHTTPSSuccess(t *testing.T) {
+func TestDNSOverHTTPSSuccess(t *testing.T) {
 	body := []byte("AAA")
 	txp := resolver.DNSOverHTTPS{
 		Do: func(*http.Request) (*http.Response, error) {
@@ -103,7 +103,7 @@ func TestUnitDNSOverHTTPSSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverHTTPTransportOK(t *testing.T) {
+func TestDNSOverHTTPTransportOK(t *testing.T) {
 	const queryURL = "https://cloudflare-dns.com/dns-query"
 	txp := resolver.NewDNSOverHTTPS(http.DefaultClient, queryURL)
 	if txp.Network() != "doh" {
@@ -117,7 +117,7 @@ func TestUnitDNSOverHTTPTransportOK(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverHTTPSClientSetsUserAgent(t *testing.T) {
+func TestDNSOverHTTPSClientSetsUserAgent(t *testing.T) {
 	expected := errors.New("mocked error")
 	var correct bool
 	txp := resolver.DNSOverHTTPS{
@@ -139,7 +139,7 @@ func TestUnitDNSOverHTTPSClientSetsUserAgent(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverHTTPSHostOverride(t *testing.T) {
+func TestDNSOverHTTPSHostOverride(t *testing.T) {
 	var correct bool
 	expected := errors.New("mocked error")
 

--- a/netx/resolver/dnsovertcp_test.go
+++ b/netx/resolver/dnsovertcp_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitDNSOverTCPTransportQueryTooLarge(t *testing.T) {
+func TestDNSOverTCPTransportQueryTooLarge(t *testing.T) {
 	const address = "9.9.9.9:53"
 	txp := resolver.NewDNSOverTCP(new(net.Dialer).DialContext, address)
 	reply, err := txp.RoundTrip(context.Background(), make([]byte, 1<<18))
@@ -21,7 +21,7 @@ func TestUnitDNSOverTCPTransportQueryTooLarge(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTCPTransportDialFailure(t *testing.T) {
+func TestDNSOverTCPTransportDialFailure(t *testing.T) {
 	const address = "9.9.9.9:53"
 	mocked := errors.New("mocked error")
 	fakedialer := resolver.FakeDialer{Err: mocked}
@@ -35,7 +35,7 @@ func TestUnitDNSOverTCPTransportDialFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTCPTransportSetDealineFailure(t *testing.T) {
+func TestDNSOverTCPTransportSetDealineFailure(t *testing.T) {
 	const address = "9.9.9.9:53"
 	mocked := errors.New("mocked error")
 	fakedialer := resolver.FakeDialer{Conn: &resolver.FakeConn{
@@ -51,7 +51,7 @@ func TestUnitDNSOverTCPTransportSetDealineFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTCPTransportWriteFailure(t *testing.T) {
+func TestDNSOverTCPTransportWriteFailure(t *testing.T) {
 	const address = "9.9.9.9:53"
 	mocked := errors.New("mocked error")
 	fakedialer := resolver.FakeDialer{Conn: &resolver.FakeConn{
@@ -67,7 +67,7 @@ func TestUnitDNSOverTCPTransportWriteFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTCPTransportReadFailure(t *testing.T) {
+func TestDNSOverTCPTransportReadFailure(t *testing.T) {
 	const address = "9.9.9.9:53"
 	mocked := errors.New("mocked error")
 	fakedialer := resolver.FakeDialer{Conn: &resolver.FakeConn{
@@ -83,7 +83,7 @@ func TestUnitDNSOverTCPTransportReadFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTCPTransportSecondReadFailure(t *testing.T) {
+func TestDNSOverTCPTransportSecondReadFailure(t *testing.T) {
 	const address = "9.9.9.9:53"
 	mocked := errors.New("mocked error")
 	fakedialer := resolver.FakeDialer{Conn: &resolver.FakeConn{
@@ -100,7 +100,7 @@ func TestUnitDNSOverTCPTransportSecondReadFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTCPTransportAllGood(t *testing.T) {
+func TestDNSOverTCPTransportAllGood(t *testing.T) {
 	const address = "9.9.9.9:53"
 	mocked := errors.New("mocked error")
 	fakedialer := resolver.FakeDialer{Conn: &resolver.FakeConn{
@@ -117,7 +117,7 @@ func TestUnitDNSOverTCPTransportAllGood(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTCPTransportOK(t *testing.T) {
+func TestDNSOverTCPTransportOK(t *testing.T) {
 	const address = "9.9.9.9:53"
 	txp := resolver.NewDNSOverTCP(new(net.Dialer).DialContext, address)
 	if txp.RequiresPadding() != false {
@@ -131,7 +131,7 @@ func TestUnitDNSOverTCPTransportOK(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverTLSTransportOK(t *testing.T) {
+func TestDNSOverTLSTransportOK(t *testing.T) {
 	const address = "9.9.9.9:853"
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, address)
 	if txp.RequiresPadding() != true {

--- a/netx/resolver/dnsoverudp_test.go
+++ b/netx/resolver/dnsoverudp_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitDNSOverUDPDialFailure(t *testing.T) {
+func TestDNSOverUDPDialFailure(t *testing.T) {
 	mocked := errors.New("mocked error")
 	const address = "9.9.9.9:53"
 	txp := resolver.NewDNSOverUDP(resolver.FakeDialer{Err: mocked}, address)
@@ -22,7 +22,7 @@ func TestUnitDNSOverUDPDialFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverUDPSetDeadlineError(t *testing.T) {
+func TestDNSOverUDPSetDeadlineError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.NewDNSOverUDP(
 		resolver.FakeDialer{
@@ -40,7 +40,7 @@ func TestUnitDNSOverUDPSetDeadlineError(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverUDPWriteFailure(t *testing.T) {
+func TestDNSOverUDPWriteFailure(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.NewDNSOverUDP(
 		resolver.FakeDialer{
@@ -58,7 +58,7 @@ func TestUnitDNSOverUDPWriteFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverUDPReadFailure(t *testing.T) {
+func TestDNSOverUDPReadFailure(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.NewDNSOverUDP(
 		resolver.FakeDialer{
@@ -76,7 +76,7 @@ func TestUnitDNSOverUDPReadFailure(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverUDPReadSuccess(t *testing.T) {
+func TestDNSOverUDPReadSuccess(t *testing.T) {
 	const expected = 17
 	txp := resolver.NewDNSOverUDP(
 		resolver.FakeDialer{
@@ -92,7 +92,7 @@ func TestUnitDNSOverUDPReadSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitDNSOverUDPTransportOK(t *testing.T) {
+func TestDNSOverUDPTransportOK(t *testing.T) {
 	const address = "9.9.9.9:53"
 	txp := resolver.NewDNSOverUDP(&net.Dialer{}, address)
 	if txp.RequiresPadding() != false {

--- a/netx/resolver/encoder_test.go
+++ b/netx/resolver/encoder_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitEncoderEncodeA(t *testing.T) {
+func TestEncoderEncodeA(t *testing.T) {
 	e := resolver.MiekgEncoder{}
 	data, err := e.Encode("x.org", dns.TypeA, false)
 	if err != nil {
@@ -17,7 +17,7 @@ func TestUnitEncoderEncodeA(t *testing.T) {
 	validate(t, data, byte(dns.TypeA))
 }
 
-func TestUnitEncoderEncodeAAAA(t *testing.T) {
+func TestEncoderEncodeAAAA(t *testing.T) {
 	e := resolver.MiekgEncoder{}
 	data, err := e.Encode("x.org", dns.TypeAAAA, false)
 	if err != nil {
@@ -64,7 +64,7 @@ func validate(t *testing.T, data []byte, qtype byte) {
 	}
 }
 
-func TestUnitEncoderPadding(t *testing.T) {
+func TestEncoderPadding(t *testing.T) {
 	// The purpose of this unit test is to make sure that for a wide
 	// array of values we obtain the right query size.
 	getquerylen := func(domainlen int, padding bool) int {

--- a/netx/resolver/errorwrapper_test.go
+++ b/netx/resolver/errorwrapper_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitErrorWrapperSuccess(t *testing.T) {
+func TestErrorWrapperSuccess(t *testing.T) {
 	orig := []string{"8.8.8.8"}
 	r := resolver.ErrorWrapperResolver{
 		Resolver: resolver.NewFakeResolverWithResult(orig),
@@ -25,7 +25,7 @@ func TestUnitErrorWrapperSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitErrorWrapperFailure(t *testing.T) {
+func TestErrorWrapperFailure(t *testing.T) {
 	r := resolver.ErrorWrapperResolver{
 		Resolver: resolver.NewFakeResolverThatFails(),
 	}

--- a/netx/resolver/integration_test.go
+++ b/netx/resolver/integration_test.go
@@ -16,7 +16,7 @@ func init() {
 
 func testresolverquick(t *testing.T, reso resolver.Resolver) {
 	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	reso = resolver.LoggingResolver{Logger: log.Log, Resolver: reso}
 	addrs, err := reso.LookupHost(context.Background(), "dns.google.com")
@@ -41,7 +41,7 @@ func testresolverquick(t *testing.T, reso resolver.Resolver) {
 // Ensuring we can handle Internationalized Domain Names (IDNs) without issues
 func testresolverquickidna(t *testing.T, reso resolver.Resolver) {
 	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	reso = resolver.IDNAResolver{
 		resolver.LoggingResolver{Logger: log.Log, Resolver: reso},
@@ -55,55 +55,55 @@ func testresolverquickidna(t *testing.T, reso resolver.Resolver) {
 	}
 }
 
-func TestIntegrationNewResolverSystem(t *testing.T) {
+func TestNewResolverSystem(t *testing.T) {
 	reso := resolver.SystemResolver{}
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
-func TestIntegrationNewResolverUDPAddress(t *testing.T) {
+func TestNewResolverUDPAddress(t *testing.T) {
 	reso := resolver.NewSerialResolver(
 		resolver.NewDNSOverUDP(new(net.Dialer), "8.8.8.8:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
-func TestIntegrationNewResolverUDPDomain(t *testing.T) {
+func TestNewResolverUDPDomain(t *testing.T) {
 	reso := resolver.NewSerialResolver(
 		resolver.NewDNSOverUDP(new(net.Dialer), "dns.google.com:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
-func TestIntegrationNewResolverTCPAddress(t *testing.T) {
+func TestNewResolverTCPAddress(t *testing.T) {
 	reso := resolver.NewSerialResolver(
 		resolver.NewDNSOverTCP(new(net.Dialer).DialContext, "8.8.8.8:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
-func TestIntegrationNewResolverTCPDomain(t *testing.T) {
+func TestNewResolverTCPDomain(t *testing.T) {
 	reso := resolver.NewSerialResolver(
 		resolver.NewDNSOverTCP(new(net.Dialer).DialContext, "dns.google.com:53"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
-func TestIntegrationNewResolverDoTAddress(t *testing.T) {
+func TestNewResolverDoTAddress(t *testing.T) {
 	reso := resolver.NewSerialResolver(
 		resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
-func TestIntegrationNewResolverDoTDomain(t *testing.T) {
+func TestNewResolverDoTDomain(t *testing.T) {
 	reso := resolver.NewSerialResolver(
 		resolver.NewDNSOverTLS(resolver.DialTLSContext, "dns.google.com:853"))
 	testresolverquick(t, reso)
 	testresolverquickidna(t, reso)
 }
 
-func TestIntegrationNewResolverDoH(t *testing.T) {
+func TestNewResolverDoH(t *testing.T) {
 	reso := resolver.NewSerialResolver(
 		resolver.NewDNSOverHTTPS(http.DefaultClient, "https://cloudflare-dns.com/dns-query"))
 	testresolverquick(t, reso)

--- a/netx/resolver/logging_test.go
+++ b/netx/resolver/logging_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitLoggingResolver(t *testing.T) {
+func TestLoggingResolver(t *testing.T) {
 	r := resolver.LoggingResolver{
 		Logger:   log.Log,
 		Resolver: resolver.NewFakeResolverThatFails(),

--- a/netx/resolver/saver_test.go
+++ b/netx/resolver/saver_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
-func TestUnitSaverResolverFailure(t *testing.T) {
+func TestSaverResolverFailure(t *testing.T) {
 	expected := errors.New("no such host")
 	saver := &trace.Saver{}
 	reso := resolver.SaverResolver{
@@ -61,7 +61,7 @@ func TestUnitSaverResolverFailure(t *testing.T) {
 	}
 }
 
-func TestUnitSaverResolverSuccess(t *testing.T) {
+func TestSaverResolverSuccess(t *testing.T) {
 	expected := []string{"8.8.8.8", "8.8.4.4"}
 	saver := &trace.Saver{}
 	reso := resolver.SaverResolver{
@@ -110,7 +110,7 @@ func TestUnitSaverResolverSuccess(t *testing.T) {
 	}
 }
 
-func TestUnitSaverDNSTransportFailure(t *testing.T) {
+func TestSaverDNSTransportFailure(t *testing.T) {
 	expected := errors.New("no such host")
 	saver := &trace.Saver{}
 	txp := resolver.SaverDNSTransport{
@@ -160,7 +160,7 @@ func TestUnitSaverDNSTransportFailure(t *testing.T) {
 	}
 }
 
-func TestUnitSaverDNSTransportSuccess(t *testing.T) {
+func TestSaverDNSTransportSuccess(t *testing.T) {
 	expected := []byte("def")
 	saver := &trace.Saver{}
 	txp := resolver.SaverDNSTransport{

--- a/netx/resolver/serial_test.go
+++ b/netx/resolver/serial_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestUnitOONIGettingTransport(t *testing.T) {
+func TestOONIGettingTransport(t *testing.T) {
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
 	r := resolver.NewSerialResolver(txp)
 	rtx := r.Transport()
@@ -27,7 +27,7 @@ func TestUnitOONIGettingTransport(t *testing.T) {
 	}
 }
 
-func TestUnitOONIEncodeError(t *testing.T) {
+func TestOONIEncodeError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.NewDNSOverTLS(resolver.DialTLSContext, "8.8.8.8:853")
 	r := resolver.SerialResolver{Encoder: resolver.FakeEncoder{Err: mocked}, Txp: txp}
@@ -40,7 +40,7 @@ func TestUnitOONIEncodeError(t *testing.T) {
 	}
 }
 
-func TestUnitOONIRoundTripError(t *testing.T) {
+func TestOONIRoundTripError(t *testing.T) {
 	mocked := errors.New("mocked error")
 	txp := resolver.FakeTransport{Err: mocked}
 	r := resolver.NewSerialResolver(txp)
@@ -53,7 +53,7 @@ func TestUnitOONIRoundTripError(t *testing.T) {
 	}
 }
 
-func TestUnitOONIWithEmptyReply(t *testing.T) {
+func TestOONIWithEmptyReply(t *testing.T) {
 	txp := resolver.FakeTransport{Data: resolver.GenReplySuccess(t, dns.TypeA)}
 	r := resolver.NewSerialResolver(txp)
 	addrs, err := r.LookupHost(context.Background(), "www.gogle.com")
@@ -65,7 +65,7 @@ func TestUnitOONIWithEmptyReply(t *testing.T) {
 	}
 }
 
-func TestUnitOONIWithAReply(t *testing.T) {
+func TestOONIWithAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeA, "8.8.8.8"),
 	}
@@ -79,7 +79,7 @@ func TestUnitOONIWithAReply(t *testing.T) {
 	}
 }
 
-func TestUnitOONIWithAAAAReply(t *testing.T) {
+func TestOONIWithAAAAReply(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Data: resolver.GenReplySuccess(t, dns.TypeAAAA, "::1"),
 	}
@@ -93,7 +93,7 @@ func TestUnitOONIWithAAAAReply(t *testing.T) {
 	}
 }
 
-func TestUnitOONIWithTimeout(t *testing.T) {
+func TestOONIWithTimeout(t *testing.T) {
 	txp := resolver.FakeTransport{
 		Err: &net.OpError{Err: syscall.ETIMEDOUT, Op: "dial"},
 	}

--- a/netx/resolver/system_test.go
+++ b/netx/resolver/system_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ooni/probe-engine/netx/resolver"
 )
 
-func TestIntegrationSystemResolverLookupHost(t *testing.T) {
+func TestSystemResolverLookupHost(t *testing.T) {
 	r := resolver.SystemResolver{}
 	if r.Network() != "system" {
 		t.Fatal("invalid Network")

--- a/netx/trace/trace_test.go
+++ b/netx/trace/trace_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ooni/probe-engine/netx/trace"
 )
 
-func TestIntegration(t *testing.T) {
+func TestGood(t *testing.T) {
 	saver := trace.Saver{}
 	var wg sync.WaitGroup
 	const parallel = 10

--- a/oonimkall/session_integration_test.go
+++ b/oonimkall/session_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package oonimkall_test
 
 import (
@@ -33,6 +31,9 @@ func NewSession() (*oonimkall.Session, error) {
 }
 
 func TestNewSessionWithInvalidStateDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := oonimkall.NewSession(&oonimkall.SessionConfig{
 		StateDir: "",
 	})
@@ -45,6 +46,9 @@ func TestNewSessionWithInvalidStateDir(t *testing.T) {
 }
 
 func TestNewSessionWithMissingSoftwareName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := oonimkall.NewSession(&oonimkall.SessionConfig{
 		StateDir: "../testdata/oonimkall/state",
 	})
@@ -57,6 +61,9 @@ func TestNewSessionWithMissingSoftwareName(t *testing.T) {
 }
 
 func TestMaybeUpdateResourcesWithCancelledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	dir, err := ioutil.TempDir("", "xx")
 	if err != nil {
 		t.Fatal(err)
@@ -88,6 +95,9 @@ func ReduceErrorForGeolocate(err error) error {
 }
 
 func TestGeolocateWithCancelledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession()
 	if err != nil {
 		t.Fatal(err)
@@ -104,6 +114,9 @@ func TestGeolocateWithCancelledContext(t *testing.T) {
 }
 
 func TestGeolocateGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession()
 	if err != nil {
 		t.Fatal(err)
@@ -141,6 +154,9 @@ func ReduceErrorForSubmitter(err error) error {
 }
 
 func TestSubmitWithCancelledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession()
 	if err != nil {
 		t.Fatal(err)
@@ -157,6 +173,9 @@ func TestSubmitWithCancelledContext(t *testing.T) {
 }
 
 func TestSubmitWithInvalidJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession()
 	if err != nil {
 		t.Fatal(err)
@@ -206,6 +225,9 @@ func DoSubmission(ctx *oonimkall.Context, sess *oonimkall.Session) error {
 }
 
 func TestSubmitMeasurementGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession()
 	if err != nil {
 		t.Fatal(err)
@@ -217,6 +239,9 @@ func TestSubmitMeasurementGood(t *testing.T) {
 }
 
 func TestSubmitCancelContextAfterFirstSubmission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession()
 	if err != nil {
 		t.Fatal(err)

--- a/oonimkall/task_integration_test.go
+++ b/oonimkall/task_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package oonimkall_test
 
 import (
@@ -19,7 +17,10 @@ type eventlike struct {
 	Value map[string]interface{} `json:"value"`
 }
 
-func TestIntegrationGood(t *testing.T) {
+func TestGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -59,7 +60,10 @@ func TestIntegrationGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationGoodWithoutGeoIPLookup(t *testing.T) {
+func TestGoodWithoutGeoIPLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -84,7 +88,10 @@ func TestIntegrationGoodWithoutGeoIPLookup(t *testing.T) {
 	}
 }
 
-func TestIntegrationWithMeasurementFailure(t *testing.T) {
+func TestWithMeasurementFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -109,7 +116,10 @@ func TestIntegrationWithMeasurementFailure(t *testing.T) {
 	}
 }
 
-func TestIntegrationInvalidJSON(t *testing.T) {
+func TestInvalidJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{`)
 	var syntaxerr *json.SyntaxError
 	if !errors.As(err, &syntaxerr) {
@@ -120,7 +130,10 @@ func TestIntegrationInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestIntegrationUnsupportedSetting(t *testing.T) {
+func TestUnsupportedSetting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"input_filepaths": ["/nonexistent"],
@@ -151,7 +164,10 @@ func TestIntegrationUnsupportedSetting(t *testing.T) {
 	}
 }
 
-func TestIntegrationEmptyStateDir(t *testing.T) {
+func TestEmptyStateDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -180,7 +196,10 @@ func TestIntegrationEmptyStateDir(t *testing.T) {
 	}
 }
 
-func TestIntegrationEmptyAssetsDir(t *testing.T) {
+func TestEmptyAssetsDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"log_level": "DEBUG",
 		"name": "Example",
@@ -209,7 +228,10 @@ func TestIntegrationEmptyAssetsDir(t *testing.T) {
 	}
 }
 
-func TestIntegrationUnknownExperiment(t *testing.T) {
+func TestUnknownExperiment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -239,7 +261,10 @@ func TestIntegrationUnknownExperiment(t *testing.T) {
 	}
 }
 
-func TestIntegrationInconsistentGeoIPSettings(t *testing.T) {
+func TestInconsistentGeoIPSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -271,7 +296,10 @@ func TestIntegrationInconsistentGeoIPSettings(t *testing.T) {
 	}
 }
 
-func TestIntegrationInputIsRequired(t *testing.T) {
+func TestInputIsRequired(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"log_level": "DEBUG",
@@ -301,7 +329,10 @@ func TestIntegrationInputIsRequired(t *testing.T) {
 	}
 }
 
-func TestIntegrationMaxRuntime(t *testing.T) {
+func TestMaxRuntime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	begin := time.Now()
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
@@ -337,7 +368,10 @@ func TestIntegrationMaxRuntime(t *testing.T) {
 	}
 }
 
-func TestIntegrationInterruptExampleWithInput(t *testing.T) {
+func TestInterruptExampleWithInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	t.Skip("Skipping broken test; see https://github.com/ooni/probe-engine/issues/992")
 	// We cannot use WebConnectivity until it's written in Go since
 	// measurement-kit may not always be available
@@ -401,7 +435,10 @@ func TestIntegrationInterruptExampleWithInput(t *testing.T) {
 	}
 }
 
-func TestIntegrationInterruptNdt7(t *testing.T) {
+func TestInterruptNdt7(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"name": "Ndt7",
@@ -451,7 +488,10 @@ func TestIntegrationInterruptNdt7(t *testing.T) {
 	}
 }
 
-func TestIntegrationCountBytesForExample(t *testing.T) {
+func TestCountBytesForExample(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"name": "Example",
@@ -485,7 +525,10 @@ func TestIntegrationCountBytesForExample(t *testing.T) {
 	}
 }
 
-func TestIntegrationPrivacySettings(t *testing.T) {
+func TestPrivacySettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	do := func(saveASN, saveCC, saveIP bool) (string, string, string) {
 		task, err := oonimkall.StartTask(fmt.Sprintf(`{
 			"assets_dir": "../testdata/oonimkall/assets",
@@ -561,7 +604,10 @@ func TestIntegrationPrivacySettings(t *testing.T) {
 	}
 }
 
-func TestIntegrationNonblock(t *testing.T) {
+func TestNonblock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	task, err := oonimkall.StartTask(`{
 		"assets_dir": "../testdata/oonimkall/assets",
 		"name": "Example",

--- a/oonimkall/tasks/eventemitter_test.go
+++ b/oonimkall/tasks/eventemitter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ooni/probe-engine/oonimkall/tasks"
 )
 
-func TestUnitDisabledEvents(t *testing.T) {
+func TestDisabledEvents(t *testing.T) {
 	out := make(chan *tasks.Event)
 	emitter := tasks.NewEventEmitter([]string{"log"}, out)
 	go func() {
@@ -24,7 +24,7 @@ func TestUnitDisabledEvents(t *testing.T) {
 	}
 }
 
-func TestUnitEmitFailureStartup(t *testing.T) {
+func TestEmitFailureStartup(t *testing.T) {
 	out := make(chan *tasks.Event)
 	emitter := tasks.NewEventEmitter([]string{}, out)
 	go func() {
@@ -45,7 +45,7 @@ func TestUnitEmitFailureStartup(t *testing.T) {
 	}
 }
 
-func TestUnitEmitStatusProgress(t *testing.T) {
+func TestEmitStatusProgress(t *testing.T) {
 	out := make(chan *tasks.Event)
 	emitter := tasks.NewEventEmitter([]string{}, out)
 	go func() {

--- a/oonimkall/tasks/runner_integration_test.go
+++ b/oonimkall/tasks/runner_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package tasks_test
 
 import (
@@ -14,7 +12,10 @@ import (
 	"github.com/ooni/probe-engine/oonimkall/tasks"
 )
 
-func TestIntegrationRunnerMaybeLookupBackendsFailure(t *testing.T) {
+func TestRunnerMaybeLookupBackendsFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
@@ -51,7 +52,10 @@ func TestIntegrationRunnerMaybeLookupBackendsFailure(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerOpenReportFailure(t *testing.T) {
+func TestRunnerOpenReportFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	var (
 		nreq int64
 		mu   sync.Mutex
@@ -105,7 +109,10 @@ func TestIntegrationRunnerOpenReportFailure(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerGood(t *testing.T) {
+func TestRunnerGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -132,7 +139,10 @@ func TestIntegrationRunnerGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithUnsupportedSettings(t *testing.T) {
+func TestRunnerWithUnsupportedSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -160,7 +170,10 @@ func TestIntegrationRunnerWithUnsupportedSettings(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithInvalidKVStorePath(t *testing.T) {
+func TestRunnerWithInvalidKVStorePath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -187,7 +200,10 @@ func TestIntegrationRunnerWithInvalidKVStorePath(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithInvalidExperimentName(t *testing.T) {
+func TestRunnerWithInvalidExperimentName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -214,7 +230,10 @@ func TestIntegrationRunnerWithInvalidExperimentName(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithInconsistentGeolookupSettings(t *testing.T) {
+func TestRunnerWithInconsistentGeolookupSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -243,7 +262,10 @@ func TestIntegrationRunnerWithInconsistentGeolookupSettings(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithNoGeolookup(t *testing.T) {
+func TestRunnerWithNoGeolookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -272,7 +294,10 @@ func TestIntegrationRunnerWithNoGeolookup(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithMissingInput(t *testing.T) {
+func TestRunnerWithMissingInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -301,7 +326,10 @@ func TestIntegrationRunnerWithMissingInput(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithMaxRuntime(t *testing.T) {
+func TestRunnerWithMaxRuntime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -344,7 +372,10 @@ func TestIntegrationRunnerWithMaxRuntime(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithMaxRuntimeNonInterruptible(t *testing.T) {
+func TestRunnerWithMaxRuntimeNonInterruptible(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",
@@ -387,7 +418,10 @@ func TestIntegrationRunnerWithMaxRuntimeNonInterruptible(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerWithFailedMeasurement(t *testing.T) {
+func TestRunnerWithFailedMeasurement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	out := make(chan *tasks.Event)
 	settings := &tasks.Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",

--- a/oonimkall/tasks/runner_internal_test.go
+++ b/oonimkall/tasks/runner_internal_test.go
@@ -12,7 +12,7 @@ import (
 	engine "github.com/ooni/probe-engine"
 )
 
-func TestUnitRunnerHasUnsupportedSettings(t *testing.T) {
+func TestRunnerHasUnsupportedSettings(t *testing.T) {
 	out := make(chan *Event)
 	var falsebool bool
 	var zerodotzero float64
@@ -128,7 +128,7 @@ func TestUnitRunnerHasUnsupportedSettings(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurementSubmissionEventName(t *testing.T) {
+func TestMeasurementSubmissionEventName(t *testing.T) {
 	if measurementSubmissionEventName(nil) != statusMeasurementSubmission {
 		t.Fatal("unexpected submission event name")
 	}
@@ -137,7 +137,7 @@ func TestUnitMeasurementSubmissionEventName(t *testing.T) {
 	}
 }
 
-func TestUnitMeasurementSubmissionFailure(t *testing.T) {
+func TestMeasurementSubmissionFailure(t *testing.T) {
 	if measurementSubmissionFailure(nil) != "" {
 		t.Fatal("unexpected submission failure")
 	}
@@ -146,7 +146,7 @@ func TestUnitMeasurementSubmissionFailure(t *testing.T) {
 	}
 }
 
-func TestIntegrationRunnerMaybeLookupLocationFailure(t *testing.T) {
+func TestRunnerMaybeLookupLocationFailure(t *testing.T) {
 	out := make(chan *Event)
 	settings := &Settings{
 		AssetsDir: "../../testdata/oonimkall/assets",

--- a/probeservices/login_test.go
+++ b/probeservices/login_test.go
@@ -54,7 +54,7 @@ func TestMaybeLogin(t *testing.T) {
 	})
 }
 
-func TestIntegrationMaybeLoginIdempotent(t *testing.T) {
+func TestMaybeLoginIdempotent(t *testing.T) {
 	clnt := newclient()
 	ctx := context.Background()
 	metadata := testorchestra.MetadataFixture()

--- a/probeservices/metadata_test.go
+++ b/probeservices/metadata_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ooni/probe-engine/probeservices"
 )
 
-func TestUnitValid(t *testing.T) {
+func TestValid(t *testing.T) {
 	t.Run("fail on probe_cc", func(t *testing.T) {
 		var m probeservices.Metadata
 		if m.Valid() != false {

--- a/probeservices/probeservices_test.go
+++ b/probeservices/probeservices_test.go
@@ -139,9 +139,9 @@ func TestNewClientCloudfrontGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationCloudfront(t *testing.T) {
+func TestCloudfront(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	client, err := probeservices.NewClient(
 		&mockable.Session{}, model.Service{
@@ -176,7 +176,7 @@ func TestIntegrationCloudfront(t *testing.T) {
 
 func TestDefaultProbeServicesWorkAsIntended(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	for _, e := range probeservices.Default() {
 		client, err := probeservices.NewClient(&mockable.Session{
@@ -397,7 +397,7 @@ func TestTryAllCanceledContext(t *testing.T) {
 
 func TestTryAllIntegrationWeRaceForFastestHTTPS(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	const pattern = "^https://ps[1-4].ooni.io$"
 	// put onion first so we also verify that we sort the endpoints
@@ -469,7 +469,7 @@ func TestTryAllIntegrationWeRaceForFastestHTTPS(t *testing.T) {
 
 func TestTryAllIntegrationWeFallback(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in short mode")
+		t.Skip("skip test in short mode")
 	}
 	// put onion first so we also verify that we sort the endpoints
 	in := []model.Service{{

--- a/probeservices/psiphon_test.go
+++ b/probeservices/psiphon_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
-func TestIntegrationFetchPsiphonConfig(t *testing.T) {
+func TestFetchPsiphonConfig(t *testing.T) {
 	clnt := newclient()
 	if err := clnt.MaybeRegister(context.Background(), testorchestra.MetadataFixture()); err != nil {
 		t.Fatal(err)

--- a/probeservices/register_test.go
+++ b/probeservices/register_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
-func TestUnitMaybeRegister(t *testing.T) {
+func TestMaybeRegister(t *testing.T) {
 	t.Run("when metadata is not valid", func(t *testing.T) {
 		clnt := newclient()
 		ctx := context.Background()
@@ -47,7 +47,7 @@ func TestUnitMaybeRegister(t *testing.T) {
 	})
 }
 
-func TestIntegrationMaybeRegisterIdempotent(t *testing.T) {
+func TestMaybeRegisterIdempotent(t *testing.T) {
 	clnt := newclient()
 	ctx := context.Background()
 	metadata := testorchestra.MetadataFixture()

--- a/probeservices/tor_test.go
+++ b/probeservices/tor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ooni/probe-engine/probeservices/testorchestra"
 )
 
-func TestIntegrationFetchTorTargets(t *testing.T) {
+func TestFetchTorTargets(t *testing.T) {
 	clnt := newclient()
 	if err := clnt.MaybeRegister(context.Background(), testorchestra.MetadataFixture()); err != nil {
 		t.Fatal(err)

--- a/session_integration_test.go
+++ b/session_integration_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package engine
 
 import (
@@ -22,6 +20,9 @@ import (
 )
 
 func TestNewSessionBuilderChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	t.Run("with no settings", func(t *testing.T) {
 		newSessionMustFail(t, SessionConfig{})
 	})
@@ -55,6 +56,9 @@ func TestNewSessionBuilderChecks(t *testing.T) {
 }
 
 func TestNewSessionBuilderGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	newSessionForTesting(t)
 }
 
@@ -69,6 +73,9 @@ func newSessionMustFail(t *testing.T, config SessionConfig) {
 }
 
 func TestSessionTorArgsTorBinary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir: "testdata",
 		AvailableProbeServices: []model.Service{{
@@ -159,7 +166,10 @@ func newSessionForTesting(t *testing.T) *Session {
 	return sess
 }
 
-func TestIntegrationNewOrchestraClient(t *testing.T) {
+func TestNewOrchestraClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	clnt, err := sess.NewOrchestraClient(context.Background())
@@ -171,7 +181,10 @@ func TestIntegrationNewOrchestraClient(t *testing.T) {
 	}
 }
 
-func TestUnitInitOrchestraClientMaybeRegisterError(t *testing.T) {
+func TestInitOrchestraClientMaybeRegisterError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // so we fail immediately
 	sess := newSessionForTestingNoLookups(t)
@@ -194,7 +207,10 @@ func TestUnitInitOrchestraClientMaybeRegisterError(t *testing.T) {
 	}
 }
 
-func TestUnitInitOrchestraClientMaybeLoginError(t *testing.T) {
+func TestInitOrchestraClientMaybeLoginError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	ctx := context.Background()
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
@@ -220,6 +236,9 @@ func TestUnitInitOrchestraClientMaybeLoginError(t *testing.T) {
 }
 
 func TestBouncerError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	// Combine proxy testing with a broken proxy with errors
 	// in reaching out to the bouncer.
 	server := httptest.NewServer(http.HandlerFunc(
@@ -243,6 +262,9 @@ func TestBouncerError(t *testing.T) {
 }
 
 func TestMaybeLookupBackendsNewClientError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	sess.availableProbeServices = []model.Service{{
 		Type:    "onion",
@@ -255,7 +277,10 @@ func TestMaybeLookupBackendsNewClientError(t *testing.T) {
 	}
 }
 
-func TestIntegrationSessionLocationLookup(t *testing.T) {
+func TestSessionLocationLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	if err := sess.MaybeLookupLocation(); err != nil {
@@ -296,7 +321,10 @@ func TestIntegrationSessionLocationLookup(t *testing.T) {
 	}
 }
 
-func TestIntegrationSessionCloseCancelsTempDir(t *testing.T) {
+func TestSessionCloseCancelsTempDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	tempDir := sess.TempDir()
 	if _, err := os.Stat(tempDir); err != nil {
@@ -310,7 +338,10 @@ func TestIntegrationSessionCloseCancelsTempDir(t *testing.T) {
 	}
 }
 
-func TestIntegrationSessionDownloadResources(t *testing.T) {
+func TestSessionDownloadResources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	tmpdir, err := ioutil.TempDir("", "test-download-resources-idempotent")
 	if err != nil {
 		t.Fatal(err)
@@ -335,7 +366,10 @@ func TestIntegrationSessionDownloadResources(t *testing.T) {
 	}
 }
 
-func TestUnitGetAvailableProbeServices(t *testing.T) {
+func TestGetAvailableProbeServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
 		Logger:          log.Log,
@@ -353,7 +387,10 @@ func TestUnitGetAvailableProbeServices(t *testing.T) {
 	}
 }
 
-func TestUnitMaybeLookupBackendsFailure(t *testing.T) {
+func TestMaybeLookupBackendsFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
 		Logger:          log.Log,
@@ -372,7 +409,10 @@ func TestUnitMaybeLookupBackendsFailure(t *testing.T) {
 	}
 }
 
-func TestIntegrationMaybeLookupTestHelpersIdempotent(t *testing.T) {
+func TestMaybeLookupTestHelpersIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
 		Logger:          log.Log,
@@ -395,7 +435,10 @@ func TestIntegrationMaybeLookupTestHelpersIdempotent(t *testing.T) {
 	}
 }
 
-func TestUnitAllProbeServicesUnsupported(t *testing.T) {
+func TestAllProbeServicesUnsupported(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
 		Logger:          log.Log,
@@ -416,7 +459,10 @@ func TestUnitAllProbeServicesUnsupported(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartTunnelGood(t *testing.T) {
+func TestStartTunnelGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	ctx := context.Background()
@@ -434,7 +480,10 @@ func TestIntegrationStartTunnelGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartTunnelNonexistent(t *testing.T) {
+func TestStartTunnelNonexistent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	ctx := context.Background()
@@ -446,7 +495,10 @@ func TestIntegrationStartTunnelNonexistent(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartTunnelEmptyString(t *testing.T) {
+func TestStartTunnelEmptyString(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	ctx := context.Background()
@@ -458,7 +510,10 @@ func TestIntegrationStartTunnelEmptyString(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartTunnelEmptyStringWithProxy(t *testing.T) {
+func TestStartTunnelEmptyStringWithProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	proxyURL := &url.URL{Scheme: "socks5", Host: "127.0.0.1:9050"}
 	sess := newSessionForTestingNoLookups(t)
 	sess.proxyURL = proxyURL
@@ -473,7 +528,10 @@ func TestIntegrationStartTunnelEmptyStringWithProxy(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartTunnelWithAlreadyExistingTunnel(t *testing.T) {
+func TestStartTunnelWithAlreadyExistingTunnel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	ctx := context.Background()
@@ -492,7 +550,10 @@ func TestIntegrationStartTunnelWithAlreadyExistingTunnel(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartTunnelWithAlreadyExistingProxy(t *testing.T) {
+func TestStartTunnelWithAlreadyExistingProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	ctx := context.Background()
@@ -509,7 +570,10 @@ func TestIntegrationStartTunnelWithAlreadyExistingProxy(t *testing.T) {
 	}
 }
 
-func TestIntegrationStartTunnelCanceledContext(t *testing.T) {
+func TestStartTunnelCanceledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	defer sess.Close()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -521,6 +585,9 @@ func TestIntegrationStartTunnelCanceledContext(t *testing.T) {
 }
 
 func TestUserAgentNoProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	expect := "ooniprobe-engine/0.0.1 ooniprobe-engine/" + Version
 	sess := newSessionForTestingNoLookups(t)
 	ua := sess.UserAgent()
@@ -531,6 +598,9 @@ func TestUserAgentNoProxy(t *testing.T) {
 }
 
 func TestNewOrchestraClientMaybeLookupBackendsFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // fail immediately
@@ -559,6 +629,9 @@ func (txp httpTransportThatSleeps) CloseIdleConnections() {
 }
 
 func TestNewOrchestraClientMaybeLookupLocationFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	sess.httpDefaultTransport = httpTransportThatSleeps{
 		txp: sess.httpDefaultTransport,
@@ -580,6 +653,9 @@ func TestNewOrchestraClientMaybeLookupLocationFailure(t *testing.T) {
 }
 
 func TestNewOrchestraClientProbeServicesNewClientFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTestingNoLookups(t)
 	sess.selectedProbeServiceHook = func(svc *model.Service) {
 		svc.Type = "antani" // should really not be supported for a long time

--- a/testlists_integration_test.go
+++ b/testlists_integration_test.go
@@ -1,12 +1,13 @@
-// +build integration
-
 package engine
 
 import (
 	"testing"
 )
 
-func TestIntegrationQueryTestListsURLs(t *testing.T) {
+func TestQueryTestListsURLs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	config := &TestListsURLsConfig{}
@@ -42,7 +43,10 @@ func TestIntegrationQueryTestListsURLs(t *testing.T) {
 	}
 }
 
-func TestUnitQueryTestListsURLsQueryFailure(t *testing.T) {
+func TestQueryTestListsURLsQueryFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	config := &TestListsURLsConfig{BaseURL: "\t"}
@@ -55,7 +59,10 @@ func TestUnitQueryTestListsURLsQueryFailure(t *testing.T) {
 	}
 }
 
-func TestUnitQueryTestListsURLsNilConfig(t *testing.T) {
+func TestQueryTestListsURLsNilConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
 	sess := newSessionForTesting(t)
 	defer sess.Close()
 	result, err := sess.QueryTestListsURLs(nil)


### PR DESCRIPTION
As I noticed in https://github.com/ooni/probe-engine/issues/1005#issuecomment-719276445,
this tag is actually harmful because it prevents VSCode from taking into account
the specific file, so a bunch of workflows are more complex.

Also, regardless of VSCode, if you don't build with the right tag you cannot notice
cases where you have, e.g., conflicting declarations. So, it's much better to
have all tests building by default and to explicitly skip long ones. Even though
this entails some manual work from me.

In the meanwhile, update CONTRIBUTING.md.

Also, remove the convention where we have `TestUnit` and `TestIntegration`
sometimes, because it was not being followed consistently. When this action
caused a test to be named just `Test`, I've changed it to `TestGood`.

There will be some extra work to do, to maybe reorganise some large
`foo_integration_test.go` files that now also contain simple, very quick,
but currently skipped tests, but this is trivial and for later.

(With VSCode able to act on files, it's actually quite easy to figure
out which are the fast tests to run at every commit.)