### PR TITLE
fix: use example.org rather than example.com

### DIFF
--- a/allexperiments.go
+++ b/allexperiments.go
@@ -198,9 +198,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 					*config.(*sniblocking.Config),
 				))
 			},
-			config: &sniblocking.Config{
-				ControlSNI: "example.com",
-			},
+			config: &sniblocking.Config{},
 			inputPolicy: InputRequired,
 		}
 	},

--- a/experiment/httphostheader/httphostheader.go
+++ b/experiment/httphostheader/httphostheader.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	testName    = "http_host_header"
-	testVersion = "0.1.0"
+	testVersion = "0.2.0"
 )
 
 // Config contains the experiment config.

--- a/experiment/httphostheader/httphostheader.go
+++ b/experiment/httphostheader/httphostheader.go
@@ -56,7 +56,7 @@ func (m *Measurer) Run(
 		return errors.New("experiment requires input")
 	}
 	if m.config.TestHelperURL == "" {
-		m.config.TestHelperURL = "http://www.example.com"
+		m.config.TestHelperURL = "http://www.example.org"
 	}
 	urlgetter.RegisterExtensions(measurement)
 	g := urlgetter.Getter{

--- a/experiment/httphostheader/httphostheader_test.go
+++ b/experiment/httphostheader/httphostheader_test.go
@@ -21,7 +21,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "http_host_header" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.1.0" {
+	if measurer.ExperimentVersion() != "0.2.0" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	testName    = "sni_blocking"
-	testVersion = "0.1.0"
+	testVersion = "0.2.0"
 )
 
 // Config contains the experiment config.

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -245,7 +245,7 @@ func (m *Measurer) Run(
 	}
 	m.mu.Unlock()
 	if m.config.ControlSNI == "" {
-		return errors.New("Experiment requires ControlSNI")
+		m.config.ControlSNI = "example.org"
 	}
 	if measurement.Input == "" {
 		return errors.New("Experiment requires measurement.Input")

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -105,7 +105,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "sni_blocking" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.1.0" {
+	if measurer.ExperimentVersion() != "0.2.0" {
 		t.Fatal("unexpected version")
 	}
 }

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -110,19 +110,6 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	}
 }
 
-func TestMeasurerMeasureNoControlSNI(t *testing.T) {
-	measurer := NewExperimentMeasurer(Config{})
-	err := measurer.Run(
-		context.Background(),
-		newsession(),
-		new(model.Measurement),
-		model.NewPrinterCallbacks(log.Log),
-	)
-	if err.Error() != "Experiment requires ControlSNI" {
-		t.Fatal("not the error we expected")
-	}
-}
-
 func TestMeasurerMeasureNoMeasurementInput(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{
 		ControlSNI: "example.com",


### PR DESCRIPTION
It seems that example.org is a more reliable helper.

Related spec change: https://github.com/ooni/spec/commit/1d3000437f19f4b3214116eae288032996dd53f8

Work done in the context of: https://github.com/ooni/probe-engine/issues/622