### PR TITLE
fix: more quiet tests, more predictable iptables tests

### DIFF
--- a/cmd/jafar/iptables/iptables_integration_test.go
+++ b/cmd/jafar/iptables/iptables_integration_test.go
@@ -37,11 +37,11 @@ func TestCannotApplyPolicy(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.DropIPs = []string{"antani"}
 	if err := policy.Apply(); err == nil {
 		t.Fatal("expected an error here")
 	}
-	defer policy.Waive()
 }
 
 func TestCreateChainsError(t *testing.T) {
@@ -52,10 +52,10 @@ func TestCreateChainsError(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	// you should not be able to apply the policy when there is
 	// already a policy, you need to waive it first
 	if err := policy.Apply(); err == nil {
@@ -71,11 +71,11 @@ func TestDropIP(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.DropIPs = []string{"1.1.1.1"}
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", "1.1.1.1:853")
@@ -98,11 +98,11 @@ func TestDropKeyword(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.DropKeywords = []string{"ooni.io"}
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	req, err := http.NewRequest("GET", "http://www.ooni.io", nil)
@@ -129,11 +129,11 @@ func TestDropKeywordHex(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.DropKeywordsHex = []string{"|6f 6f 6e 69|"}
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	req, err := http.NewRequest("GET", "http://www.ooni.io", nil)
@@ -164,11 +164,11 @@ func TestResetIP(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.ResetIPs = []string{"1.1.1.1"}
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	conn, err := (&net.Dialer{}).Dial("tcp", "1.1.1.1:853")
 	if err == nil {
 		t.Fatalf("expected an error here")
@@ -189,11 +189,11 @@ func TestResetKeyword(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.ResetKeywords = []string{"ooni.io"}
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	resp, err := http.Get("http://www.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -214,11 +214,11 @@ func TestResetKeywordHex(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.ResetKeywordsHex = []string{"|6f 6f 6e 69|"}
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	resp, err := http.Get("http://www.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -248,11 +248,11 @@ func TestHijackDNS(t *testing.T) {
 	}
 	defer server.Shutdown()
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	policy.HijackDNSAddress = server.PacketConn.LocalAddr().String()
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	addrs, err := net.LookupHost("www.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -281,6 +281,7 @@ func TestHijackHTTP(t *testing.T) {
 	)
 	defer server.Close()
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	pu, err := url.Parse(server.URL)
 	if err != nil {
 		t.Fatal(err)
@@ -289,7 +290,6 @@ func TestHijackHTTP(t *testing.T) {
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	err = shellx.Run("sudo", "-u", "nobody", "--",
 		"curl", "-sf", "http://example.com")
 	if err == nil {
@@ -320,6 +320,7 @@ func TestHijackHTTPS(t *testing.T) {
 	)
 	defer server.Close()
 	policy := newCensoringPolicy()
+	defer policy.Waive()
 	pu, err := url.Parse(server.URL)
 	if err != nil {
 		t.Fatal(err)
@@ -328,7 +329,6 @@ func TestHijackHTTPS(t *testing.T) {
 	if err := policy.Apply(); err != nil {
 		t.Fatal(err)
 	}
-	defer policy.Waive()
 	err = shellx.Run("sudo", "-u", "nobody", "--",
 		"curl", "-sf", "https://example.com")
 	if err == nil {

--- a/cmd/jafar/iptables/iptables_integration_test.go
+++ b/cmd/jafar/iptables/iptables_integration_test.go
@@ -147,8 +147,9 @@ func TestDropKeywordHex(t *testing.T) {
 	// the error we see with GitHub Actions is different from the error
 	// we see when testing locally on Fedora
 	if !strings.HasSuffix(err.Error(), "operation not permitted") &&
-		!strings.HasSuffix(err.Error(), "Temporary failure in name resolution") {
-		t.Fatal("unexpected error occurred")
+		!strings.HasSuffix(err.Error(), "Temporary failure in name resolution") &&
+		!strings.HasSuffix(err.Error(), "no such host") {
+		t.Fatalf("unexpected error occurred: %+v", err)
 	}
 	if resp != nil {
 		t.Fatal("expected nil response here")

--- a/cmd/jafar/iptables/iptables_linux.go
+++ b/cmd/jafar/iptables/iptables_linux.go
@@ -100,15 +100,15 @@ func (s *linuxShell) hijackHTTP(address string) error {
 }
 
 func (s *linuxShell) waive() error {
-	shellx.Run("sudo", "iptables", "-D", "OUTPUT", "-j", "JAFAR_OUTPUT")
-	shellx.Run("sudo", "iptables", "-D", "INPUT", "-j", "JAFAR_INPUT")
-	shellx.Run("sudo", "iptables", "-t", "nat", "-D", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
-	shellx.Run("sudo", "iptables", "-F", "JAFAR_INPUT")
-	shellx.Run("sudo", "iptables", "-X", "JAFAR_INPUT")
-	shellx.Run("sudo", "iptables", "-F", "JAFAR_OUTPUT")
-	shellx.Run("sudo", "iptables", "-X", "JAFAR_OUTPUT")
-	shellx.Run("sudo", "iptables", "-t", "nat", "-F", "JAFAR_NAT_OUTPUT")
-	shellx.Run("sudo", "iptables", "-t", "nat", "-X", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-D", "OUTPUT", "-j", "JAFAR_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-D", "INPUT", "-j", "JAFAR_INPUT")
+	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-D", "OUTPUT", "-j", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-F", "JAFAR_INPUT")
+	shellx.RunQuiet("sudo", "iptables", "-X", "JAFAR_INPUT")
+	shellx.RunQuiet("sudo", "iptables", "-F", "JAFAR_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-X", "JAFAR_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-F", "JAFAR_NAT_OUTPUT")
+	shellx.RunQuiet("sudo", "iptables", "-t", "nat", "-X", "JAFAR_NAT_OUTPUT")
 	return nil
 }
 

--- a/cmd/jafar/shellx/shellx.go
+++ b/cmd/jafar/shellx/shellx.go
@@ -9,17 +9,47 @@ import (
 
 	"github.com/apex/log"
 	"github.com/google/shlex"
+	"github.com/ooni/probe-engine/model"
 )
+
+type runconfig struct {
+	args     []string
+	loginfof func(format string, v ...interface{})
+	name     string
+	stdout   *os.File
+	stderr   *os.File
+}
+
+func run(config runconfig) error {
+	config.loginfof("exec: %s %s", config.name, strings.Join(config.args, " "))
+	cmd := exec.Command(config.name, config.args...)
+	cmd.Stdout = config.stdout
+	cmd.Stderr = config.stderr
+	err := cmd.Run()
+	config.loginfof("exec result: %+v", err)
+	return err
+}
 
 // Run executes the specified command with the specified args
 func Run(name string, arg ...string) error {
-	log.Infof("exec: %s %s", name, strings.Join(arg, " "))
-	cmd := exec.Command(name, arg...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	log.Infof("exec result: %+v", err)
-	return err
+	return run(runconfig{
+		args:     arg,
+		loginfof: log.Log.Infof,
+		name:     name,
+		stdout:   os.Stdout,
+		stderr:   os.Stderr,
+	})
+}
+
+// RunQuiet is like Run but it does not emit any output.
+func RunQuiet(name string, arg ...string) error {
+	return run(runconfig{
+		args:     arg,
+		loginfof: model.DiscardLogger.Infof,
+		name:     name,
+		stdout:   nil,
+		stderr:   nil,
+	})
 }
 
 // RunCommandline is like Run but its only argument is a command

--- a/cmd/jafar/shellx/shellx_test.go
+++ b/cmd/jafar/shellx/shellx_test.go
@@ -11,6 +11,15 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestRunQuiet(t *testing.T) {
+	if err := RunQuiet("true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunQuiet("./nonexistent/command"); err == nil {
+		t.Fatal("expected an error here")
+	}
+}
+
 func TestRunCommandline(t *testing.T) {
 	t.Run("when the command does not parse", func(t *testing.T) {
 		if err := RunCommandline(`"foobar`); err == nil {

--- a/model/logger.go
+++ b/model/logger.go
@@ -21,3 +21,20 @@ type Logger interface {
 	// Warnf formats and emits a warning message.
 	Warnf(format string, v ...interface{})
 }
+
+// DiscardLogger is a logger that discards its input
+var DiscardLogger Logger = logDiscarder{}
+
+type logDiscarder struct{}
+
+func (logDiscarder) Debug(msg string) {}
+
+func (logDiscarder) Debugf(format string, v ...interface{}) {}
+
+func (logDiscarder) Info(msg string) {}
+
+func (logDiscarder) Infof(format string, v ...interface{}) {}
+
+func (logDiscarder) Warn(msg string) {}
+
+func (logDiscarder) Warnf(format string, v ...interface{}) {}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -281,3 +281,13 @@ func TestMakeGenericTestKeysMarshalError(t *testing.T) {
 		t.Fatal("expected nil output here")
 	}
 }
+
+func TestDiscardLoggerWorksAsIntended(t *testing.T) {
+	logger := model.DiscardLogger
+	logger.Debug("foo")
+	logger.Debugf("%s", "foo")
+	logger.Info("foo")
+	logger.Infof("%s", "foo")
+	logger.Warn("foo")
+	logger.Warnf("%s", "foo")
+}

--- a/session_integration_test.go
+++ b/session_integration_test.go
@@ -35,20 +35,20 @@ func TestNewSessionBuilderChecks(t *testing.T) {
 	t.Run("with also logger", func(t *testing.T) {
 		newSessionMustFail(t, SessionConfig{
 			AssetsDir: "testdata",
-			Logger:    log.Log,
+			Logger:    model.DiscardLogger,
 		})
 	})
 	t.Run("with also software name", func(t *testing.T) {
 		newSessionMustFail(t, SessionConfig{
 			AssetsDir:    "testdata",
-			Logger:       log.Log,
+			Logger:       model.DiscardLogger,
 			SoftwareName: "ooniprobe-engine",
 		})
 	})
 	t.Run("with software version and wrong tempdir", func(t *testing.T) {
 		newSessionMustFail(t, SessionConfig{
 			AssetsDir:       "testdata",
-			Logger:          log.Log,
+			Logger:          model.DiscardLogger,
 			SoftwareName:    "ooniprobe-engine",
 			SoftwareVersion: "0.0.1",
 			TempDir:         "./nonexistent",
@@ -83,7 +83,7 @@ func TestSessionTorArgsTorBinary(t *testing.T) {
 			Address: "https://ams-pg-test.ooni.org",
 			Type:    "https",
 		}},
-		Logger: log.Log,
+		Logger: model.DiscardLogger,
 		PrivacySettings: model.PrivacySettings{
 			IncludeASN:     true,
 			IncludeCountry: true,
@@ -121,7 +121,7 @@ func newSessionForTestingNoLookupsWithProxyURL(t *testing.T, URL *url.URL) *Sess
 			Address: "https://ams-pg-test.ooni.org",
 			Type:    "https",
 		}},
-		Logger: log.Log,
+		Logger: model.DiscardLogger,
 		PrivacySettings: model.PrivacySettings{
 			IncludeASN:     true,
 			IncludeCountry: true,
@@ -373,7 +373,7 @@ func TestGetAvailableProbeServices(t *testing.T) {
 	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
-		Logger:          log.Log,
+		Logger:          model.DiscardLogger,
 		SoftwareName:    "ooniprobe-engine",
 		SoftwareVersion: "0.0.1",
 	})
@@ -394,7 +394,7 @@ func TestMaybeLookupBackendsFailure(t *testing.T) {
 	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
-		Logger:          log.Log,
+		Logger:          model.DiscardLogger,
 		SoftwareName:    "ooniprobe-engine",
 		SoftwareVersion: "0.0.1",
 	})
@@ -416,7 +416,7 @@ func TestMaybeLookupTestHelpersIdempotent(t *testing.T) {
 	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
-		Logger:          log.Log,
+		Logger:          model.DiscardLogger,
 		SoftwareName:    "ooniprobe-engine",
 		SoftwareVersion: "0.0.1",
 	})
@@ -442,7 +442,7 @@ func TestAllProbeServicesUnsupported(t *testing.T) {
 	}
 	sess, err := NewSession(SessionConfig{
 		AssetsDir:       "testdata",
-		Logger:          log.Log,
+		Logger:          model.DiscardLogger,
 		SoftwareName:    "ooniprobe-engine",
 		SoftwareVersion: "0.0.1",
 	})


### PR DESCRIPTION
This is especially helpful when trying to understand what kind of
error or errors has caused test runs to fail.

This specific issue with out test harness has been bugging me when
working on https://github.com/ooni/probe-engine/issues/974.

In addition to making tests more silent, this PR also fixes the way in
which we waive policies for iptables so it's consistent across runs
also in case, for some reason, one of the tests fails.