### PR TITLE
feat(dash): introduce APIs used by probe-cli

### DIFF
--- a/experiment/dash/dash.go
+++ b/experiment/dash/dash.go
@@ -27,7 +27,7 @@ const (
 	defaultTimeout = 120 * time.Second
 	magicVersion   = "0.008000000"
 	testName       = "dash"
-	testVersion    = "0.10.0"
+	testVersion    = "0.11.0"
 	totalStep      = 15.0
 )
 
@@ -302,4 +302,33 @@ func (m Measurer) Run(
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
 	return Measurer{config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	Latency   float64 `json:"connect_latency"`
+	Bitrate   float64 `json:"median_bitrate"`
+	Delay     float64 `json:"min_playout_delay"`
+	IsAnomaly bool    `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	sk := SummaryKeys{IsAnomaly: false}
+	tk, ok := measurement.TestKeys.(*TestKeys)
+	if !ok {
+		return sk, errors.New("invalid test keys type")
+	}
+	sk.Latency = tk.Simple.ConnectLatency
+	sk.Bitrate = float64(tk.Simple.MedianBitrate)
+	sk.Delay = tk.Simple.MinPlayoutDelay
+	return sk, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -358,6 +358,9 @@ func TestSummaryKeysGood(t *testing.T) {
 	if sk.Delay != 12 {
 		t.Fatal("invalid delay")
 	}
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
 }
 
 func TestLogSummary(t *testing.T) {

--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -262,7 +262,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "dash" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.10.0" {
+	if measurer.ExperimentVersion() != "0.11.0" {
 		t.Fatal("unexpected version")
 	}
 }
@@ -325,5 +325,44 @@ func TestMeasureWithProxyURL(t *testing.T) {
 	}
 	if measurement.TestKeys.(*TestKeys).SOCKSProxy != "1.1.1.1:22" {
 		t.Fatal("unexpected SOCKSProxy")
+	}
+}
+
+func TestSummaryKeysInvalidType(t *testing.T) {
+	measurement := new(model.Measurement)
+	m := &Measurer{}
+	_, err := m.GetSummaryKeys(measurement)
+	if err.Error() != "invalid test keys type" {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestSummaryKeysGood(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &TestKeys{Simple: Simple{
+		ConnectLatency:  1234,
+		MedianBitrate:   123,
+		MinPlayoutDelay: 12,
+	}}}
+	m := &Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(SummaryKeys)
+	if sk.Latency != 1234 {
+		t.Fatal("invalid latency")
+	}
+	if sk.Bitrate != 123 {
+		t.Fatal("invalid bitrate")
+	}
+	if sk.Delay != 12 {
+		t.Fatal("invalid delay")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Here the idea is to make the dash experiment such that we can
easily ask it about summary test keys and a log summary from
probe-cli. This allows to get rid of some code that should not
actually be part of probe-cli. In turn, the objective here is
to further the integration between the two code bases to ensure
we can tell probe-cli to run nettests using specific inputs as
documented by https://github.com/ooni/probe/issues/1283.

I'm proceeding piecemeal, adding functions to each experiment
and then ensuring all experiments have the same functions. Thus
this is just the first ~small diff of many.