### PR TITLE
feat: continue introducing API used by probe-cli

### DIFF
--- a/experiment/dnscheck/dnscheck.go
+++ b/experiment/dnscheck/dnscheck.go
@@ -63,7 +63,7 @@ import (
 
 const (
 	testName      = "dnscheck"
-	testVersion   = "0.0.1"
+	testVersion   = "0.1.0"
 	defaultDomain = "example.org"
 )
 
@@ -241,4 +241,22 @@ func makeResolverURL(URL *url.URL, addr string) string {
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
 	return Measurer{Config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/dnscheck/dnscheck_test.go
+++ b/experiment/dnscheck/dnscheck_test.go
@@ -18,7 +18,7 @@ func TestExperimentNameAndVersion(t *testing.T) {
 		t.Error("unexpected experiment name")
 	}
 
-	if measurer.ExperimentVersion() != "0.0.1" {
+	if measurer.ExperimentVersion() != "0.1.0" {
 		t.Error("unexpected experiment version")
 	}
 }
@@ -139,4 +139,24 @@ func TestDNSCheckValid(t *testing.T) {
 
 func newsession() model.ExperimentSession {
 	return &mockable.Session{MockableLogger: log.Log}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &TestKeys{}}
+	m := &Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/experiment/example/example.go
+++ b/experiment/example/example.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/probe-engine/model"
 )
 
-const testVersion = "0.0.1"
+const testVersion = "0.1.0"
 
 // Config contains the experiment config.
 //
@@ -79,4 +79,22 @@ func (m Measurer) Run(
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config, testName string) model.ExperimentMeasurer {
 	return Measurer{config: config, testName: testName}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/example/example_test.go
+++ b/experiment/example/example_test.go
@@ -19,7 +19,7 @@ func TestSuccess(t *testing.T) {
 	if m.ExperimentName() != "example" {
 		t.Fatal("invalid ExperimentName")
 	}
-	if m.ExperimentVersion() != "0.0.1" {
+	if m.ExperimentVersion() != "0.1.0" {
 		t.Fatal("invalid ExperimentVersion")
 	}
 	ctx := context.Background()
@@ -42,5 +42,25 @@ func TestFailure(t *testing.T) {
 	err := m.Run(ctx, sess, new(model.Measurement), callbacks)
 	if !errors.Is(err, example.ErrFailure) {
 		t.Fatal("expected an error here")
+	}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &example.TestKeys{}}
+	m := &example.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(example.SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &example.Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/experiment/httphostheader/httphostheader.go
+++ b/experiment/httphostheader/httphostheader.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	testName    = "http_host_header"
-	testVersion = "0.2.0"
+	testVersion = "0.3.0"
 )
 
 // Config contains the experiment config.
@@ -68,11 +68,32 @@ func (m *Measurer) Run(
 		Target:  fmt.Sprintf(m.config.TestHelperURL),
 	}
 	tk, _ := g.Get(ctx)
-	measurement.TestKeys = tk
+	measurement.TestKeys = &TestKeys{
+		TestKeys:  tk,
+		THAddress: m.config.TestHelperURL,
+	}
 	return nil
 }
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
 	return &Measurer{config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/httphostheader/httphostheader_test.go
+++ b/experiment/httphostheader/httphostheader_test.go
@@ -21,7 +21,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "http_host_header" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.2.0" {
+	if measurer.ExperimentVersion() != "0.3.0" {
 		t.Fatal("unexpected version")
 	}
 }
@@ -84,4 +84,24 @@ func TestRunnerHTTPSetHostHeader(t *testing.T) {
 
 func newsession() model.ExperimentSession {
 	return &mockable.Session{MockableLogger: log.Log}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &TestKeys{}}
+	m := &Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/experiment/riseupvpn/riseupvpn.go
+++ b/experiment/riseupvpn/riseupvpn.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	testName      = "riseupvpn"
-	testVersion   = "0.0.2"
+	testVersion   = "0.1.0"
 	eipServiceURL = "https://api.black.riseup.net:443/3/config/eip-service.json"
 	providerURL   = "https://riseup.net/provider.json"
 	geoServiceURL = "https://api.black.riseup.net:9001/json"
@@ -279,4 +279,22 @@ func DecodeEIP3(body string) (*EipService, error) {
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
 	return Measurer{Config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/riseupvpn/riseupvpn_test.go
+++ b/experiment/riseupvpn/riseupvpn_test.go
@@ -26,7 +26,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "riseupvpn" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.0.2" {
+	if measurer.ExperimentVersion() != "0.1.0" {
 		t.Fatal("unexpected version")
 	}
 }
@@ -425,5 +425,25 @@ func runGatewayTest(t *testing.T, censoredGateway *SelfCensoredGateway) {
 
 	if tk.APIFailure != nil {
 		t.Fatal("ApiFailure should be null")
+	}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &riseupvpn.TestKeys{}}
+	m := &riseupvpn.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(riseupvpn.SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &riseupvpn.Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	testName    = "sni_blocking"
-	testVersion = "0.2.0"
+	testVersion = "0.3.0"
 )
 
 // Config contains the experiment config.
@@ -290,4 +290,22 @@ func asString(failure *string) (result string) {
 		result = *failure
 	}
 	return
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m *Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m *Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -105,7 +105,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "sni_blocking" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.2.0" {
+	if measurer.ExperimentVersion() != "0.3.0" {
 		t.Fatal("unexpected version")
 	}
 }
@@ -411,4 +411,24 @@ func TestMaybeURLToSNI(t *testing.T) {
 
 func newsession() model.ExperimentSession {
 	return &mockable.Session{MockableLogger: log.Log}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &TestKeys{}}
+	m := &Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/experiment/stunreachability/stunreachability.go
+++ b/experiment/stunreachability/stunreachability.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	testName    = "stun_reachability"
-	testVersion = "0.0.1"
+	testVersion = "0.1.0"
 )
 
 // Config contains the experiment config.
@@ -153,4 +153,22 @@ func (tk *TestKeys) do(
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
 	return &Measurer{config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/stunreachability/stunreachability_test.go
+++ b/experiment/stunreachability/stunreachability_test.go
@@ -21,7 +21,7 @@ func TestMeasurerExperimentNameVersion(t *testing.T) {
 	if measurer.ExperimentName() != "stun_reachability" {
 		t.Fatal("unexpected ExperimentName")
 	}
-	if measurer.ExperimentVersion() != "0.0.1" {
+	if measurer.ExperimentVersion() != "0.1.0" {
 		t.Fatal("unexpected ExperimentVersion")
 	}
 }
@@ -218,5 +218,25 @@ func TestReadFailure(t *testing.T) {
 	}
 	if len(tk.Queries) > 0 {
 		t.Fatal("DNS queries?!")
+	}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &stunreachability.TestKeys{}}
+	m := &stunreachability.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(stunreachability.SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &stunreachability.Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/experiment/tlstool/tlstool.go
+++ b/experiment/tlstool/tlstool.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	testName    = "tlstool"
-	testVersion = "0.0.3"
+	testVersion = "0.1.0"
 )
 
 // Config contains the experiment configuration.
@@ -161,4 +161,22 @@ func (m Measurer) pattern(address string) string {
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
 	return Measurer{config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/tlstool/tlstool_test.go
+++ b/experiment/tlstool/tlstool_test.go
@@ -15,7 +15,7 @@ func TestMeasurerExperimentNameVersion(t *testing.T) {
 	if measurer.ExperimentName() != "tlstool" {
 		t.Fatal("unexpected ExperimentName")
 	}
-	if measurer.ExperimentVersion() != "0.0.3" {
+	if measurer.ExperimentVersion() != "0.1.0" {
 		t.Fatal("unexpected ExperimentVersion")
 	}
 }
@@ -67,6 +67,26 @@ func TestRunWithCancelledContext(t *testing.T) {
 		model.NewPrinterCallbacks(log.Log),
 	)
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &tlstool.TestKeys{}}
+	m := &tlstool.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(tlstool.SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &tlstool.Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -106,7 +106,7 @@ func (m Measurer) Run(
 		Target:  string(measurement.Input),
 	}
 	tk, err := g.Get(ctx)
-	measurement.TestKeys = tk
+	measurement.TestKeys = &tk
 	return err
 }
 

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	testName    = "urlgetter"
-	testVersion = "0.0.3"
+	testVersion = "0.1.0"
 )
 
 // Config contains the experiment's configuration.
@@ -73,19 +73,23 @@ func RegisterExtensions(m *model.Measurement) {
 	archival.ExtTunnel.AddTo(m)
 }
 
-type measurer struct {
+// Measurer performs the measurement.
+type Measurer struct {
 	Config
 }
 
-func (m measurer) ExperimentName() string {
+// ExperimentName implements model.ExperimentSession.ExperimentName
+func (m Measurer) ExperimentName() string {
 	return testName
 }
 
-func (m measurer) ExperimentVersion() string {
+// ExperimentVersion implements model.ExperimentSession.ExperimentVersion
+func (m Measurer) ExperimentVersion() string {
 	return testVersion
 }
 
-func (m measurer) Run(
+// Run implements model.ExperimentSession.Run
+func (m Measurer) Run(
 	ctx context.Context, sess model.ExperimentSession,
 	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
 ) error {
@@ -108,5 +112,23 @@ func (m measurer) Run(
 
 // NewExperimentMeasurer creates a new ExperimentMeasurer.
 func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
-	return measurer{Config: config}
+	return Measurer{Config: config}
+}
+
+// SummaryKeys contains summary keys for this experiment.
+//
+// Note that this structure is part of the ABI contract with probe-cli
+// therefore we should be careful when changing it.
+type SummaryKeys struct {
+	IsAnomaly bool `json:"-"`
+}
+
+// GetSummaryKeys implements model.ExperimentMeasurer.GetSummaryKeys.
+func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
+	return SummaryKeys{IsAnomaly: false}, nil
+}
+
+// LogSummary implements model.ExperimentMeasurer.LogSummary.
+func (m Measurer) LogSummary(model.Logger, string) error {
+	return nil
 }

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -18,7 +18,7 @@ func TestMeasurer(t *testing.T) {
 	if m.ExperimentName() != "urlgetter" {
 		t.Fatal("invalid experiment name")
 	}
-	if m.ExperimentVersion() != "0.0.3" {
+	if m.ExperimentVersion() != "0.1.0" {
 		t.Fatal("invalid experiment version")
 	}
 	measurement := new(model.Measurement)
@@ -48,7 +48,7 @@ func TestMeasurerDNSCache(t *testing.T) {
 	if m.ExperimentName() != "urlgetter" {
 		t.Fatal("invalid experiment name")
 	}
-	if m.ExperimentVersion() != "0.0.3" {
+	if m.ExperimentVersion() != "0.1.0" {
 		t.Fatal("invalid experiment version")
 	}
 	measurement := new(model.Measurement)
@@ -66,5 +66,25 @@ func TestMeasurerDNSCache(t *testing.T) {
 	tk := measurement.TestKeys.(urlgetter.TestKeys)
 	if len(tk.DNSCache) != 1 || tk.DNSCache[0] != "dns.google 8.8.8.8 8.8.4.4" {
 		t.Fatal("invalid tk.DNSCache")
+	}
+}
+
+func TestSummaryKeysGeneric(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: urlgetter.TestKeys{}}
+	m := &urlgetter.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(urlgetter.SummaryKeys)
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &urlgetter.Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -33,7 +33,7 @@ func TestMeasurer(t *testing.T) {
 	if len(measurement.Extensions) != 5 {
 		t.Fatal("not the expected number of extensions")
 	}
-	tk := measurement.TestKeys.(urlgetter.TestKeys)
+	tk := measurement.TestKeys.(*urlgetter.TestKeys)
 	if len(tk.DNSCache) != 0 {
 		t.Fatal("not the DNSCache value we expected")
 	}
@@ -63,14 +63,14 @@ func TestMeasurerDNSCache(t *testing.T) {
 	if len(measurement.Extensions) != 5 {
 		t.Fatal("not the expected number of extensions")
 	}
-	tk := measurement.TestKeys.(urlgetter.TestKeys)
+	tk := measurement.TestKeys.(*urlgetter.TestKeys)
 	if len(tk.DNSCache) != 1 || tk.DNSCache[0] != "dns.google 8.8.8.8 8.8.4.4" {
 		t.Fatal("invalid tk.DNSCache")
 	}
 }
 
 func TestSummaryKeysGeneric(t *testing.T) {
-	measurement := &model.Measurement{TestKeys: urlgetter.TestKeys{}}
+	measurement := &model.Measurement{TestKeys: &urlgetter.TestKeys{}}
 	m := &urlgetter.Measurer{}
 	osk, err := m.GetSummaryKeys(measurement)
 	if err != nil {


### PR DESCRIPTION
Same as 46e42dc2a7ca70aebd941f9081fb58a3e98b0d7c but this time
we're dealing with experiments that currently we're not running
from probe-cli, so it's easy to support them.

Part of https://github.com/ooni/probe/issues/1283.