### PR TITLE
feat(fbmessenger): continue introducing API used by probe-cli

### DIFF
--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -232,3 +232,132 @@ func newsession(t *testing.T) model.ExperimentSession {
 	}
 	return sess
 }
+
+func TestSummaryKeysInvalidType(t *testing.T) {
+	measurement := new(model.Measurement)
+	m := &fbmessenger.Measurer{}
+	_, err := m.GetSummaryKeys(measurement)
+	if err.Error() != "invalid test keys type" {
+		t.Fatal("not the error we expected")
+	}
+}
+
+func TestSummaryKeysWithNils(t *testing.T) {
+	measurement := &model.Measurement{TestKeys: &fbmessenger.TestKeys{}}
+	m := &fbmessenger.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(fbmessenger.SummaryKeys)
+	if sk.DNSBlocking {
+		t.Fatal("invalid dnsBlocking")
+	}
+	if sk.TCPBlocking {
+		t.Fatal("invalid tcpBlocking")
+	}
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestSummaryKeysWithFalseFalse(t *testing.T) {
+	falsy := false
+	measurement := &model.Measurement{TestKeys: &fbmessenger.TestKeys{
+		FacebookTCPBlocking: &falsy,
+		FacebookDNSBlocking: &falsy,
+	}}
+	m := &fbmessenger.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(fbmessenger.SummaryKeys)
+	if sk.DNSBlocking {
+		t.Fatal("invalid dnsBlocking")
+	}
+	if sk.TCPBlocking {
+		t.Fatal("invalid tcpBlocking")
+	}
+	if sk.IsAnomaly {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestSummaryKeysWithFalseTrue(t *testing.T) {
+	falsy := false
+	truy := true
+	measurement := &model.Measurement{TestKeys: &fbmessenger.TestKeys{
+		FacebookTCPBlocking: &falsy,
+		FacebookDNSBlocking: &truy,
+	}}
+	m := &fbmessenger.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(fbmessenger.SummaryKeys)
+	if sk.DNSBlocking == false {
+		t.Fatal("invalid dnsBlocking")
+	}
+	if sk.TCPBlocking {
+		t.Fatal("invalid tcpBlocking")
+	}
+	if sk.IsAnomaly == false {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestSummaryKeysWithTrueFalse(t *testing.T) {
+	falsy := false
+	truy := true
+	measurement := &model.Measurement{TestKeys: &fbmessenger.TestKeys{
+		FacebookTCPBlocking: &truy,
+		FacebookDNSBlocking: &falsy,
+	}}
+	m := &fbmessenger.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(fbmessenger.SummaryKeys)
+	if sk.DNSBlocking {
+		t.Fatal("invalid dnsBlocking")
+	}
+	if sk.TCPBlocking == false {
+		t.Fatal("invalid tcpBlocking")
+	}
+	if sk.IsAnomaly == false {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestSummaryKeysWithTrueTrue(t *testing.T) {
+	truy := true
+	measurement := &model.Measurement{TestKeys: &fbmessenger.TestKeys{
+		FacebookTCPBlocking: &truy,
+		FacebookDNSBlocking: &truy,
+	}}
+	m := &fbmessenger.Measurer{}
+	osk, err := m.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := osk.(fbmessenger.SummaryKeys)
+	if sk.DNSBlocking == false {
+		t.Fatal("invalid dnsBlocking")
+	}
+	if sk.TCPBlocking == false {
+		t.Fatal("invalid tcpBlocking")
+	}
+	if sk.IsAnomaly == false {
+		t.Fatal("invalid isAnomaly")
+	}
+}
+
+func TestLogSummary(t *testing.T) {
+	m := &fbmessenger.Measurer{}
+	if err := m.LogSummary(log.Log, "xyz"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Same as 46e42dc2a7ca70aebd941f9081fb58a3e98b0d7c but this time
we're dealing with fbmessenger.

Part of https://github.com/ooni/probe/issues/1283.