### PR TITLE
feat(hhfm): continue introducing api required by probe-cli

### DIFF
--- a/experiment/fbmessenger/fbmessenger.go
+++ b/experiment/fbmessenger/fbmessenger.go
@@ -40,7 +40,7 @@ const (
 	ServiceStar = "tcpconnect://star.c10r.facebook.com:443"
 
 	testName    = "facebook_messenger"
-	testVersion = "0.1.0"
+	testVersion = "0.2.0"
 )
 
 // Config contains the experiment config.

--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -20,7 +20,7 @@ func TestNewExperimentMeasurer(t *testing.T) {
 	if measurer.ExperimentName() != "facebook_messenger" {
 		t.Fatal("unexpected name")
 	}
-	if measurer.ExperimentVersion() != "0.1.0" {
+	if measurer.ExperimentVersion() != "0.2.0" {
 		t.Fatal("unexpected version")
 	}
 }


### PR DESCRIPTION
While there, remember to also bump fbmessenger version number.

Work is part of https://github.com/ooni/probe/issues/1283.