### PR TITLE
cleanup and refine new API for probe-cli

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -68,6 +68,12 @@ func (e *Experiment) Name() string {
 	return e.testName
 }
 
+// GetSummaryKeys returns a data structure containing a
+// summary of the test keys for probe-cli.
+func (e *Experiment) GetSummaryKeys(m *model.Measurement) (interface{}, error) {
+	return e.measurer.GetSummaryKeys(m)
+}
+
 // OpenReport is an idempotent method to open a report. We assume that
 // you have configured the available probe services, either manually or
 // through using the session's MaybeLookupBackends method.

--- a/experiment/dash/dash.go
+++ b/experiment/dash/dash.go
@@ -327,8 +327,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.Delay = tk.Simple.MinPlayoutDelay
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/dash/dash_test.go
+++ b/experiment/dash/dash_test.go
@@ -370,10 +370,3 @@ func TestSummaryKeysGood(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/dnscheck/dnscheck.go
+++ b/experiment/dnscheck/dnscheck.go
@@ -255,8 +255,3 @@ type SummaryKeys struct {
 func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/dnscheck/dnscheck_test.go
+++ b/experiment/dnscheck/dnscheck_test.go
@@ -163,10 +163,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/example/example.go
+++ b/experiment/example/example.go
@@ -93,8 +93,3 @@ type SummaryKeys struct {
 func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/example/example_test.go
+++ b/experiment/example/example_test.go
@@ -65,10 +65,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &example.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/fbmessenger/fbmessenger.go
+++ b/experiment/fbmessenger/fbmessenger.go
@@ -225,8 +225,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.IsAnomaly = dnsBlocking || tcpBlocking
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/fbmessenger/fbmessenger_test.go
+++ b/experiment/fbmessenger/fbmessenger_test.go
@@ -361,10 +361,3 @@ func TestSummaryKeysWithTrueTrue(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &fbmessenger.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/hhfm/hhfm.go
+++ b/experiment/hhfm/hhfm.go
@@ -368,8 +368,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 		tk.Tampering.Total)
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/hhfm/hhfm_test.go
+++ b/experiment/hhfm/hhfm_test.go
@@ -904,10 +904,3 @@ func TestSummaryKeysWorksAsIntended(t *testing.T) {
 		})
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &hhfm.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/hirl/hirl.go
+++ b/experiment/hirl/hirl.go
@@ -321,8 +321,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.IsAnomaly = tk.Tampering
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/hirl/hirl_test.go
+++ b/experiment/hirl/hirl_test.go
@@ -596,10 +596,3 @@ func TestSummaryKeysTrue(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &hirl.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/httphostheader/httphostheader.go
+++ b/experiment/httphostheader/httphostheader.go
@@ -92,8 +92,3 @@ type SummaryKeys struct {
 func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/httphostheader/httphostheader_test.go
+++ b/experiment/httphostheader/httphostheader_test.go
@@ -105,10 +105,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/ndt7/ndt7.go
+++ b/experiment/ndt7/ndt7.go
@@ -326,8 +326,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.RetransmitRate = tk.Summary.RetransmitRate
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/ndt7/ndt7_test.go
+++ b/experiment/ndt7/ndt7_test.go
@@ -285,10 +285,3 @@ func TestSummaryKeysGood(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/psiphon/psiphon.go
+++ b/experiment/psiphon/psiphon.go
@@ -130,8 +130,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.BootstrapTime = tk.BootstrapTime
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/psiphon/psiphon_test.go
+++ b/experiment/psiphon/psiphon_test.go
@@ -164,10 +164,3 @@ func TestSummaryKeysFailure(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &psiphon.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/riseupvpn/riseupvpn.go
+++ b/experiment/riseupvpn/riseupvpn.go
@@ -292,8 +292,3 @@ type SummaryKeys struct {
 func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/riseupvpn/riseupvpn_test.go
+++ b/experiment/riseupvpn/riseupvpn_test.go
@@ -440,10 +440,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &riseupvpn.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/sniblocking/sniblocking.go
+++ b/experiment/sniblocking/sniblocking.go
@@ -304,8 +304,3 @@ type SummaryKeys struct {
 func (m *Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m *Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/sniblocking/sniblocking_test.go
+++ b/experiment/sniblocking/sniblocking_test.go
@@ -432,10 +432,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/stunreachability/stunreachability.go
+++ b/experiment/stunreachability/stunreachability.go
@@ -167,8 +167,3 @@ type SummaryKeys struct {
 func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/stunreachability/stunreachability_test.go
+++ b/experiment/stunreachability/stunreachability_test.go
@@ -240,10 +240,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &stunreachability.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/telegram/telegram.go
+++ b/experiment/telegram/telegram.go
@@ -172,8 +172,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.IsAnomaly = webBlocking || httpBlocking || tcpBlocking
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/telegram/telegram_test.go
+++ b/experiment/telegram/telegram_test.go
@@ -414,10 +414,3 @@ func TestSummaryKeysWorksAsIntended(t *testing.T) {
 		})
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &telegram.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/tlstool/tlstool.go
+++ b/experiment/tlstool/tlstool.go
@@ -175,8 +175,3 @@ type SummaryKeys struct {
 func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/tlstool/tlstool_test.go
+++ b/experiment/tlstool/tlstool_test.go
@@ -90,10 +90,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &tlstool.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/tor/tor.go
+++ b/experiment/tor/tor.go
@@ -474,8 +474,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 		(sk.ORPortAccessible <= 0 && sk.ORPortTotal > 0))
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/tor/tor_test.go
+++ b/experiment/tor/tor_test.go
@@ -929,10 +929,3 @@ func TestSummaryKeysWorksAsIntended(t *testing.T) {
 		})
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -127,8 +127,3 @@ type SummaryKeys struct {
 func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, error) {
 	return SummaryKeys{IsAnomaly: false}, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -88,10 +88,3 @@ func TestSummaryKeysGeneric(t *testing.T) {
 		t.Fatal("invalid isAnomaly")
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &urlgetter.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/webconnectivity/webconnectivity.go
+++ b/experiment/webconnectivity/webconnectivity.go
@@ -222,8 +222,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.Accessible = tk.Accessible != nil && *tk.Accessible
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/webconnectivity/webconnectivity_test.go
+++ b/experiment/webconnectivity/webconnectivity_test.go
@@ -415,10 +415,3 @@ func TestSummaryKeysWorksAsIntended(t *testing.T) {
 		})
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &webconnectivity.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment/whatsapp/whatsapp.go
+++ b/experiment/whatsapp/whatsapp.go
@@ -235,8 +235,3 @@ func (m Measurer) GetSummaryKeys(measurement *model.Measurement) (interface{}, e
 	sk.IsAnomaly = (sk.RegistrationServerBlocking || sk.WebBlocking || sk.EndpointsBlocking)
 	return sk, nil
 }
-
-// LogSummary implements model.ExperimentMeasurer.LogSummary.
-func (m Measurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment/whatsapp/whatsapp_test.go
+++ b/experiment/whatsapp/whatsapp_test.go
@@ -673,10 +673,3 @@ func TestSummaryKeysWorksAsIntended(t *testing.T) {
 		})
 	}
 }
-
-func TestLogSummary(t *testing.T) {
-	m := &whatsapp.Measurer{}
-	if err := m.LogSummary(log.Log, "xyz"); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/experiment_integration_test.go
+++ b/experiment_integration_test.go
@@ -340,7 +340,6 @@ func runexperimentflow(t *testing.T, experiment *Experiment, input string) {
 	if data == nil {
 		t.Fatal("data is nil")
 	}
-	t.Log(measurement.MakeGenericTestKeys())
 	err = experiment.SubmitAndUpdateMeasurement(measurement)
 	if err != nil {
 		t.Fatal(err)

--- a/experiment_integration_test.go
+++ b/experiment_integration_test.go
@@ -721,7 +721,3 @@ func (am *antaniMeasurer) Run(
 func (am *antaniMeasurer) GetSummaryKeys(m *model.Measurement) (interface{}, error) {
 	return nil, nil
 }
-
-func (am *antaniMeasurer) LogSummary(model.Logger, string) error {
-	return nil
-}

--- a/experiment_integration_test.go
+++ b/experiment_integration_test.go
@@ -358,6 +358,9 @@ func runexperimentflow(t *testing.T, experiment *Experiment, input string) {
 	if experiment.KibiBytesReceived() <= 0 {
 		t.Fatal("no data received?!")
 	}
+	if _, err := experiment.GetSummaryKeys(measurement); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestOptions(t *testing.T) {
@@ -718,5 +721,7 @@ func (am *antaniMeasurer) Run(
 }
 
 func (am *antaniMeasurer) GetSummaryKeys(m *model.Measurement) (interface{}, error) {
-	return nil, nil
+	return struct {
+		Failure *string `json:"failure"`
+	}{}, nil
 }

--- a/model/experiment.go
+++ b/model/experiment.go
@@ -91,7 +91,4 @@ type ExperimentMeasurer interface {
 
 	// GetSummaryKeys returns summary keys expected by ooni/probe-cli.
 	GetSummaryKeys(*Measurement) (interface{}, error)
-
-	// LogSummary logs the experiment summary.
-	LogSummary(Logger, string) error
 }

--- a/model/measurement.go
+++ b/model/measurement.go
@@ -130,33 +130,3 @@ func (m *Measurement) AddAnnotation(key, value string) {
 	}
 	m.Annotations[key] = value
 }
-
-// MakeGenericTestKeys casts the m.TestKeys to a map[string]interface{}.
-//
-// Ideally, all tests should have a clear Go structure, well defined, that
-// will be stored in m.TestKeys as an interface. This is not already the
-// case and it's just valid for tests written in Go. Until all tests will
-// be written in Go, we'll keep this glue here to make sure we convert from
-// the engine format to the cli format.
-//
-// This function will first attempt to cast directly to map[string]interface{},
-// which is possible for MK tests, and then use JSON serialization and
-// de-serialization only if that's required.
-func (m *Measurement) MakeGenericTestKeys() (map[string]interface{}, error) {
-	return m.makeGenericTestKeys(json.Marshal)
-}
-
-func (m *Measurement) makeGenericTestKeys(
-	marshal func(v interface{}) ([]byte, error),
-) (map[string]interface{}, error) {
-	if result, ok := m.TestKeys.(map[string]interface{}); ok {
-		return result, nil
-	}
-	data, err := marshal(m.TestKeys)
-	if err != nil {
-		return nil, err
-	}
-	var result map[string]interface{}
-	err = json.Unmarshal(data, &result)
-	return result, err
-}

--- a/model/model_internal_test.go
+++ b/model/model_internal_test.go
@@ -1,7 +1,0 @@
-package model
-
-func (m *Measurement) MakeGenericTestKeysEx(
-	marshal func(v interface{}) ([]byte, error),
-) (map[string]interface{}, error) {
-	return m.makeGenericTestKeys(marshal)
-}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -168,49 +168,6 @@ func TestScrubMarshalError(t *testing.T) {
 	}
 }
 
-func TestMakeGenericTestKeysIdempotent(t *testing.T) {
-	m := new(model.Measurement)
-	m.TestKeys = make(map[string]interface{})
-	_, err := m.MakeGenericTestKeysEx(
-		func(interface{}) ([]byte, error) {
-			return nil, errors.New("mocked error")
-		},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMakeGenericTestKeysSuccess(t *testing.T) {
-	m := makeMeasurement(makeMeasurementConfig{
-		ProbeIP:  "127.0.0.1",
-		ProbeASN: "AS137",
-		ProbeCC:  "IT",
-	})
-	out, err := m.MakeGenericTestKeys()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if out["client_resolver"].(string) != "91.80.37.104" {
-		t.Fatal("expected different client resolver here")
-	}
-}
-
-func TestMakeGenericTestKeysMarshalError(t *testing.T) {
-	m := new(model.Measurement)
-	out, err := m.MakeGenericTestKeysEx(
-		func(interface{}) ([]byte, error) {
-			return nil, errors.New("mocked error")
-		},
-	)
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if out != nil {
-		t.Fatal("expected nil output here")
-	}
-}
-
 func TestDiscardLoggerWorksAsIntended(t *testing.T) {
 	logger := model.DiscardLogger
 	logger.Debug("foo")


### PR DESCRIPTION
This pull request contains cleanups and refinements for the new probe-cli API that is meant to radically simplify the interaction between probe-cli and probe-engine and move a large amount of code to probe-engine.

The reference issue is https://github.com/ooni/probe/issues/1283.