### PR TITLE
fix context timeout not working as intended bug

### DIFF
--- a/oonimkall/sessioncontext_test.go
+++ b/oonimkall/sessioncontext_test.go
@@ -31,8 +31,8 @@ func TestNewContextWithZeroTimeout(t *testing.T) {
 	defer cancel()
 	go func() {
 		<-time.After(250 * time.Millisecond)
-		cancel()
 		here.Add(1)
+		cancel()
 	}()
 	<-ctx.Done()
 	if here.Load() != 1 {
@@ -46,8 +46,8 @@ func TestNewContextWithNegativeTimeout(t *testing.T) {
 	defer cancel()
 	go func() {
 		<-time.After(250 * time.Millisecond)
-		cancel()
 		here.Add(1)
+		cancel()
 	}()
 	<-ctx.Done()
 	if here.Load() != 1 {
@@ -61,8 +61,8 @@ func TestNewContextWithHugeTimeout(t *testing.T) {
 	defer cancel()
 	go func() {
 		<-time.After(250 * time.Millisecond)
-		cancel()
 		here.Add(1)
+		cancel()
 	}()
 	<-ctx.Done()
 	if here.Load() != 1 {
@@ -76,8 +76,8 @@ func TestNewContextWithReasonableTimeout(t *testing.T) {
 	defer cancel()
 	go func() {
 		<-time.After(5 * time.Second)
-		cancel()
 		here.Add(1)
+		cancel()
 	}()
 	<-ctx.Done()
 	if here.Load() != 0 {
@@ -92,8 +92,8 @@ func TestNewContextWithArtificiallyLowMaxTimeout(t *testing.T) {
 	defer cancel()
 	go func() {
 		<-time.After(30 * time.Second)
-		cancel()
 		here.Add(1)
+		cancel()
 	}()
 	<-ctx.Done()
 	if here.Load() != 0 {


### PR DESCRIPTION
This diff fixes the context timeout not working as intended bug
described in https://github.com/ooni/probe-engine/issues/994.

Before canceling the context we need to increase the counter so that
we're sure that canceling the context happens _after_ we increased
the counter. Otherwise, it may actually happen before depending on the
choices made by the Go scheduler.

Closes https://github.com/ooni/probe-engine/issues/994. If I am
wrong we will reopen, but I think this is at least a good explanation.