### PR TITLE
cleanup: remove unused OnDataUsage

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -142,14 +142,6 @@ type sessionExperimentCallbacks struct {
 	sess  *Session
 }
 
-func (cb *sessionExperimentCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
-	cb.sess.byteCounter.CountKibiBytesReceived(dloadKiB)
-	cb.exp.byteCounter.CountKibiBytesReceived(dloadKiB)
-	cb.sess.byteCounter.CountKibiBytesSent(uploadKiB)
-	cb.exp.byteCounter.CountKibiBytesSent(uploadKiB)
-	cb.inner.OnDataUsage(dloadKiB, uploadKiB)
-}
-
 func (cb *sessionExperimentCallbacks) OnProgress(percentage float64, message string) {
 	cb.inner.OnProgress(percentage, message)
 }

--- a/experiment/psiphon/psiphon_test.go
+++ b/experiment/psiphon/psiphon_test.go
@@ -101,9 +101,6 @@ type observerCallbacks struct {
 	progress *atomicx.Int64
 }
 
-func (d observerCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
-}
-
 func (d observerCallbacks) OnProgress(percentage float64, message string) {
 	d.progress.Add(1)
 }

--- a/experiment/webconnectivity/connects.go
+++ b/experiment/webconnectivity/connects.go
@@ -54,8 +54,5 @@ func Connects(ctx context.Context, config ConnectsConfig) (out ConnectsResult) {
 // ConnectsNoCallbacks suppresses the callbacks
 type ConnectsNoCallbacks struct{}
 
-// OnDataUsage implements ExperimentCallbacks.OnDataUsage
-func (ConnectsNoCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {}
-
 // OnProgress implements ExperimentCallbacks.OnProgress
 func (ConnectsNoCallbacks) OnProgress(percentage float64, message string) {}

--- a/experiment_integration_test.go
+++ b/experiment_integration_test.go
@@ -175,10 +175,6 @@ type registerCallbacksCalled struct {
 	onProgressCalled bool
 }
 
-func (c *registerCallbacksCalled) OnDataUsage(dloadKiB, uploadKiB float64) {
-	// nothing - unused
-}
-
 func (c *registerCallbacksCalled) OnProgress(percentage float64, message string) {
 	c.onProgressCalled = true
 }

--- a/model/experiment.go
+++ b/model/experiment.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/ooni/probe-engine/internal/humanizex"
 )
 
 // ExperimentOrchestraClient is the experiment's view of
@@ -35,12 +33,6 @@ type ExperimentSession interface {
 
 // ExperimentCallbacks contains experiment event-handling callbacks
 type ExperimentCallbacks interface {
-	// OnDataUsage provides information about data usage.
-	//
-	// This callback is deprecated and will be removed once we have
-	// removed the dependency on Measurement Kit.
-	OnDataUsage(dloadKiB, uploadKiB float64)
-
 	// OnProgress provides information about an experiment progress.
 	OnProgress(percentage float64, message string)
 }
@@ -53,14 +45,6 @@ type PrinterCallbacks struct {
 // NewPrinterCallbacks returns a new default callback handler
 func NewPrinterCallbacks(logger Logger) PrinterCallbacks {
 	return PrinterCallbacks{Logger: logger}
-}
-
-// OnDataUsage provides information about data usage.
-func (d PrinterCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
-	d.Logger.Infof("experiment: recv %s, sent %s",
-		humanizex.SI(dloadKiB*1024, "byte"),
-		humanizex.SI(uploadKiB*1024, "byte"),
-	)
 }
 
 // OnProgress provides information about an experiment progress.

--- a/model/experiment_test.go
+++ b/model/experiment_test.go
@@ -9,6 +9,5 @@ import (
 
 func TestPrinterCallbacksCallbacks(t *testing.T) {
 	printer := model.NewPrinterCallbacks(log.Log)
-	printer.OnDataUsage(10, 10)
 	printer.OnProgress(0.4, "progress")
 }

--- a/oonimkall/tasks/runner.go
+++ b/oonimkall/tasks/runner.go
@@ -205,10 +205,6 @@ type runnerCallbacks struct {
 	emitter *EventEmitter
 }
 
-func (cb *runnerCallbacks) OnDataUsage(dloadKiB, uploadKiB float64) {
-	// nothing!
-}
-
 func (cb *runnerCallbacks) OnProgress(percentage float64, message string) {
 	cb.emitter.Emit(statusProgress, EventStatusProgress{
 		Percentage: 0.4 + (percentage * 0.6), // open report is 40%


### PR DESCRIPTION
This callback is unused since we removed MK, as very cleary specified
in the sources of probe-cli. For this reason, I thought it was time for
us to get rid of this deprecated, unused piece of code.

See https://github.com/ooni/probe/issues/1283