### PR TITLE
feat(engine): create Submitter abstraction

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -79,7 +79,7 @@ func (e *Experiment) GetSummaryKeys(m *model.Measurement) (interface{}, error) {
 // you have configured the available probe services, either manually or
 // through using the session's MaybeLookupBackends method.
 func (e *Experiment) OpenReport() (err error) {
-	return e.openReport(context.Background())
+	return e.OpenReportContext(context.Background())
 }
 
 // ReportID returns the open reportID, if we have opened a report
@@ -184,7 +184,9 @@ func (e *Experiment) newMeasurement(input string) *model.Measurement {
 	return &m
 }
 
-func (e *Experiment) openReport(ctx context.Context) error {
+// OpenReportContext will open a report using the given context
+// to possibly limit the lifetime of this operation.
+func (e *Experiment) OpenReportContext(ctx context.Context) error {
 	if e.report != nil {
 		return nil // already open
 	}

--- a/submitter.go
+++ b/submitter.go
@@ -1,0 +1,75 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/model"
+)
+
+// TODO(bassosimone): maybe keep track of which measurements
+// could not be submitted by a specific submitter?
+
+// Submitter submits a measurement to the OONI collector.
+type Submitter interface {
+	// SubmitAndUpdateMeasurementContext submits the measurement
+	// and updates its report ID field in case of sucess.
+	SubmitAndUpdateMeasurementContext(
+		ctx context.Context, m *model.Measurement) error
+}
+
+// NewSubmitterConfig contains settings for NewSubmitter.
+type NewSubmitterConfig struct {
+	// Enabled is true if measurement submission is enabled.
+	Enabled bool
+
+	// Experiment is the current experiment.
+	Experiment SubmitterExperiment
+
+	// Logger is the logger to be used.
+	Logger SubmitterLogger
+}
+
+// SubmitterExperiment is the Submitter's view of the Experiment.
+//
+// Implementation note: we don't bother to define a function for closing
+// the report here, since closing reports is no longer necessary since
+// changes implemented in ooni/api in Oct-Nov 2020.
+type SubmitterExperiment interface {
+	// ReportID returns the ID of the currently opened report.
+	ReportID() string
+
+	// OpenReportContext opens a report for this experiment using the
+	// given context to possibly limit the operation duration.
+	OpenReportContext(ctx context.Context) error
+
+	// SubmitAndUpdateMeasurementContext submits the measurement
+	// and updates its report ID field in case of sucess.
+	SubmitAndUpdateMeasurementContext(
+		ctx context.Context, m *model.Measurement) error
+}
+
+// SubmitterLogger is the logger expected by Submitter.
+type SubmitterLogger interface {
+	Infof(format string, v ...interface{})
+}
+
+// NewSubmitter creates a new submitter instance. Depending on
+// whether submission is enabled or not, the returned submitter
+// instance migh just be a stub implementation.
+func NewSubmitter(ctx context.Context, config NewSubmitterConfig) (Submitter, error) {
+	if !config.Enabled {
+		return stubSubmitter{}, nil
+	}
+	if err := config.Experiment.OpenReportContext(ctx); err != nil {
+		return nil, err
+	}
+	config.Logger.Infof("reportID: %s", config.Experiment.ReportID())
+	return config.Experiment, nil
+}
+
+type stubSubmitter struct{}
+
+func (stubSubmitter) SubmitAndUpdateMeasurementContext(
+	ctx context.Context, m *model.Measurement) error {
+	return nil
+}

--- a/submitter.go
+++ b/submitter.go
@@ -64,7 +64,7 @@ func NewSubmitter(ctx context.Context, config NewSubmitterConfig) (Submitter, er
 		return nil, err
 	}
 	config.Logger.Infof("reportID: %s", config.Experiment.ReportID())
-	return config.Experiment, nil
+	return realSubmitter{Experiment: config.Experiment, Logger: config.Logger}, nil
 }
 
 type stubSubmitter struct{}
@@ -73,3 +73,18 @@ func (stubSubmitter) SubmitAndUpdateMeasurementContext(
 	ctx context.Context, m *model.Measurement) error {
 	return nil
 }
+
+var _ Submitter = stubSubmitter{}
+
+type realSubmitter struct {
+	Experiment SubmitterExperiment
+	Logger     SubmitterLogger
+}
+
+func (rs realSubmitter) SubmitAndUpdateMeasurementContext(
+	ctx context.Context, m *model.Measurement) error {
+	rs.Logger.Infof("submitting measurement to OONI collector; please, be patient...")
+	return rs.Experiment.SubmitAndUpdateMeasurementContext(ctx, m)
+}
+
+var _ Submitter = realSubmitter{}

--- a/submitter_test.go
+++ b/submitter_test.go
@@ -1,0 +1,105 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ooni/probe-engine/model"
+)
+
+func TestSubmitterNotEnabled(t *testing.T) {
+	ctx := context.Background()
+	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := submitter.(stubSubmitter); !ok {
+		t.Fatal("we did not get a stubSubmitter instance")
+	}
+	m := new(model.Measurement)
+	if err := submitter.SubmitAndUpdateMeasurementContext(ctx, m); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type FakeExperiment struct {
+	FakeReportID  string
+	OpenReportErr error
+	SubmitErr     error
+}
+
+func (fe FakeExperiment) OpenReportContext(ctx context.Context) error {
+	return fe.OpenReportErr
+}
+
+func (fe FakeExperiment) ReportID() string {
+	return fe.FakeReportID
+}
+
+func (fe FakeExperiment) SubmitAndUpdateMeasurementContext(
+	ctx context.Context, m *model.Measurement) error {
+	if fe.SubmitErr != nil {
+		return fe.SubmitErr
+	}
+	m.ReportID = fe.FakeReportID
+	return nil
+}
+
+var _ SubmitterExperiment = FakeExperiment{}
+
+func TestNewSubmitterOpenReportFailure(t *testing.T) {
+	expected := errors.New("mocked error")
+	ctx := context.Background()
+	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
+		Enabled:    true,
+		Experiment: FakeExperiment{OpenReportErr: expected},
+	})
+	if !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if submitter != nil {
+		t.Fatal("expected nil submitter here")
+	}
+}
+
+type FakeSubmitterLogger struct {
+	Written []string
+}
+
+func (fsl *FakeSubmitterLogger) Infof(format string, v ...interface{}) {
+	fsl.Written = append(fsl.Written, fmt.Sprintf(format, v...))
+}
+
+var _ SubmitterLogger = &FakeSubmitterLogger{}
+
+func TestNewSubmitterOpenReportSuccess(t *testing.T) {
+	fakeLogger := &FakeSubmitterLogger{}
+	reportID := "a_fake_report_id"
+	expected := errors.New("mocked error")
+	ctx := context.Background()
+	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
+		Enabled: true,
+		Experiment: FakeExperiment{
+			FakeReportID: reportID,
+			SubmitErr:    expected,
+		},
+		Logger: fakeLogger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fakeLogger.Written) != 1 {
+		t.Fatal("written wrong number of log entries")
+	}
+	if fakeLogger.Written[0] != "reportID: a_fake_report_id" {
+		t.Fatal("unexpected lopg entry written")
+	}
+	m := new(model.Measurement)
+	if err := submitter.SubmitAndUpdateMeasurementContext(ctx, m); !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+}

--- a/submitter_test.go
+++ b/submitter_test.go
@@ -102,4 +102,10 @@ func TestNewSubmitterOpenReportSuccess(t *testing.T) {
 	if err := submitter.SubmitAndUpdateMeasurementContext(ctx, m); !errors.Is(err, expected) {
 		t.Fatalf("not the error we expected: %+v", err)
 	}
+	if len(fakeLogger.Written) != 2 {
+		t.Fatal("written wrong number of log entries")
+	}
+	if fakeLogger.Written[1] != "submitting measurement to OONI collector; please, be patient..." {
+		t.Fatal("unexpected lopg entry written")
+	}
 }


### PR DESCRIPTION
This is a small abstraction that allows us to simplify code that is
submitting measurements by eliminating conditionals.

Work part of https://github.com/ooni/probe/issues/1283.