### PR TITLE
feat(engine): introduce the Saver abstraction

### DIFF
--- a/saver.go
+++ b/saver.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"errors"
+
+	"github.com/ooni/probe-engine/model"
+)
+
+// Saver saves a measurement on some persistent storage.
+type Saver interface {
+	SaveMeasurement(m *model.Measurement) error
+}
+
+// NewSaverConfig is the configuration for creating a new Saver.
+type NewSaverConfig struct {
+	// Enabled is true if saving is enabled.
+	Enabled bool
+
+	// Experiment is the experiment we're currently running.
+	Experiment SaverExperiment
+
+	// FilePath is the filepath where to append the measurement as a
+	// serialized JSON followed by a newline character.
+	FilePath string
+
+	// Logger is the logger we should be using.
+	Logger SaverLogger
+}
+
+// SaverExperiment is an experiment according to the Saver.
+type SaverExperiment interface {
+	SaveMeasurement(m *model.Measurement, filepath string) error
+}
+
+// SaverLogger is the logger expected by Saver.
+type SaverLogger interface {
+	Infof(format string, v ...interface{})
+}
+
+// NewSaver creates a new instance of Saver.
+func NewSaver(config NewSaverConfig) (Saver, error) {
+	if !config.Enabled {
+		return fakeSaver{}, nil
+	}
+	if config.FilePath == "" {
+		return nil, errors.New("saver: passed an empty filepath")
+	}
+	return realSaver{
+		Experiment: config.Experiment,
+		FilePath:   config.FilePath,
+		Logger:     config.Logger,
+	}, nil
+}
+
+type fakeSaver struct{}
+
+func (fs fakeSaver) SaveMeasurement(m *model.Measurement) error {
+	return nil
+}
+
+var _ Saver = fakeSaver{}
+
+type realSaver struct {
+	Experiment SaverExperiment
+	FilePath   string
+	Logger     SaverLogger
+}
+
+func (rs realSaver) SaveMeasurement(m *model.Measurement) error {
+	rs.Logger.Infof("saving measurement to disk")
+	return rs.Experiment.SaveMeasurement(m, rs.FilePath)
+}
+
+var _ Saver = realSaver{}

--- a/saver_test.go
+++ b/saver_test.go
@@ -1,0 +1,97 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ooni/probe-engine/model"
+)
+
+func TestNewSaverDisabled(t *testing.T) {
+	saver, err := NewSaver(NewSaverConfig{
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := saver.(fakeSaver); !ok {
+		t.Fatal("not the type of Saver we expected")
+	}
+	m := new(model.Measurement)
+	if err := saver.SaveMeasurement(m); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewSaverWithEmptyFilePath(t *testing.T) {
+	saver, err := NewSaver(NewSaverConfig{
+		Enabled:  true,
+		FilePath: "",
+	})
+	if err == nil || err.Error() != "saver: passed an empty filepath" {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if saver != nil {
+		t.Fatal("saver should be nil here")
+	}
+}
+
+type FakeSaverExperiment struct {
+	M        *model.Measurement
+	Error    error
+	FilePath string
+}
+
+func (fse *FakeSaverExperiment) SaveMeasurement(m *model.Measurement, filepath string) error {
+	fse.M = m
+	fse.FilePath = filepath
+	return fse.Error
+}
+
+var _ SaverExperiment = &FakeSaverExperiment{}
+
+type FakeSaverLogger struct {
+	Written []string
+}
+
+func (fsl *FakeSaverLogger) Infof(format string, v ...interface{}) {
+	fsl.Written = append(fsl.Written, fmt.Sprintf(format, v...))
+}
+
+var _ SaverLogger = &FakeSaverLogger{}
+
+func TestNewSaverWithFailureWhenSaving(t *testing.T) {
+	expected := errors.New("mocked error")
+	logger := &FakeSaverLogger{}
+	fse := &FakeSaverExperiment{Error: expected}
+	saver, err := NewSaver(NewSaverConfig{
+		Enabled:    true,
+		FilePath:   "report.jsonl",
+		Experiment: fse,
+		Logger:     logger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := saver.(realSaver); !ok {
+		t.Fatal("not the type of saver we expected")
+	}
+	m := &model.Measurement{Input: "www.kernel.org"}
+	if err := saver.SaveMeasurement(m); !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if len(logger.Written) != 1 {
+		t.Fatal("invalid number of log entries")
+	}
+	if logger.Written[0] != "saving measurement to disk" {
+		t.Fatal("invalid logged message")
+	}
+	if diff := cmp.Diff(fse.M, m); diff != "" {
+		t.Fatal(diff)
+	}
+	if fse.FilePath != "report.jsonl" {
+		t.Fatal("passed invalid filepath")
+	}
+}

--- a/submitter_test.go
+++ b/submitter_test.go
@@ -26,37 +26,37 @@ func TestSubmitterNotEnabled(t *testing.T) {
 	}
 }
 
-type FakeExperiment struct {
+type FakeSubmitterExperiment struct {
 	FakeReportID  string
 	OpenReportErr error
 	SubmitErr     error
 }
 
-func (fe FakeExperiment) OpenReportContext(ctx context.Context) error {
-	return fe.OpenReportErr
+func (fse FakeSubmitterExperiment) OpenReportContext(ctx context.Context) error {
+	return fse.OpenReportErr
 }
 
-func (fe FakeExperiment) ReportID() string {
-	return fe.FakeReportID
+func (fse FakeSubmitterExperiment) ReportID() string {
+	return fse.FakeReportID
 }
 
-func (fe FakeExperiment) SubmitAndUpdateMeasurementContext(
+func (fse FakeSubmitterExperiment) SubmitAndUpdateMeasurementContext(
 	ctx context.Context, m *model.Measurement) error {
-	if fe.SubmitErr != nil {
-		return fe.SubmitErr
+	if fse.SubmitErr != nil {
+		return fse.SubmitErr
 	}
-	m.ReportID = fe.FakeReportID
+	m.ReportID = fse.FakeReportID
 	return nil
 }
 
-var _ SubmitterExperiment = FakeExperiment{}
+var _ SubmitterExperiment = FakeSubmitterExperiment{}
 
 func TestNewSubmitterOpenReportFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	ctx := context.Background()
 	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
 		Enabled:    true,
-		Experiment: FakeExperiment{OpenReportErr: expected},
+		Experiment: FakeSubmitterExperiment{OpenReportErr: expected},
 	})
 	if !errors.Is(err, expected) {
 		t.Fatalf("not the error we expected: %+v", err)
@@ -83,7 +83,7 @@ func TestNewSubmitterOpenReportSuccess(t *testing.T) {
 	ctx := context.Background()
 	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
 		Enabled: true,
-		Experiment: FakeExperiment{
+		Experiment: FakeSubmitterExperiment{
 			FakeReportID: reportID,
 			SubmitErr:    expected,
 		},
@@ -91,6 +91,9 @@ func TestNewSubmitterOpenReportSuccess(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if _, ok := submitter.(realSubmitter); !ok {
+		t.Fatal("not the type of submitter we expected")
 	}
 	if len(fakeLogger.Written) != 1 {
 		t.Fatal("written wrong number of log entries")


### PR DESCRIPTION
Same design of Submitter, except we use it for saving measurements
on the file system. While there, tweak submitter tests.

Reference issue: https://github.com/ooni/probe/issues/1283.