### PR TITLE
fix(engine): InputLoader's now an interface

### DIFF
--- a/inputloader_integration_test.go
+++ b/inputloader_integration_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 func TestInputLoaderInputNoneWithStaticInputs(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		StaticInputs: []string{"https://www.google.com/"},
 		InputPolicy:  engine.InputNone,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if !errors.Is(err, engine.ErrNoInputExpected) {
@@ -29,13 +29,13 @@ func TestInputLoaderInputNoneWithStaticInputs(t *testing.T) {
 }
 
 func TestInputLoaderInputNoneWithFilesInputs(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		SourceFiles: []string{
 			"testdata/inputloader1.txt",
 			"testdata/inputloader2.txt",
 		},
 		InputPolicy: engine.InputNone,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if !errors.Is(err, engine.ErrNoInputExpected) {
@@ -47,14 +47,14 @@ func TestInputLoaderInputNoneWithFilesInputs(t *testing.T) {
 }
 
 func TestInputLoaderInputNoneWithBothInputs(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		StaticInputs: []string{"https://www.google.com/"},
 		SourceFiles: []string{
 			"testdata/inputloader1.txt",
 			"testdata/inputloader2.txt",
 		},
 		InputPolicy: engine.InputNone,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if !errors.Is(err, engine.ErrNoInputExpected) {
@@ -66,9 +66,9 @@ func TestInputLoaderInputNoneWithBothInputs(t *testing.T) {
 }
 
 func TestInputLoaderInputNoneWithNoInput(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		InputPolicy: engine.InputNone,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if err != nil {
@@ -80,9 +80,9 @@ func TestInputLoaderInputNoneWithNoInput(t *testing.T) {
 }
 
 func TestInputLoaderInputOptionalWithNoInput(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		InputPolicy: engine.InputOptional,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if err != nil {
@@ -94,14 +94,14 @@ func TestInputLoaderInputOptionalWithNoInput(t *testing.T) {
 }
 
 func TestInputLoaderInputOptionalWithInput(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		StaticInputs: []string{"https://www.google.com/"},
 		SourceFiles: []string{
 			"testdata/inputloader1.txt",
 			"testdata/inputloader2.txt",
 		},
 		InputPolicy: engine.InputOptional,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if err != nil {
@@ -123,7 +123,7 @@ func TestInputLoaderInputOptionalWithInput(t *testing.T) {
 }
 
 func TestInputLoaderInputOptionalNonexistentFile(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		StaticInputs: []string{"https://www.google.com/"},
 		SourceFiles: []string{
 			"testdata/inputloader1.txt",
@@ -131,7 +131,7 @@ func TestInputLoaderInputOptionalNonexistentFile(t *testing.T) {
 			"testdata/inputloader2.txt",
 		},
 		InputPolicy: engine.InputOptional,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if !errors.Is(err, syscall.ENOENT) {
@@ -143,14 +143,14 @@ func TestInputLoaderInputOptionalNonexistentFile(t *testing.T) {
 }
 
 func TestInputLoaderInputRequiredlWithInput(t *testing.T) {
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		StaticInputs: []string{"https://www.google.com/"},
 		SourceFiles: []string{
 			"testdata/inputloader1.txt",
 			"testdata/inputloader2.txt",
 		},
 		InputPolicy: engine.InputRequired,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if err != nil {
@@ -184,10 +184,10 @@ func TestInputLoaderInputRequiredlWithNoInputAndCancelledContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer sess.Close()
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		InputPolicy: engine.InputRequired,
 		Session:     sess,
-	}
+	})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // fail immediately
 	out, err := il.Load(ctx)
@@ -219,11 +219,11 @@ func TestInputLoaderInputRequiredlWithNoInputGood(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer sess.Close()
-	il := engine.InputLoader{
+	il := engine.NewInputLoader(engine.InputLoaderConfig{
 		InputPolicy: engine.InputRequired,
 		Session:     sess,
 		URLLimit:    30,
-	}
+	})
 	ctx := context.Background()
 	out, err := il.Load(ctx)
 	if err != nil {

--- a/inputloader_test.go
+++ b/inputloader_test.go
@@ -33,7 +33,7 @@ func (InputLoaderBrokenFile) Close() error {
 }
 
 func TestInputLoaderReadfileScannerFailure(t *testing.T) {
-	il := InputLoader{}
+	il := inputLoader{}
 	out, err := il.readfile("", InputLoaderBrokenFS{}.Open)
 	if !errors.Is(err, syscall.EFAULT) {
 		t.Fatal("not the error we expected")
@@ -64,7 +64,7 @@ func (InputLoaderBrokenSession) ProbeCC() string {
 }
 
 func TestInputLoaderNewOrchestraClientFailure(t *testing.T) {
-	il := InputLoader{}
+	il := inputLoader{}
 	lrc := loadRemoteConfig{
 		ctx:     context.Background(),
 		session: InputLoaderBrokenSession{},
@@ -93,7 +93,7 @@ func (InputLoaderBrokenOrchestraClient) FetchURLList(ctx context.Context, config
 }
 
 func TestInputLoaderFetchURLListFailure(t *testing.T) {
-	il := InputLoader{}
+	il := inputLoader{}
 	lrc := loadRemoteConfig{
 		ctx: context.Background(),
 		session: InputLoaderBrokenSession{

--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -318,13 +318,13 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 	builder, err := sess.NewExperimentBuilder(experimentName)
 	fatalOnError(err, "cannot create experiment builder")
 
-	inputLoader := engine.InputLoader{
+	inputLoader := engine.NewInputLoader(engine.InputLoaderConfig{
 		StaticInputs: currentOptions.Inputs,
 		SourceFiles:  currentOptions.InputFilePaths,
 		InputPolicy:  builder.InputPolicy(),
 		Session:      sess,
 		URLLimit:     17,
-	}
+	})
 	inputs, err := inputLoader.Load(context.Background())
 	fatalOnError(err, "cannot load inputs")
 
@@ -339,14 +339,14 @@ func MainWithConfiguration(experimentName string, currentOptions Options) {
 		)
 	}()
 
-	submitter, err := engine.NewSubmitter(ctx, engine.NewSubmitterConfig{
+	submitter, err := engine.NewSubmitter(ctx, engine.SubmitterConfig{
 		Enabled:    currentOptions.NoCollector == false,
 		Experiment: experiment,
 		Logger:     sess.Logger(),
 	})
 	fatalOnError(err, "cannot create submitter")
 
-	saver, err := engine.NewSaver(engine.NewSaverConfig{
+	saver, err := engine.NewSaver(engine.SaverConfig{
 		Enabled:    currentOptions.NoJSON == false,
 		Experiment: experiment,
 		FilePath:   currentOptions.ReportFile,

--- a/saver.go
+++ b/saver.go
@@ -11,8 +11,8 @@ type Saver interface {
 	SaveMeasurement(m *model.Measurement) error
 }
 
-// NewSaverConfig is the configuration for creating a new Saver.
-type NewSaverConfig struct {
+// SaverConfig is the configuration for creating a new Saver.
+type SaverConfig struct {
 	// Enabled is true if saving is enabled.
 	Enabled bool
 
@@ -38,7 +38,7 @@ type SaverLogger interface {
 }
 
 // NewSaver creates a new instance of Saver.
-func NewSaver(config NewSaverConfig) (Saver, error) {
+func NewSaver(config SaverConfig) (Saver, error) {
 	if !config.Enabled {
 		return fakeSaver{}, nil
 	}

--- a/saver_test.go
+++ b/saver_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewSaverDisabled(t *testing.T) {
-	saver, err := NewSaver(NewSaverConfig{
+	saver, err := NewSaver(SaverConfig{
 		Enabled: false,
 	})
 	if err != nil {
@@ -26,7 +26,7 @@ func TestNewSaverDisabled(t *testing.T) {
 }
 
 func TestNewSaverWithEmptyFilePath(t *testing.T) {
-	saver, err := NewSaver(NewSaverConfig{
+	saver, err := NewSaver(SaverConfig{
 		Enabled:  true,
 		FilePath: "",
 	})
@@ -66,7 +66,7 @@ func TestNewSaverWithFailureWhenSaving(t *testing.T) {
 	expected := errors.New("mocked error")
 	logger := &FakeSaverLogger{}
 	fse := &FakeSaverExperiment{Error: expected}
-	saver, err := NewSaver(NewSaverConfig{
+	saver, err := NewSaver(SaverConfig{
 		Enabled:    true,
 		FilePath:   "report.jsonl",
 		Experiment: fse,

--- a/submitter.go
+++ b/submitter.go
@@ -17,8 +17,8 @@ type Submitter interface {
 		ctx context.Context, m *model.Measurement) error
 }
 
-// NewSubmitterConfig contains settings for NewSubmitter.
-type NewSubmitterConfig struct {
+// SubmitterConfig contains settings for NewSubmitter.
+type SubmitterConfig struct {
 	// Enabled is true if measurement submission is enabled.
 	Enabled bool
 
@@ -56,7 +56,7 @@ type SubmitterLogger interface {
 // NewSubmitter creates a new submitter instance. Depending on
 // whether submission is enabled or not, the returned submitter
 // instance migh just be a stub implementation.
-func NewSubmitter(ctx context.Context, config NewSubmitterConfig) (Submitter, error) {
+func NewSubmitter(ctx context.Context, config SubmitterConfig) (Submitter, error) {
 	if !config.Enabled {
 		return stubSubmitter{}, nil
 	}

--- a/submitter_test.go
+++ b/submitter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSubmitterNotEnabled(t *testing.T) {
 	ctx := context.Background()
-	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
+	submitter, err := NewSubmitter(ctx, SubmitterConfig{
 		Enabled: false,
 	})
 	if err != nil {
@@ -54,7 +54,7 @@ var _ SubmitterExperiment = FakeSubmitterExperiment{}
 func TestNewSubmitterOpenReportFailure(t *testing.T) {
 	expected := errors.New("mocked error")
 	ctx := context.Background()
-	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
+	submitter, err := NewSubmitter(ctx, SubmitterConfig{
 		Enabled:    true,
 		Experiment: FakeSubmitterExperiment{OpenReportErr: expected},
 	})
@@ -81,7 +81,7 @@ func TestNewSubmitterOpenReportSuccess(t *testing.T) {
 	reportID := "a_fake_report_id"
 	expected := errors.New("mocked error")
 	ctx := context.Background()
-	submitter, err := NewSubmitter(ctx, NewSubmitterConfig{
+	submitter, err := NewSubmitter(ctx, SubmitterConfig{
 		Enabled: true,
 		Experiment: FakeSubmitterExperiment{
 			FakeReportID: reportID,


### PR DESCRIPTION
We need InputLoader to be an interface because:

1. its implementation is actually quite appropriate for an interface
since we select different code paths depending on the policy

2. an interface is easier to wrap for probe-cli

While there, don't name config structs like NewFooConfig because the
NewSomething pattern in Go implies a factory, so better to avoid being
confusing with naming.

Notwithstanding point 1. above, I'm not doing a full refactoring to
an interfaces based implementation for InputLoader because the existing
code is already good and we don't need this change now.

This diff is part of https://github.com/ooni/probe/issues/1283.