### PR TITLE
feat(engine): introduce InputProcessor abstraction

### DIFF
--- a/inputprocessor.go
+++ b/inputprocessor.go
@@ -1,0 +1,140 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/model"
+)
+
+// InputProcessorExperiment is the Experiment
+// according to InputProcessor.
+type InputProcessorExperiment interface {
+	MeasureWithContext(
+		ctx context.Context, input string) (*model.Measurement, error)
+}
+
+// InputProcessorExperimentWrapper is a wrapper for an
+// Experiment that also allow to pass around the input index.
+type InputProcessorExperimentWrapper interface {
+	MeasureWithContext(
+		ctx context.Context, idx int, input string) (*model.Measurement, error)
+}
+
+// NewInputProcessorExperimentWrapper creates a new
+// instance of InputProcessorExperimentWrapper.
+func NewInputProcessorExperimentWrapper(
+	exp InputProcessorExperiment) InputProcessorExperimentWrapper {
+	return inputProcessorExperimentWrapper{exp: exp}
+}
+
+type inputProcessorExperimentWrapper struct {
+	exp InputProcessorExperiment
+}
+
+func (ipew inputProcessorExperimentWrapper) MeasureWithContext(
+	ctx context.Context, idx int, input string) (*model.Measurement, error) {
+	return ipew.exp.MeasureWithContext(ctx, input)
+}
+
+var _ InputProcessorExperimentWrapper = inputProcessorExperimentWrapper{}
+
+// InputProcessor processes inputs. We perform a Measurement
+// for each input using the given Experiment.
+type InputProcessor struct {
+	// Annotations contains the measurement annotations
+	Annotations map[string]string
+
+	// Experiment is the code that will run the experiment.
+	Experiment InputProcessorExperimentWrapper
+
+	// Inputs is the list of inputs to measure.
+	Inputs []model.URLInfo
+
+	// Options contains command line options for this experiment.
+	Options []string
+
+	// Saver is the code that will save measurement results
+	// on persistent storage (e.g. the file system).
+	Saver InputProcessorSaverWrapper
+
+	// Submitter is the code that will submit measurements
+	// to the OONI collector.
+	Submitter InputProcessorSubmitterWrapper
+}
+
+// InputProcessorSaverWrapper is InputProcessor's
+// wrapper for a Saver implementation.
+type InputProcessorSaverWrapper interface {
+	SaveMeasurement(idx int, m *model.Measurement) error
+}
+
+type inputProcessorSaverWrapper struct {
+	saver Saver
+}
+
+// NewInputProcessorSaverWrapper wraps a Saver for InputProcessor.
+func NewInputProcessorSaverWrapper(saver Saver) InputProcessorSaverWrapper {
+	return inputProcessorSaverWrapper{saver: saver}
+}
+
+func (ipsw inputProcessorSaverWrapper) SaveMeasurement(
+	idx int, m *model.Measurement) error {
+	return ipsw.saver.SaveMeasurement(m)
+}
+
+// InputProcessorSubmitterWrapper is InputProcessor's
+// wrapper for a Submitter implementation.
+type InputProcessorSubmitterWrapper interface {
+	SubmitAndUpdateMeasurementContext(
+		ctx context.Context, idx int, m *model.Measurement) error
+}
+
+type inputProcessorSubmitterWrapper struct {
+	submitter Submitter
+}
+
+// NewInputProcessorSubmitterWrapper wraps a Submitter
+// for the InputProcessor.
+func NewInputProcessorSubmitterWrapper(submitter Submitter) InputProcessorSubmitterWrapper {
+	return inputProcessorSubmitterWrapper{submitter: submitter}
+}
+
+func (ipsw inputProcessorSubmitterWrapper) SubmitAndUpdateMeasurementContext(
+	ctx context.Context, idx int, m *model.Measurement) error {
+	return ipsw.submitter.SubmitAndUpdateMeasurementContext(ctx, m)
+}
+
+// Run processes all the input subject to the duration of the
+// context. The code will perform measurements using the given
+// experiment; submit measurements using the given submitter;
+// save measurements using the given saver.
+//
+// Annotations and Options will be saved in the measurement.
+//
+// The default behaviour of this code is that an error while
+// measuring, while submitting, or while saving a measurement
+// is always causing us to break out of the loop. The user
+// though is free to choose different policies by configuring
+// the Experiment, Submitter, and Saver fields properly.
+func (ip InputProcessor) Run(ctx context.Context) error {
+	for idx, url := range ip.Inputs {
+		input := url.URL
+		meas, err := ip.Experiment.MeasureWithContext(ctx, idx, input)
+		if err != nil {
+			return err
+		}
+		meas.Annotations = ip.Annotations
+		meas.Options = ip.Options
+		err = ip.Submitter.SubmitAndUpdateMeasurementContext(ctx, idx, meas)
+		if err != nil {
+			return err
+		}
+		// Note: must be after submission because submission modifies
+		// the measurement to include the report ID.
+		err = ip.Saver.SaveMeasurement(idx, meas)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/inputprocessor_test.go
+++ b/inputprocessor_test.go
@@ -1,0 +1,156 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ooni/probe-engine/model"
+)
+
+type FakeInputProcessorExperiment struct {
+	Err error
+	M   []*model.Measurement
+}
+
+func (fipe *FakeInputProcessorExperiment) MeasureWithContext(
+	ctx context.Context, input string) (*model.Measurement, error) {
+	if fipe.Err != nil {
+		return nil, fipe.Err
+	}
+	m := new(model.Measurement)
+	m.Input = model.MeasurementTarget(input)
+	fipe.M = append(fipe.M, m)
+	return m, nil
+}
+
+func TestInputProcessorMeasurementFailed(t *testing.T) {
+	expected := errors.New("mocked error")
+	ip := InputProcessor{
+		Experiment: NewInputProcessorExperimentWrapper(
+			&FakeInputProcessorExperiment{Err: expected},
+		),
+		Inputs: []model.URLInfo{{
+			URL: "https://www.kernel.org/",
+		}},
+	}
+	ctx := context.Background()
+	if err := ip.Run(ctx); !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+}
+
+type FakeInputProcessorSubmitter struct {
+	Err error
+	M   []*model.Measurement
+}
+
+func (fips *FakeInputProcessorSubmitter) SubmitAndUpdateMeasurementContext(
+	ctx context.Context, m *model.Measurement) error {
+	fips.M = append(fips.M, m)
+	return fips.Err
+}
+
+func TestInputProcessorSubmissionFailed(t *testing.T) {
+	fipe := &FakeInputProcessorExperiment{}
+	expected := errors.New("mocked error")
+	ip := InputProcessor{
+		Annotations: map[string]string{
+			"foo": "bar",
+		},
+		Experiment: NewInputProcessorExperimentWrapper(fipe),
+		Inputs: []model.URLInfo{{
+			URL: "https://www.kernel.org/",
+		}},
+		Options: []string{"fake=true"},
+		Submitter: NewInputProcessorSubmitterWrapper(
+			&FakeInputProcessorSubmitter{Err: expected},
+		),
+	}
+	ctx := context.Background()
+	if err := ip.Run(ctx); !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+	if len(fipe.M) != 1 {
+		t.Fatal("no measurements generated")
+	}
+	m := fipe.M[0]
+	if m.Input != "https://www.kernel.org/" {
+		t.Fatal("invalid input")
+	}
+	if m.Annotations["foo"] != "bar" {
+		t.Fatal("annotation not set")
+	}
+	if len(m.Options) != 1 || m.Options[0] != "fake=true" {
+		t.Fatal("options not set")
+	}
+}
+
+type FakeInputProcessorSaver struct {
+	Err error
+	M   []*model.Measurement
+}
+
+func (fips *FakeInputProcessorSaver) SaveMeasurement(m *model.Measurement) error {
+	fips.M = append(fips.M, m)
+	return fips.Err
+}
+
+func TestInputProcessorSaveOnDiskFailed(t *testing.T) {
+	expected := errors.New("mocked error")
+	ip := InputProcessor{
+		Experiment: NewInputProcessorExperimentWrapper(
+			&FakeInputProcessorExperiment{},
+		),
+		Inputs: []model.URLInfo{{
+			URL: "https://www.kernel.org/",
+		}},
+		Options: []string{"fake=true"},
+		Saver: NewInputProcessorSaverWrapper(
+			&FakeInputProcessorSaver{Err: expected},
+		),
+		Submitter: NewInputProcessorSubmitterWrapper(
+			&FakeInputProcessorSubmitter{Err: nil},
+		),
+	}
+	ctx := context.Background()
+	if err := ip.Run(ctx); !errors.Is(err, expected) {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+}
+
+func TestInputProcessorGood(t *testing.T) {
+	fipe := &FakeInputProcessorExperiment{}
+	saver := &FakeInputProcessorSaver{Err: nil}
+	submitter := &FakeInputProcessorSubmitter{Err: nil}
+	ip := InputProcessor{
+		Experiment: NewInputProcessorExperimentWrapper(fipe),
+		Inputs: []model.URLInfo{{
+			URL: "https://www.kernel.org/",
+		}, {
+			URL: "https://www.slashdot.org/",
+		}},
+		Options:   []string{"fake=true"},
+		Saver:     NewInputProcessorSaverWrapper(saver),
+		Submitter: NewInputProcessorSubmitterWrapper(submitter),
+	}
+	ctx := context.Background()
+	if err := ip.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(fipe.M) != 2 || len(saver.M) != 2 || len(submitter.M) != 2 {
+		t.Fatal("not all measurements saved")
+	}
+	if submitter.M[0].Input != "https://www.kernel.org/" {
+		t.Fatal("invalid submitter.M[0].Input")
+	}
+	if submitter.M[1].Input != "https://www.slashdot.org/" {
+		t.Fatal("invalid submitter.M[1].Input")
+	}
+	if saver.M[0].Input != "https://www.kernel.org/" {
+		t.Fatal("invalid saver.M[0].Input")
+	}
+	if saver.M[1].Input != "https://www.slashdot.org/" {
+		t.Fatal("invalid saver.M[1].Input")
+	}
+}

--- a/saver.go
+++ b/saver.go
@@ -22,19 +22,11 @@ type SaverConfig struct {
 	// FilePath is the filepath where to append the measurement as a
 	// serialized JSON followed by a newline character.
 	FilePath string
-
-	// Logger is the logger we should be using.
-	Logger SaverLogger
 }
 
 // SaverExperiment is an experiment according to the Saver.
 type SaverExperiment interface {
 	SaveMeasurement(m *model.Measurement, filepath string) error
-}
-
-// SaverLogger is the logger expected by Saver.
-type SaverLogger interface {
-	Infof(format string, v ...interface{})
 }
 
 // NewSaver creates a new instance of Saver.
@@ -48,7 +40,6 @@ func NewSaver(config SaverConfig) (Saver, error) {
 	return realSaver{
 		Experiment: config.Experiment,
 		FilePath:   config.FilePath,
-		Logger:     config.Logger,
 	}, nil
 }
 
@@ -63,11 +54,9 @@ var _ Saver = fakeSaver{}
 type realSaver struct {
 	Experiment SaverExperiment
 	FilePath   string
-	Logger     SaverLogger
 }
 
 func (rs realSaver) SaveMeasurement(m *model.Measurement) error {
-	rs.Logger.Infof("saving measurement to disk")
 	return rs.Experiment.SaveMeasurement(m, rs.FilePath)
 }
 

--- a/saver_test.go
+++ b/saver_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -52,25 +51,13 @@ func (fse *FakeSaverExperiment) SaveMeasurement(m *model.Measurement, filepath s
 
 var _ SaverExperiment = &FakeSaverExperiment{}
 
-type FakeSaverLogger struct {
-	Written []string
-}
-
-func (fsl *FakeSaverLogger) Infof(format string, v ...interface{}) {
-	fsl.Written = append(fsl.Written, fmt.Sprintf(format, v...))
-}
-
-var _ SaverLogger = &FakeSaverLogger{}
-
 func TestNewSaverWithFailureWhenSaving(t *testing.T) {
 	expected := errors.New("mocked error")
-	logger := &FakeSaverLogger{}
 	fse := &FakeSaverExperiment{Error: expected}
 	saver, err := NewSaver(SaverConfig{
 		Enabled:    true,
 		FilePath:   "report.jsonl",
 		Experiment: fse,
-		Logger:     logger,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -81,12 +68,6 @@ func TestNewSaverWithFailureWhenSaving(t *testing.T) {
 	m := &model.Measurement{Input: "www.kernel.org"}
 	if err := saver.SaveMeasurement(m); !errors.Is(err, expected) {
 		t.Fatalf("not the error we expected: %+v", err)
-	}
-	if len(logger.Written) != 1 {
-		t.Fatal("invalid number of log entries")
-	}
-	if logger.Written[0] != "saving measurement to disk" {
-		t.Fatal("invalid logged message")
 	}
 	if diff := cmp.Diff(fse.M, m); diff != "" {
 		t.Fatal(diff)

--- a/submitter_test.go
+++ b/submitter_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/ooni/probe-engine/model"
@@ -66,18 +65,7 @@ func TestNewSubmitterOpenReportFailure(t *testing.T) {
 	}
 }
 
-type FakeSubmitterLogger struct {
-	Written []string
-}
-
-func (fsl *FakeSubmitterLogger) Infof(format string, v ...interface{}) {
-	fsl.Written = append(fsl.Written, fmt.Sprintf(format, v...))
-}
-
-var _ SubmitterLogger = &FakeSubmitterLogger{}
-
 func TestNewSubmitterOpenReportSuccess(t *testing.T) {
-	fakeLogger := &FakeSubmitterLogger{}
 	reportID := "a_fake_report_id"
 	expected := errors.New("mocked error")
 	ctx := context.Background()
@@ -87,28 +75,12 @@ func TestNewSubmitterOpenReportSuccess(t *testing.T) {
 			FakeReportID: reportID,
 			SubmitErr:    expected,
 		},
-		Logger: fakeLogger,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := submitter.(realSubmitter); !ok {
-		t.Fatal("not the type of submitter we expected")
-	}
-	if len(fakeLogger.Written) != 1 {
-		t.Fatal("written wrong number of log entries")
-	}
-	if fakeLogger.Written[0] != "reportID: a_fake_report_id" {
-		t.Fatal("unexpected lopg entry written")
-	}
 	m := new(model.Measurement)
 	if err := submitter.SubmitAndUpdateMeasurementContext(ctx, m); !errors.Is(err, expected) {
 		t.Fatalf("not the error we expected: %+v", err)
-	}
-	if len(fakeLogger.Written) != 2 {
-		t.Fatal("written wrong number of log entries")
-	}
-	if fakeLogger.Written[1] != "submitting measurement to OONI collector; please, be patient..." {
-		t.Fatal("unexpected lopg entry written")
 	}
 }


### PR DESCRIPTION
The InputProcessor should capture the behaviour of any code that
is processing input to run an experiment.

Users should be able to customise this behaviour by wrapping specific
interfaces with other interfaces implementing state monads.

This work is part of https://github.com/ooni/probe/issues/1283