### PR TITLE
fix(urlgetter): say we're using the tcpconnect data format

### DIFF
--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -69,6 +69,7 @@ func RegisterExtensions(m *model.Measurement) {
 	archival.ExtHTTP.AddTo(m)
 	archival.ExtDNS.AddTo(m)
 	archival.ExtNetevents.AddTo(m)
+	archival.ExtTCPConnect.AddTo(m)
 	archival.ExtTLSHandshake.AddTo(m)
 	archival.ExtTunnel.AddTo(m)
 }

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -1,6 +1,6 @@
-// Package urlgetter implements a nettest that fetches a URL. This is not
-// an official OONI nettest, but rather is a probe-engine specific internal
-// experimental nettest that can be useful to do research.
+// Package urlgetter implements a nettest that fetches a URL.
+//
+// See https://github.com/ooni/spec/blob/master/nettests/ts-027-urlgetter.md.
 package urlgetter
 
 import (

--- a/experiment/urlgetter/urlgetter_test.go
+++ b/experiment/urlgetter/urlgetter_test.go
@@ -30,7 +30,7 @@ func TestMeasurer(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
 	}
-	if len(measurement.Extensions) != 5 {
+	if len(measurement.Extensions) != 6 {
 		t.Fatal("not the expected number of extensions")
 	}
 	tk := measurement.TestKeys.(*urlgetter.TestKeys)
@@ -67,7 +67,7 @@ func TestMeasurerDNSCache(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
 	}
-	if len(measurement.Extensions) != 5 {
+	if len(measurement.Extensions) != 6 {
 		t.Fatal("not the expected number of extensions")
 	}
 	tk := measurement.TestKeys.(*urlgetter.TestKeys)

--- a/probeservices/urls_test.go
+++ b/probeservices/urls_test.go
@@ -29,7 +29,7 @@ func TestFetchURLListSuccess(t *testing.T) {
 	}
 	for _, entry := range result {
 		if entry.CategoryCode != "NEWS" && entry.CategoryCode != "CULTR" {
-			t.Fatal("unexpected category code")
+			t.Fatalf("unexpected category code: %+v", entry)
 		}
 	}
 }


### PR DESCRIPTION
Related to https://github.com/ooni/probe-engine/issues/1055.