### PR TITLE
[MOBILE API CHANGE] cleanup(oonimkall): remove legacy options

### DIFF
--- a/oonimkall/tasks/runner_internal_test.go
+++ b/oonimkall/tasks/runner_internal_test.go
@@ -4,129 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
-	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	engine "github.com/ooni/probe-engine"
 )
-
-func TestRunnerHasUnsupportedSettings(t *testing.T) {
-	out := make(chan *Event)
-	var falsebool bool
-	var zerodotzero float64
-	var zero int64
-	var emptystring string
-	settings := &Settings{
-		InputFilepaths: []string{"foo"},
-		Options: SettingsOptions{
-			AllEndpoints:          &falsebool,
-			Backend:               "foo",
-			BouncerBaseURL:        "https://ps-nonexistent.ooni.io/",
-			CABundlePath:          "foo",
-			CollectorBaseURL:      "https://ps-nonexistent.ooni.io/",
-			ConstantBitrate:       &falsebool,
-			DNSNameserver:         &emptystring,
-			DNSEngine:             &emptystring,
-			ExpectedBody:          &emptystring,
-			GeoIPASNPath:          "foo",
-			GeoIPCountryPath:      "foo",
-			Hostname:              &emptystring,
-			IgnoreBouncerError:    &falsebool,
-			IgnoreOpenReportError: &falsebool,
-			MLabNSAddressFamily:   &emptystring,
-			MLabNSBaseURL:         &emptystring,
-			MLabNSCountry:         &emptystring,
-			MLabNSMetro:           &emptystring,
-			MLabNSPolicy:          &emptystring,
-			MLabNSToolName:        &emptystring,
-			NoFileReport:          false,
-			Port:                  &zero,
-			ProbeASN:              "AS0",
-			ProbeCC:               "ZZ",
-			ProbeIP:               "127.0.0.1",
-			ProbeNetworkName:      "XXX",
-			RandomizeInput:        true,
-			SaveRealResolverIP:    &falsebool,
-			Server:                &emptystring,
-			TestSuite:             &zero,
-			Timeout:               &zerodotzero,
-			UUID:                  &emptystring,
-		},
-		OutputFilepath: "foo",
-	}
-	go func() {
-		defer close(out)
-		r := NewRunner(settings, out)
-		logger := NewChanLogger(r.emitter, "WARNING", r.out)
-		if r.hasUnsupportedSettings(logger) != true {
-			panic("expected to see unsupported settings")
-		}
-	}()
-	var fatal, warn []string
-	for ev := range out {
-		switch ev.Key {
-		case "failure.startup":
-			evv := ev.Value.(EventFailure)
-			if strings.HasSuffix("not supported", evv.Failure) {
-				log.Fatalf("invalid value: %s", evv.Failure)
-			}
-			fatal = append(fatal, evv.Failure)
-		case "log":
-			evv := ev.Value.(EventLog)
-			if strings.HasSuffix("not supported", evv.Message) {
-				log.Fatalf("invalid value: %s", evv.Message)
-			}
-			warn = append(warn, evv.Message)
-		default:
-			log.Fatalf("invalid key: %s", ev.Key)
-		}
-	}
-	expectedFatal := []string{
-		"InputFilepaths: not supported",
-		"Options.Backend: not supported",
-		"Options.BouncerBaseURL: not supported",
-		"Options.CollectorBaseURL: not supported",
-		"Options.Port: not supported",
-		"Options.RandomizeInput: not supported",
-		"Options.SaveRealResolverIP: not supported",
-		"Options.Server: not supported",
-		"Options.TestSuite: not supported",
-		"Options.Timeout: not supported",
-		"Options.UUID: not supported",
-		"OutputFilepath && !NoFileReport: not supported",
-	}
-	if diff := cmp.Diff(expectedFatal, fatal); diff != "" {
-		t.Fatal(diff)
-	}
-	expectedWarn := []string{
-		"Options.AllEndpoints: not supported",
-		"Options.CABundlePath: not supported",
-		"Options.ConstantBitrate: not supported",
-		"Options.DNSNameserver: not supported",
-		"Options.DNSEngine: not supported",
-		"Options.ExpectedBody: not supported",
-		"Options.GeoIPASNPath: not supported",
-		"Options.GeoIPCountryPath: not supported",
-		"Options.Hostname: not supported",
-		"Options.IgnoreBouncerError: not supported",
-		"Options.IgnoreOpenReportError: not supported",
-		"Options.MLabNSAddressFamily: not supported",
-		"Options.MLabNSBaseURL: not supported",
-		"Options.MLabNSCountry: not supported",
-		"Options.MLabNSMetro: not supported",
-		"Options.MLabNSPolicy: not supported",
-		"Options.MLabNSToolName: not supported",
-		"Options.ProbeASN: not supported",
-		"Options.ProbeCC: not supported",
-		"Options.ProbeIP: not supported",
-		"Options.ProbeNetworkName: not supported",
-	}
-	if diff := cmp.Diff(expectedWarn, warn); diff != "" {
-		t.Fatal(diff)
-	}
-}
 
 func TestMeasurementSubmissionEventName(t *testing.T) {
 	if measurementSubmissionEventName(nil) != statusMeasurementSubmission {
@@ -156,6 +37,7 @@ func TestRunnerMaybeLookupLocationFailure(t *testing.T) {
 			SoftwareVersion: "0.1.0",
 		},
 		StateDir: "../../testdata/oonimkall/state",
+		Version:  1,
 	}
 	seench := make(chan int64)
 	go func() {

--- a/oonimkall/tasks/settings.go
+++ b/oonimkall/tasks/settings.go
@@ -1,7 +1,8 @@
 package tasks
 
-// Settings contains settings for a task. This structure extends the one
-// described by MK v0.10.9 FFI API (https://git.io/Jv4Rv).
+// Settings contains settings for a task. This structure derives from
+// the one described by MK v0.10.9 FFI API (https://git.io/Jv4Rv), yet
+// since 2020-12-03 we're not backwards compatible anymore.
 type Settings struct {
 	// Annotations contains the annotations to be added
 	// to every measurements performed by the task.
@@ -20,11 +21,6 @@ type Settings struct {
 	// requires input and you provide no input.
 	Inputs []string `json:"inputs,omitempty"`
 
-	// InputFilepaths contains the input file paths. This
-	// setting is not implemented by this library. Attempting
-	// to set it will cause a startup error.
-	InputFilepaths []string `json:"input_filepaths,omitempty"`
-
 	// LogLevel contains the logs level. See https://git.io/Jv4Rv
 	// for the names of the available log levels.
 	LogLevel string `json:"log_level,omitempty"`
@@ -35,12 +31,6 @@ type Settings struct {
 
 	// Options contains the task options.
 	Options SettingsOptions `json:"options"`
-
-	// OutputFilepath contains the output filepath. This
-	// setting is not implemented by this library. Attempting
-	// to set it will cause a startup error unless the
-	// Options.NoFileReport setting is true.
-	OutputFilepath string `json:"output_filepath,omitempty"`
 
 	// StateDir is the directory where to store persistent data. This
 	// field is an extension of MK's specification. If
@@ -53,184 +43,25 @@ type Settings struct {
 	// to our experiments as of 2020-06-10, leaving the TempDir empty works
 	// for iOS and does not work for Android.
 	TempDir string `json:"temp_dir"`
+
+	// Version indicates the version of this structure.
+	Version int64 `json:"version"`
 }
 
 // SettingsOptions contains the settings options
 type SettingsOptions struct {
-	// AllEndpoints is a WhatsApp specific option indicating that we
-	// should test all endpoints rather than a random susbet. This
-	// library does not support this setting and will emit a warning
-	// if you provide this option to a nettest.
-	AllEndpoints *bool `json:"all_endpoints,omitempty"`
-
-	// Backend is a test helper for a nettest. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup error.
-	Backend string `json:"backend,omitempty"`
-
-	// BouncerBaseURL contains the bouncer base URL. This option is not
-	// implemented by this library. Attempting to set it will cause
-	// a startup failure.
-	BouncerBaseURL string `json:"bouncer_base_url,omitempty"`
-
-	// CABundlePath contains the CA bundle path. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup warning, and the
-	// library will otherwise ignore this setting.
-	CABundlePath string `json:"net/ca_bundle_path,omitempty"`
-
-	// CollectorBaseURL contains the collector base URL. This option is not
-	// implemented by this library. Attempting to set it will cause
-	// a startup failure.
-	CollectorBaseURL string `json:"collector_base_url,omitempty"`
-
-	// ConstantBitrate was an option for the DASH experiment that
-	// this library does not support. Setting it to any value will
-	// cause the code to stop early with a startup failure.
-	ConstantBitrate *bool `json:"constant_bitrate,omitempty"`
-
-	// DNSNameserver is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	DNSNameserver *string `json:"dns_nameserver,omitempty"`
-
-	// DNSEngine is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	DNSEngine *string `json:"dns_engine,omitempty"`
-
-	// ExpectedBody is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	ExpectedBody *string `json:"expected_body,omitempty"`
-
-	// GeoIPASNPath is the ASN database path. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup warning, and the
-	// library will otherwise ignore this setting.
-	GeoIPASNPath string `json:"geoip_asn_path,omitempty"`
-
-	// GeoIPCountryPath is the country database path. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup warning, and the
-	// library will otherwise ignore this setting.
-	GeoIPCountryPath string `json:"geoip_country_path,omitempty"`
-
-	// Hostname is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	Hostname *string `json:"hostname,omitempty"`
-
-	// IgnoreBouncerError is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	IgnoreBouncerError *bool `json:"ignore_bouncer_error,omitempty"`
-
-	// IgnoreOpenReportError is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	IgnoreOpenReportError *bool `json:"ignore_open_report_error,omitempty"`
-
-	// MaxRuntime is the maximum runtime expressed. A negative
+	// MaxRuntime is the maximum runtime expressed in seconds. A negative
 	// value for this field disables the maximum runtime. Using
 	// a zero value will also mean disabled. This is not the
 	// original behaviour of Measurement Kit, which used to run
 	// for zero time in such case.
 	MaxRuntime float64 `json:"max_runtime,omitempty"`
 
-	// MLabNSAddressFamily is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	MLabNSAddressFamily *string `json:"mlabns/address_family,omitempty"`
-
-	// MLabNSBaseURL is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	MLabNSBaseURL *string `json:"mlabns/base_url,omitempty"`
-
-	// MLabNSCountry is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	MLabNSCountry *string `json:"mlabns/country,omitempty"`
-
-	// MLabNSMetro is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	MLabNSMetro *string `json:"mlabns/metro,omitempty"`
-
-	// MLabNSPolicy is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	MLabNSPolicy *string `json:"mlabns/policy,omitempty"`
-
-	// MLabNSToolName is a legacy option that this library does
-	// not support. Setting it causes the experiment to fail.
-	MLabNSToolName *string `json:"mlabns_tool_name,omitempty"`
-
-	// NoBouncer indicates whether to use a bouncer
-	NoBouncer bool `json:"no_bouncer,omitempty"`
-
 	// NoCollector indicates whether to use a collector
 	NoCollector bool `json:"no_collector,omitempty"`
 
-	// NoFileReport indicates whether to write a report file. Saving
-	// the report to file is currently not implemented by this
-	// library. Hence, if NoFileReport is false and OutputFilepath
-	// is not empty, there will be a startup error.
-	NoFileReport bool `json:"no_file_report,omitempty"`
-
-	// NoGeoIP indicates whether to perform a GeoIP lookup. This
-	// library fails if NoGeoIP and NoResolverLookup have different
-	// values since these two steps are performed together.
-	NoGeoIP bool `json:"no_geoip,omitempty"`
-
-	// NoResolverLookup indicates whether to perform a resolver lookup. This
-	// library fails if NoGeoIP and NoResolverLookup have different
-	// values since these two steps are performed together.
-	NoResolverLookup bool `json:"no_resolver_lookup"`
-
-	// Port is the port used by performance tests. This library does not
-	// support this option and fails if it is set by the user.
-	Port *int64 `json:"port"`
-
-	// ProbeASN is the AS number. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup warning, and the
-	// library will otherwise ignore this setting.
-	ProbeASN string `json:"probe_asn,omitempty"`
-
-	// ProbeCC is the probe country code. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup warning, and the
-	// library will otherwise ignore this setting.
-	ProbeCC string `json:"probe_cc,omitempty"`
-
-	// ProbeIP is the probe IP. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup warning, and the
-	// library will otherwise ignore this setting.
-	ProbeIP string `json:"probe_ip,omitempty"`
-
-	// ProbeNetworkName is the probe network name. This
-	// option is not implemented by this library. Attempting
-	// to set it will cause a startup warning, and the
-	// library will otherwise ignore this setting.
-	ProbeNetworkName string `json:"probe_network_name,omitempty"`
-
 	// ProbeServicesBaseURL contains the probe services base URL.
 	ProbeServicesBaseURL string `json:"probe_services_base_url,omitempty"`
-
-	// RandomizeInput indicates whether to randomize inputs. This
-	// option is not implemented by this library. Attempting
-	// to set it to true will cause a startup error.
-	RandomizeInput bool `json:"randomize_input,omitempty"`
-
-	// SaveRealProbeASN indicates whether to save the real probe ASN
-	SaveRealProbeASN bool `json:"save_real_probe_asn,omitempty"`
-
-	// SaveRealProbeCC indicates whether to save the real probe CC
-	SaveRealProbeCC bool `json:"save_real_probe_cc,omitempty"`
-
-	// SaveRealProbeIP indicates whether to save the real probe IP
-	SaveRealProbeIP bool `json:"save_real_probe_ip,omitempty"`
-
-	// SaveRealResolverIP is a legacy option that this library
-	// does not support. We will stop if you provide it.
-	SaveRealResolverIP *bool `json:"save_real_resolver_ip,omitempty"`
-
-	// Server is used by performance tests to indicate the specific
-	// hostname that shall be used for the server. This library does
-	// not support this setting and fails if you provide it.
-	Server *string `json:"server,omitempty"`
 
 	// SoftwareName is the software name. If this option is not
 	// present, then the library startup will fail.
@@ -239,13 +70,4 @@ type SettingsOptions struct {
 	// SoftwareVersion is the software version. If this option is not
 	// present, then the library startup will fail.
 	SoftwareVersion string `json:"software_version,omitempty"`
-
-	// TestSuite is a legacy option that this library does not support.
-	TestSuite *int64 `json:"test_suite,omitempty"`
-
-	// Timeout is a legacy option that this library does not support.
-	Timeout *float64 `json:"timeout,omitempty"`
-
-	// UUID is a legacy option that this library does not support.
-	UUID *string `json:"uuid,omitempty"`
 }


### PR DESCRIPTION
This diff removes all the legacy options. We now require a `version`
field to be present in the top-level settings and equal to 1.

I started this diff as a minimal attempt to cleanup oonimkall after
https://github.com/ooni/probe-engine/issues/974, but then realised the
time was ripe for a more fundamental cleanup.

Cc: @lorenzoPrimi.