### PR TITLE
fix(netx.go): address linter warning

### DIFF
--- a/netx/netx.go
+++ b/netx/netx.go
@@ -258,12 +258,12 @@ type httpTransportInfo struct {
 }
 
 var allTransportsInfo = map[bool]httpTransportInfo{
-	false: httpTransportInfo{
+	false: {
 		Factory: httptransport.NewSystemTransport,
 		// TODO(kelmenhorst): distinguish between h2 / http/1.1
 		TransportName: "h2 / http/1.1",
 	},
-	true: httpTransportInfo{
+	true: {
 		Factory:       httptransport.NewHTTP3Transport,
 		TransportName: "h3",
 	},


### PR DESCRIPTION
We can remove redundant structure tags from there.

Part of https://github.com/ooni/probe-engine/issues/1057.