### PR TITLE
fix(inputprocessor): merge annotations rather overwriting them

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -158,7 +158,7 @@ func (e *Experiment) CloseReport() (err error) {
 
 func (e *Experiment) newMeasurement(input string) *model.Measurement {
 	utctimenow := time.Now().UTC()
-	m := model.Measurement{
+	m := &model.Measurement{
 		DataFormatVersion:         probeservices.DefaultDataFormatVersion,
 		Input:                     model.MeasurementTarget(input),
 		MeasurementStartTime:      utctimenow.Format(dateFormat),
@@ -181,7 +181,7 @@ func (e *Experiment) newMeasurement(input string) *model.Measurement {
 	m.AddAnnotation("engine_name", "ooniprobe-engine")
 	m.AddAnnotation("engine_version", version.Version)
 	m.AddAnnotation("platform", platform.Name())
-	return &m
+	return m
 }
 
 // OpenReportContext will open a report using the given context

--- a/inputprocessor.go
+++ b/inputprocessor.go
@@ -123,7 +123,7 @@ func (ip InputProcessor) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		meas.Annotations = ip.Annotations
+		meas.AddAnnotations(ip.Annotations)
 		meas.Options = ip.Options
 		err = ip.Submitter.SubmitAndUpdateMeasurementContext(ctx, idx, meas)
 		if err != nil {

--- a/inputprocessor_test.go
+++ b/inputprocessor_test.go
@@ -19,6 +19,10 @@ func (fipe *FakeInputProcessorExperiment) MeasureWithContext(
 		return nil, fipe.Err
 	}
 	m := new(model.Measurement)
+	// Here we add annotations to ensure that the input processor
+	// is MERGING annotations as opposed to overwriting them.
+	m.AddAnnotation("antani", "antani")
+	m.AddAnnotation("foo", "baz") // would be bar below
 	m.Input = model.MeasurementTarget(input)
 	fipe.M = append(fipe.M, m)
 	return m, nil
@@ -78,8 +82,14 @@ func TestInputProcessorSubmissionFailed(t *testing.T) {
 	if m.Input != "https://www.kernel.org/" {
 		t.Fatal("invalid input")
 	}
+	if len(m.Annotations) != 2 {
+		t.Fatal("invalid number of annotations")
+	}
 	if m.Annotations["foo"] != "bar" {
-		t.Fatal("annotation not set")
+		t.Fatal("invalid annotation: foo")
+	}
+	if m.Annotations["antani"] != "antani" {
+		t.Fatal("invalid annotation: antani")
 	}
 	if len(m.Options) != 1 || m.Options[0] != "fake=true" {
 		t.Fatal("options not set")


### PR DESCRIPTION
Noticed while working on https://github.com/ooni/probe-engine/issues/1057.