### PR TITLE
fix(saver, submitter): make sure we only log when needed

### DIFF
--- a/saver.go
+++ b/saver.go
@@ -22,6 +22,9 @@ type SaverConfig struct {
 	// FilePath is the filepath where to append the measurement as a
 	// serialized JSON followed by a newline character.
 	FilePath string
+
+	// Logger is the logger used by the saver.
+	Logger model.Logger
 }
 
 // SaverExperiment is an experiment according to the Saver.
@@ -40,6 +43,7 @@ func NewSaver(config SaverConfig) (Saver, error) {
 	return realSaver{
 		Experiment: config.Experiment,
 		FilePath:   config.FilePath,
+		Logger:     config.Logger,
 	}, nil
 }
 
@@ -54,9 +58,11 @@ var _ Saver = fakeSaver{}
 type realSaver struct {
 	Experiment SaverExperiment
 	FilePath   string
+	Logger     model.Logger
 }
 
 func (rs realSaver) SaveMeasurement(m *model.Measurement) error {
+	rs.Logger.Info("saving measurement to disk")
 	return rs.Experiment.SaveMeasurement(m, rs.FilePath)
 }
 

--- a/saver_test.go
+++ b/saver_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/apex/log"
 	"github.com/google/go-cmp/cmp"
 	"github.com/ooni/probe-engine/model"
 )
@@ -58,6 +59,7 @@ func TestNewSaverWithFailureWhenSaving(t *testing.T) {
 		Enabled:    true,
 		FilePath:   "report.jsonl",
 		Experiment: fse,
+		Logger:     log.Log,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/submitter_test.go
+++ b/submitter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/apex/log"
 	"github.com/ooni/probe-engine/model"
 )
 
@@ -75,6 +76,7 @@ func TestNewSubmitterOpenReportSuccess(t *testing.T) {
 			FakeReportID: reportID,
 			SubmitErr:    expected,
 		},
+		Logger: log.Log,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
While working on https://github.com/ooni/probe-engine/issues/1057, I noticed
that since recent changes in probe-engine that introduced Saver and Submitter,
we've got logging wrong. We should actually be logging only when we're are
submitting and/or saving, and we shan't be logging otherwise.

While there, make sure we continue to print the reportID, which is a very
useful piece of information to see emitted by miniooni.