### PR TITLE
fix(mlablocatev2.go): correctly quote dots in regexp

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,12 +3,6 @@
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -28,10 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'go', 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        language: [ 'go' ]
 
     steps:
     - name: Checkout repository

--- a/internal/mlablocatev2/mlablocatev2.go
+++ b/internal/mlablocatev2/mlablocatev2.go
@@ -62,7 +62,7 @@ var (
 	//
 	// Example: mlab3-mil04.mlab-oti.measurement-lab.org.
 	siteRegexp = regexp.MustCompile(
-		`^(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.([a-z0-9-]{1,16})\.(measurement-lab.org)$`)
+		`^(mlab[1-4]d?)-([a-z]{3}[0-9tc]{2})\.([a-z0-9-]{1,16})\.(measurement-lab\.org)$`)
 )
 
 // Site returns the site name. If it is not possible to determine


### PR DESCRIPTION
See https://github.com/ooni/probe-engine/security/code-scanning/2