### PR TITLE
fix(whatsapp): escape all dots in regexp

### DIFF
--- a/experiment/whatsapp/whatsapp.go
+++ b/experiment/whatsapp/whatsapp.go
@@ -32,7 +32,7 @@ const (
 	testVersion = "0.9.0"
 )
 
-var endpointPattern = regexp.MustCompile("^tcpconnect://e[0-9]{1,2}.whatsapp.net:[0-9]{3,5}$")
+var endpointPattern = regexp.MustCompile(`^tcpconnect://e[0-9]{1,2}\.whatsapp\.net:[0-9]{3,5}$`)
 
 // Config contains the experiment config.
 type Config struct{}


### PR DESCRIPTION
See https://github.com/ooni/probe-engine/security/code-scanning/1