### PR TITLE
fix(urlgetter): progress over multiple collection tasks

### DIFF
--- a/experiment/riseupvpn/riseupvpn.go
+++ b/experiment/riseupvpn/riseupvpn.go
@@ -205,7 +205,7 @@ func (m Measurer) Run(ctx context.Context, sess model.ExperimentSession,
 	}
 	multi := urlgetter.Multi{Begin: measurement.MeasurementStartTimeSaved, Getter: m.Getter, Session: sess}
 
-	for entry := range multi.Collect(ctx, inputs, "riseupvpn", callbacks) {
+	for entry := range multi.CollectOverall(ctx, inputs, 0, 50, "riseupvpn", callbacks) {
 		testkeys.UpdateProviderAPITestKeys(entry)
 	}
 
@@ -213,16 +213,17 @@ func (m Measurer) Run(ctx context.Context, sess model.ExperimentSession,
 	gateways := parseGateways(testkeys)
 	openvpnEndpoints := generateMultiInputs(gateways, "openvpn")
 	obfs4Endpoints := generateMultiInputs(gateways, "obfs4")
+	overallCount := len(inputs) + len(openvpnEndpoints) + len(obfs4Endpoints)
 
 	// measure openvpn in parallel
 	multi = urlgetter.Multi{Begin: measurement.MeasurementStartTimeSaved, Getter: m.Getter, Session: sess}
-	for entry := range multi.Collect(ctx, openvpnEndpoints, "riseupvpn", callbacks) {
+	for entry := range multi.CollectOverall(ctx, openvpnEndpoints, len(inputs), overallCount, "riseupvpn", callbacks) {
 		testkeys.AddGatewayConnectTestKeys(entry, "openvpn")
 	}
 
 	// measure obfs4 in parallel
 	multi = urlgetter.Multi{Begin: measurement.MeasurementStartTimeSaved, Getter: m.Getter, Session: sess}
-	for entry := range multi.Collect(ctx, obfs4Endpoints, "riseupvpn", callbacks) {
+	for entry := range multi.CollectOverall(ctx, obfs4Endpoints, len(inputs)+len(openvpnEndpoints), overallCount, "riseupvpn", callbacks) {
 		testkeys.AddGatewayConnectTestKeys(entry, "obfs4")
 	}
 


### PR DESCRIPTION
Currently the `Multi.Collect()` method calculates the progress of a task based on the length of the `MultiInput` array. If an experiment performs multiple times `Multi.Collect()` the progress repeats increasing from 0% to 100%. This is especially an issue for a GUI client such as OONI Android, as it shows confusing estimations about the expected remaining runtime of a test. The shown expected time decreases multiple times to 0s and starts over again with a higher expected remaining time.

This PR introduces a method `Multi.CollectOverall()` that calculates the progress over multiple collection tasks. It is used in the RiseupVPN experiment. 

I would be interested to know if you see other/better options to archive the same goal.