### PR TITLE
[CLI CHANGE] feat(libminiooni): use --input-file like ooniprobe

### DIFF
--- a/libminiooni/libminiooni.go
+++ b/libminiooni/libminiooni.go
@@ -72,7 +72,7 @@ func init() {
 		"Pass an option to the experiment", "KEY=VALUE",
 	)
 	getopt.FlagLong(
-		&globalOptions.InputFilePaths, "file", 'f',
+		&globalOptions.InputFilePaths, "input-file", 'f',
 		"Path to input file to supply test-dependent input. File must contain one input per line.", "PATH",
 	)
 	getopt.FlagLong(


### PR DESCRIPTION
For ooniprobe we use --input-file to indicate the file to read input
from. Let us use the same CLI flag for consistency.

Done while working on https://github.com/ooni/probe-engine/issues/1115.