### PR TITLE
feat(dnscheck): allow users to force http3

### DIFF
--- a/experiment/dnscheck/dnscheck.go
+++ b/experiment/dnscheck/dnscheck.go
@@ -28,7 +28,8 @@ const (
 
 // Config contains the experiment's configuration.
 type Config struct {
-	Domain string `ooni:"domain to resolve using the specified resolver"`
+	Domain       string `json:"domain" ooni:"domain to resolve using the specified resolver"`
+	HTTP3Enabled bool   `json:"http3_enabled" ooni:"use http3 instead of http/1.1 or http2"`
 }
 
 // TestKeys contains the results of the dnscheck experiment.
@@ -129,7 +130,8 @@ func (m Measurer) Run(
 		inputs = append(inputs, urlgetter.MultiInput{
 			Config: urlgetter.Config{
 				DNSHTTPHost:      URL.Host, // use original host (and optional port)
-				RejectDNSBogons:  true,     // bogons are errors in this context
+				HTTP3Enabled:     m.Config.HTTP3Enabled,
+				RejectDNSBogons:  true, // bogons are errors in this context
 				ResolverURL:      makeResolverURL(URL, addr),
 				DNSTLSServerName: URL.Hostname(), // just the domain/IP for SNI
 			},

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -27,7 +27,7 @@ type Config struct {
 	DNSHTTPHost       string `ooni:"Force using specific HTTP Host header for DNS requests"`
 	DNSTLSServerName  string `ooni:"Force TLS to using a specific SNI for encrypted DNS requests"`
 	FailOnHTTPError   bool   `ooni:"Fail HTTP request if status code is 400 or above"`
-	HTTP3Enabled      bool   `ooni:"Force http3"`
+	HTTP3Enabled      bool   `ooni:"use http3 instead of http/1.1 or http2"`
 	HTTPHost          string `ooni:"Force using specific HTTP Host header"`
 	Method            string `ooni:"Force HTTP method different than GET"`
 	NoFollowRedirects bool   `ooni:"Disable following redirects"`


### PR DESCRIPTION
While there, tweak the documentation for HTTP3Enabled for both
urlgetter and dnscheck. While there, tag dnsheck options so that
they use snake case when they are serialised to JSON.

The latter change will become useful in the next pull request.

Part of https://github.com/ooni/probe-engine/issues/1115.