### PR TITLE
feat: introduce the experimental run experiment

### DIFF
--- a/allexperiments.go
+++ b/allexperiments.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ooni/probe-engine/experiment/ndt7"
 	"github.com/ooni/probe-engine/experiment/psiphon"
 	"github.com/ooni/probe-engine/experiment/riseupvpn"
+	"github.com/ooni/probe-engine/experiment/run"
 	"github.com/ooni/probe-engine/experiment/sniblocking"
 	"github.com/ooni/probe-engine/experiment/stunreachability"
 	"github.com/ooni/probe-engine/experiment/telegram"
@@ -191,6 +192,37 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 		}
 	},
 
+	"riseupvpn": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *Experiment {
+				return NewExperiment(session, riseupvpn.NewExperimentMeasurer(
+					*config.(*riseupvpn.Config),
+				))
+			},
+			config:      &riseupvpn.Config{},
+			inputPolicy: InputNone,
+		}
+	},
+
+	"run": func(session *Session) *ExperimentBuilder {
+		return &ExperimentBuilder{
+			build: func(config interface{}) *Experiment {
+				return NewExperiment(session, run.NewExperimentMeasurer(
+					*config.(*run.Config),
+				))
+			},
+			config: &run.Config{},
+			// TODO(bassosimone): we need to distinguish between the
+			// case where input is mandatory (this case actually) and
+			// the case where it is mandatory and we have an API to
+			// fetch input if missing (web connectivity). Current the
+			// case of web connectivity (InputRequired) cannot be used
+			// safely here because using it would cause us to fetch
+			// and run the experiment with meaningless URLs.
+			inputPolicy: InputOptional,
+		}
+	},
+
 	"sni_blocking": func(session *Session) *ExperimentBuilder {
 		return &ExperimentBuilder{
 			build: func(config interface{}) *Experiment {
@@ -198,7 +230,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 					*config.(*sniblocking.Config),
 				))
 			},
-			config: &sniblocking.Config{},
+			config:      &sniblocking.Config{},
 			inputPolicy: InputRequired,
 		}
 	},
@@ -212,18 +244,6 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 			},
 			config:      &stunreachability.Config{},
 			inputPolicy: InputOptional,
-		}
-	},
-
-	"riseupvpn": func(session *Session) *ExperimentBuilder {
-		return &ExperimentBuilder{
-			build: func(config interface{}) *Experiment {
-				return NewExperiment(session, riseupvpn.NewExperimentMeasurer(
-					*config.(*riseupvpn.Config),
-				))
-			},
-			config:      &riseupvpn.Config{},
-			inputPolicy: InputNone,
 		}
 	},
 

--- a/experiment/dnscheck/dnscheck.go
+++ b/experiment/dnscheck/dnscheck.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	testName      = "dnscheck"
-	testVersion   = "0.1.0"
+	testVersion   = "0.2.0"
 	defaultDomain = "example.org"
 )
 

--- a/experiment/dnscheck/dnscheck_test.go
+++ b/experiment/dnscheck/dnscheck_test.go
@@ -13,12 +13,10 @@ import (
 
 func TestExperimentNameAndVersion(t *testing.T) {
 	measurer := NewExperimentMeasurer(Config{Domain: "example.com"})
-
 	if measurer.ExperimentName() != "dnscheck" {
 		t.Error("unexpected experiment name")
 	}
-
-	if measurer.ExperimentVersion() != "0.1.0" {
+	if measurer.ExperimentVersion() != "0.2.0" {
 		t.Error("unexpected experiment version")
 	}
 }

--- a/experiment/run/dnscheck.go
+++ b/experiment/run/dnscheck.go
@@ -1,0 +1,16 @@
+package run
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/experiment/dnscheck"
+	"github.com/ooni/probe-engine/model"
+)
+
+func dodnscheck(ctx context.Context, input StructuredInput,
+	sess model.ExperimentSession, measurement *model.Measurement,
+	callbacks model.ExperimentCallbacks) error {
+	exp := dnscheck.Measurer{Config: input.DNSCheck}
+	measurement.Input = model.MeasurementTarget(input.Input)
+	return exp.Run(ctx, sess, measurement, callbacks)
+}

--- a/experiment/run/run.go
+++ b/experiment/run/run.go
@@ -1,0 +1,68 @@
+// Package run contains code to run other experiments.
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ooni/probe-engine/experiment/dnscheck"
+	"github.com/ooni/probe-engine/model"
+)
+
+// Config contains settings.
+type Config struct{}
+
+// Measurer runs the measurement.
+type Measurer struct{}
+
+// ExperimentName implements ExperimentMeasurer.ExperimentName.
+func (Measurer) ExperimentName() string {
+	return "run"
+}
+
+// ExperimentVersion implements ExperimentMeasurer.ExperimentVersion.
+func (Measurer) ExperimentVersion() string {
+	return "0.1.0"
+}
+
+// StructuredInput contains structured input for this experiment.
+type StructuredInput struct {
+	// DNSCheck contains settings for the dnscheck experiment.
+	DNSCheck dnscheck.Config `json:"dns_check"`
+
+	// Name is the name of the experiment to run.
+	Name string `json:"name"`
+
+	// Input is the input for this experiment.
+	Input string `json:"input"`
+}
+
+// Run implements ExperimentMeasurer.ExperimentVersion.
+func (Measurer) Run(
+	ctx context.Context, sess model.ExperimentSession,
+	measurement *model.Measurement, callbacks model.ExperimentCallbacks,
+) error {
+	var input StructuredInput
+	if err := json.Unmarshal([]byte(measurement.Input), &input); err != nil {
+		return err
+	}
+	mainfunc, found := table[input.Name]
+	if !found {
+		return fmt.Errorf("no such experiment: %s", input.Name)
+	}
+	return mainfunc(ctx, input, sess, measurement, callbacks)
+}
+
+// GetSummaryKeys implements ExperimentMeasurer.GetSummaryKeys
+func (Measurer) GetSummaryKeys(*model.Measurement) (interface{}, error) {
+	// TODO(bassosimone): we could extend this interface to call the
+	// specific GetSummaryKeys of the experiment we're running.
+	return dnscheck.SummaryKeys{IsAnomaly: false}, nil
+}
+
+// NewExperimentMeasurer creates a new model.ExperimentMeasurer
+// implementing the run experiment.
+func NewExperimentMeasurer(config Config) model.ExperimentMeasurer {
+	return Measurer{}
+}

--- a/experiment/run/run_test.go
+++ b/experiment/run/run_test.go
@@ -1,0 +1,81 @@
+package run_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/ooni/probe-engine/experiment/dnscheck"
+	"github.com/ooni/probe-engine/experiment/run"
+	"github.com/ooni/probe-engine/internal/mockable"
+	"github.com/ooni/probe-engine/model"
+)
+
+func TestExperimentNameAndVersion(t *testing.T) {
+	measurer := run.NewExperimentMeasurer(run.Config{})
+	if measurer.ExperimentName() != "run" {
+		t.Error("unexpected experiment name")
+	}
+	if measurer.ExperimentVersion() != "0.1.0" {
+		t.Error("unexpected experiment version")
+	}
+}
+
+func TestRunDNSCheckWithCancelledContext(t *testing.T) {
+	measurer := run.NewExperimentMeasurer(run.Config{})
+	input := `{"name": "dnscheck", "input": "https://dns.google/dns-query"}`
+	measurement := new(model.Measurement)
+	measurement.Input = model.MeasurementTarget(input)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // fail immediately
+	sess := &mockable.Session{MockableLogger: log.Log}
+	callbacks := model.NewPrinterCallbacks(log.Log)
+	err := measurer.Run(ctx, sess, measurement, callbacks)
+	// TODO(bassosimone): here we could improve the tests by checking
+	// whether the result makes sense for a cancelled context.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := measurement.TestKeys.(*dnscheck.TestKeys); !ok {
+		t.Fatal("invalid type for test keys")
+	}
+	sk, err := measurer.GetSummaryKeys(measurement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsk, ok := sk.(dnscheck.SummaryKeys)
+	if !ok {
+		t.Fatal("cannot convert summary keys to specific type")
+	}
+	if rsk.IsAnomaly != false {
+		t.Fatal("unexpected IsAnomaly value")
+	}
+}
+
+func TestRunWithInvalidJSON(t *testing.T) {
+	measurer := run.NewExperimentMeasurer(run.Config{})
+	input := `{"name": }`
+	measurement := new(model.Measurement)
+	measurement.Input = model.MeasurementTarget(input)
+	ctx := context.Background()
+	sess := &mockable.Session{MockableLogger: log.Log}
+	callbacks := model.NewPrinterCallbacks(log.Log)
+	err := measurer.Run(ctx, sess, measurement, callbacks)
+	if err == nil || err.Error() != "invalid character '}' looking for beginning of value" {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+}
+
+func TestRunWithUnknownExperiment(t *testing.T) {
+	measurer := run.NewExperimentMeasurer(run.Config{})
+	input := `{"name": "antani"}`
+	measurement := new(model.Measurement)
+	measurement.Input = model.MeasurementTarget(input)
+	ctx := context.Background()
+	sess := &mockable.Session{MockableLogger: log.Log}
+	callbacks := model.NewPrinterCallbacks(log.Log)
+	err := measurer.Run(ctx, sess, measurement, callbacks)
+	if err == nil || err.Error() != "no such experiment: antani" {
+		t.Fatalf("not the error we expected: %+v", err)
+	}
+}

--- a/experiment/run/table.go
+++ b/experiment/run/table.go
@@ -1,0 +1,20 @@
+package run
+
+import (
+	"context"
+
+	"github.com/ooni/probe-engine/model"
+)
+
+type experimentMain func(ctx context.Context, input StructuredInput,
+	sess model.ExperimentSession, measurement *model.Measurement,
+	callbacks model.ExperimentCallbacks) error
+
+var table = map[string]experimentMain{
+	// TODO(bassosimone): before extending run to support more than
+	// single experiment, we need to handle the case in which we are
+	// including different experiments into the same report ID.
+	// Probably, the right way to implement this functionality is to
+	// use proveservices.Submitter to submit reports.
+	"dnscheck": dodnscheck,
+}


### PR DESCRIPTION
This experiment takes in input one or more JSON documents. Each
JSON document describes an experiment that should be run.

The document also allows you to specify all the settings for the
experiment. We currently only support dnscheck.

This is an example of input file:

```JSON
{"name": "dnscheck", "input": "https://dns.google/dns-query", "dns_check":{"http3_enabled": true, "domain": "x.org"}}
{"name": "dnscheck", "input": "dot://dns.google", "dns_check":{"domain": "x.org"}}
```

This runs dnscheck twice. The first time using Google's DoH over
http3, for x.org. The second time using Google's DoT.

Part of https://github.com/ooni/probe-engine/issues/1115.