### PR TITLE
feat(experiment): split InputRequired policy

### DIFF
--- a/allexperiments.go
+++ b/allexperiments.go
@@ -46,7 +46,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &dnscheck.Config{},
-			inputPolicy: InputRequired,
+			inputPolicy: InputStrictlyRequired,
 		}
 	},
 
@@ -78,7 +78,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				SleepTime: int64(time.Second),
 			},
 			interruptible: true,
-			inputPolicy:   InputRequired,
+			inputPolicy:   InputStrictlyRequired,
 		}
 	},
 
@@ -98,7 +98,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				SleepTime: int64(time.Second),
 			},
 			interruptible: false,
-			inputPolicy:   InputRequired,
+			inputPolicy:   InputStrictlyRequired,
 		}
 	},
 
@@ -151,7 +151,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &httphostheader.Config{},
-			inputPolicy: InputRequired,
+			inputPolicy: InputOrQueryTestLists,
 		}
 	},
 
@@ -211,15 +211,8 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 					*config.(*run.Config),
 				))
 			},
-			config: &run.Config{},
-			// TODO(bassosimone): we need to distinguish between the
-			// case where input is mandatory (this case actually) and
-			// the case where it is mandatory and we have an API to
-			// fetch input if missing (web connectivity). Current the
-			// case of web connectivity (InputRequired) cannot be used
-			// safely here because using it would cause us to fetch
-			// and run the experiment with meaningless URLs.
-			inputPolicy: InputOptional,
+			config:      &run.Config{},
+			inputPolicy: InputStrictlyRequired,
 		}
 	},
 
@@ -231,7 +224,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &sniblocking.Config{},
-			inputPolicy: InputRequired,
+			inputPolicy: InputOrQueryTestLists,
 		}
 	},
 
@@ -267,7 +260,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &tlstool.Config{},
-			inputPolicy: InputRequired,
+			inputPolicy: InputOrQueryTestLists,
 		}
 	},
 
@@ -291,7 +284,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &urlgetter.Config{},
-			inputPolicy: InputRequired,
+			inputPolicy: InputStrictlyRequired,
 		}
 	},
 
@@ -303,7 +296,7 @@ var experimentsByName = map[string]func(*Session) *ExperimentBuilder{
 				))
 			},
 			config:      &webconnectivity.Config{},
-			inputPolicy: InputRequired,
+			inputPolicy: InputOrQueryTestLists,
 		}
 	},
 

--- a/experiment/run/run.go
+++ b/experiment/run/run.go
@@ -1,4 +1,6 @@
 // Package run contains code to run other experiments.
+//
+// This code is currently alpha.
 package run
 
 import (

--- a/experiment_integration_test.go
+++ b/experiment_integration_test.go
@@ -142,7 +142,7 @@ func TestNeedsInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if builder.InputPolicy() != InputRequired {
+	if builder.InputPolicy() != InputOrQueryTestLists {
 		t.Fatal("web_connectivity certainly needs input")
 	}
 }

--- a/experimentbuilder.go
+++ b/experimentbuilder.go
@@ -16,10 +16,18 @@ import (
 type InputPolicy string
 
 const (
-	// InputRequired indicates that the experiment requires
-	// external input to run. If this input is not provided to
-	// the experiment, it will not know what to do.
-	InputRequired = InputPolicy("required")
+	// InputOrQueryTestLists indicates that the experiment requires
+	// external input to run and that this kind of input is URLs
+	// from the citizenlab/test-lists repository. If this input
+	// not provided to the experiment, then the code that runs the
+	// experiment is supposed to fetch from URLs from OONI's backends.
+	InputOrQueryTestLists = InputPolicy("or_query_test_lists")
+
+	// InputStrictlyRequired indicates that the experiment
+	// requires input and we currently don't have an API for
+	// fetching such input. Therefore, either the user specifies
+	// input or the experiment will fail for the lack of input.
+	InputStrictlyRequired = InputPolicy("strictly_required")
 
 	// InputOptional indicates that the experiment handles input,
 	// if any; otherwise it fetchs input/uses a default.

--- a/oonimkall/tasks/runner.go
+++ b/oonimkall/tasks/runner.go
@@ -175,7 +175,8 @@ func (r *Runner) Run(ctx context.Context) {
 
 	builder.SetCallbacks(&runnerCallbacks{emitter: r.emitter})
 	if len(r.settings.Inputs) <= 0 {
-		if builder.InputPolicy() == engine.InputRequired {
+		switch builder.InputPolicy() {
+		case engine.InputOrQueryTestLists, engine.InputStrictlyRequired:
 			r.emitter.EmitFailureStartup("no input provided")
 			return
 		}
@@ -206,12 +207,19 @@ func (r *Runner) Run(ctx context.Context) {
 	// sense, here we're changing the behaviour.
 	//
 	// See https://github.com/measurement-kit/measurement-kit/issues/1922
-	if r.settings.Options.MaxRuntime > 0 && builder.InputPolicy() == engine.InputRequired {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(
-			ctx, time.Duration(r.settings.Options.MaxRuntime)*time.Second,
-		)
-		defer cancel()
+	if r.settings.Options.MaxRuntime > 0 {
+		// We want to honour max_runtime only when we're running an
+		// experiment that clearly wants specific input. We could refine
+		// this policy in the future, but for now this covers in a
+		// reasonable way web connectivity, so we should be ok.
+		switch builder.InputPolicy() {
+		case engine.InputOrQueryTestLists, engine.InputStrictlyRequired:
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(
+				ctx, time.Duration(r.settings.Options.MaxRuntime)*time.Second,
+			)
+			defer cancel()
+		}
 	}
 	inputCount := len(r.settings.Inputs)
 	start := time.Now()


### PR DESCRIPTION
We used to have InputRequired category, which meant that you were
providing input and, if there was not input, we would then use the
test-lists API to fetch input URLs.

This policy was used, however, improperly in some cases. As noted
in https://github.com/ooni/probe-engine/issues/1123, dnscheck would
for example use the test lists if no input was provided. Sadly,
though, such input does not make any sense when provided to dnscheck,
which leads to miniooni running very useless tests.

So, here's an improvement:

1. we rename InputRequired to InputOrQueryTestLists, which BTW
captures in an even better way the original intent

2. we introduce InputStrictlyRequired, where, if there is no
input, we just fail, and we apply it to dnscheck, run, and all
the cases in which it makes sense to use this new policy

Work done as part of https://github.com/ooni/probe-engine/issues/1115.