### PR TITLE
fix(archival): don't include UDP conns in tcp_connect

### DIFF
--- a/netx/archival/archival.go
+++ b/netx/archival/archival.go
@@ -86,6 +86,9 @@ func NewTCPConnectList(begin time.Time, events []trace.Event) []TCPConnectEntry 
 		if event.Name != errorx.ConnectOperation {
 			continue
 		}
+		if event.Proto != "tcp" {
+			continue
+		}
 		// We assume Go is passing us legit data structures
 		ip, sport, _ := net.SplitHostPort(event.Address)
 		iport, _ := strconv.Atoi(sport)

--- a/netx/archival/archival_test.go
+++ b/netx/archival/archival_test.go
@@ -53,6 +53,12 @@ func TestNewTCPConnectList(t *testing.T) {
 				Proto:    "tcp",
 				Time:     begin.Add(130 * time.Millisecond),
 			}, {
+				Address:  "8.8.8.8:853",
+				Duration: 55 * time.Millisecond,
+				Name:     errorx.ConnectOperation,
+				Proto:    "udp",
+				Time:     begin.Add(130 * time.Millisecond),
+			}, {
 				Address:  "8.8.4.4:53",
 				Duration: 50 * time.Millisecond,
 				Err:      io.EOF,


### PR DESCRIPTION
Discovered while working on https://github.com/ooni/probe-engine/issues/1115.