### PR TITLE
fix(riseupvpn): we can re-enable a disabled test

### DIFF
--- a/experiment/riseupvpn/riseupvpn_test.go
+++ b/experiment/riseupvpn/riseupvpn_test.go
@@ -278,7 +278,6 @@ func TestFailureGeoIpServiceBlocked(t *testing.T) {
 }
 
 func TestFailureGateway(t *testing.T) {
-	t.Skip("See https://github.com/ooni/probe-engine/issues/1137")
 	var testCases = [...]string{"openvpn", "obfs4"}
 	eipService, err := fetchEipService()
 	if err != nil {


### PR DESCRIPTION
See https://github.com/ooni/probe-engine/issues/1137.