### PR TITLE
cleanup(report): remove report.close operation

### DIFF
--- a/experiment.go
+++ b/experiment.go
@@ -31,7 +31,7 @@ type Experiment struct {
 	byteCounter   *bytecounter.Counter
 	callbacks     model.ExperimentCallbacks
 	measurer      model.ExperimentMeasurer
-	report        *probeservices.Report
+	report        probeservices.ReportChannel
 	session       *Session
 	testName      string
 	testStartTime string
@@ -88,7 +88,7 @@ func (e *Experiment) ReportID() string {
 	if e.report == nil {
 		return ""
 	}
-	return e.report.ID
+	return e.report.ReportID()
 }
 
 // Measure performs a measurement with input. We assume that you have
@@ -144,16 +144,6 @@ func (e *Experiment) SubmitAndUpdateMeasurementContext(
 		return errors.New("Report is not open")
 	}
 	return e.report.SubmitMeasurement(ctx, measurement)
-}
-
-// CloseReport is an idempotent method that closes an open report
-// if one has previously been opened, otherwise it does nothing.
-func (e *Experiment) CloseReport() (err error) {
-	if e.report != nil {
-		err = e.report.Close(context.Background())
-		e.report = nil
-	}
-	return
 }
 
 func (e *Experiment) newMeasurement(input string) *model.Measurement {

--- a/experiment_integration_test.go
+++ b/experiment_integration_test.go
@@ -343,10 +343,6 @@ func runexperimentflow(t *testing.T, experiment *Experiment, input string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = experiment.CloseReport()
-	if err != nil {
-		t.Fatal(err)
-	}
 	if experiment.KibiBytesSent() <= 0 {
 		t.Fatal("no data sent?!")
 	}
@@ -428,7 +424,6 @@ func TestOpenReportIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer exp.CloseReport()
 	rid := exp.ReportID()
 	if rid == "" {
 		t.Fatal("invalid report ID")

--- a/model/measurement.go
+++ b/model/measurement.go
@@ -48,9 +48,6 @@ type Measurement struct {
 	// and is only used within probe-engine as a "zero" time.
 	MeasurementStartTimeSaved time.Time `json:"-"`
 
-	// OOID is the measurement ID stamped by the OONI collector.
-	OOID string `json:"ooid,omitempty"`
-
 	// Options contains command line options
 	Options []string `json:"options,omitempty"`
 

--- a/oonimkall/session.go
+++ b/oonimkall/session.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
-	"time"
 
 	engine "github.com/ooni/probe-engine"
 	"github.com/ooni/probe-engine/atomicx"
@@ -140,11 +139,6 @@ func NewSession(config *SessionConfig) (*Session, error) {
 func sessionFinalizer(sess *Session) {
 	for _, fn := range sess.cl {
 		fn()
-	}
-	if sess.submitter != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
-		defer cancel()
-		sess.submitter.Close(ctx) // ignore return value
 	}
 	sess.sessp.Close() // ignore return value
 	ActiveSessions.Add(-1)

--- a/oonimkall/tasks/runner.go
+++ b/oonimkall/tasks/runner.go
@@ -193,10 +193,6 @@ func (r *Runner) Run(ctx context.Context) {
 			r.emitter.EmitFailureGeneric(failureReportCreate, err.Error())
 			return
 		}
-		defer func() {
-			logger.Info("Closing report... please, be patient")
-			experiment.CloseReport()
-		}()
 		r.emitter.EmitStatusProgress(0.4, "open report")
 		r.emitter.Emit(statusReportCreate, eventStatusReportGeneric{
 			ReportID: experiment.ReportID(),

--- a/probeservices/collector.go
+++ b/probeservices/collector.go
@@ -2,7 +2,6 @@ package probeservices
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -86,8 +85,7 @@ type collectorOpenResponse struct {
 	SupportedFormats []string `json:"supported_formats"`
 }
 
-// Report is an open report
-type Report struct {
+type reportChan struct {
 	// ID is the report ID
 	ID string
 
@@ -99,9 +97,7 @@ type Report struct {
 }
 
 // OpenReport opens a new report.
-//
-// This method will eventually be replaced by NewReportChannel.
-func (c Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, error) {
+func (c Client) OpenReport(ctx context.Context, rt ReportTemplate) (ReportChannel, error) {
 	if rt.DataFormatVersion != DefaultDataFormatVersion {
 		return nil, ErrUnsupportedDataFormatVersion
 	}
@@ -114,7 +110,7 @@ func (c Client) OpenReport(ctx context.Context, rt ReportTemplate) (*Report, err
 	}
 	for _, format := range cor.SupportedFormats {
 		if format == "json" {
-			return &Report{ID: cor.ID, client: c, tmpl: rt}, nil
+			return &reportChan{ID: cor.ID, client: c, tmpl: rt}, nil
 		}
 	}
 	return nil, ErrJSONFormatNotSupported
@@ -136,72 +132,43 @@ type collectorUpdateResponse struct {
 // CanSubmit returns true whether the provided measurement belongs to
 // this report, false otherwise. We say that a given measurement belongs
 // to this report if its report template matches the report's one.
-func (r Report) CanSubmit(m *model.Measurement) bool {
+func (r reportChan) CanSubmit(m *model.Measurement) bool {
 	return reflect.DeepEqual(NewReportTemplate(m), r.tmpl)
 }
 
 // SubmitMeasurement submits a measurement belonging to the report
 // to the OONI collector. We will unconditionally modify the measurement
-// with the ReportID it should contain. If the collector supports sending
-// back to us a measurement ID, we also update the m.OOID field with it.
-func (r Report) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
+// with the ReportID it should contain.
+func (r reportChan) SubmitMeasurement(ctx context.Context, m *model.Measurement) error {
 	var updateResponse collectorUpdateResponse
 	m.ReportID = r.ID
-	err := r.client.Client.PostJSON(
+	return r.client.Client.PostJSON(
 		ctx, fmt.Sprintf("/report/%s", r.ID), collectorUpdateRequest{
 			Format:  "json",
 			Content: m,
 		}, &updateResponse,
 	)
-	if err == nil {
-		m.OOID = updateResponse.ID
-	}
-	return err
 }
 
-// Close closes the report. Returns nil on success; an error on failure.
-func (r Report) Close(ctx context.Context) error {
-	var input, output struct{}
-	err := r.client.Client.PostJSON(
-		ctx, fmt.Sprintf("/report/%s/close", r.ID), input, &output,
-	)
-	// Implementation note: the server is not compliant with
-	// the spec, which says it MUST return a JSON. It does
-	// instead return an empty string. Intercept this error
-	// and turn it to nil, since we cannot really act upon
-	// this error, and we ought be flexible.
-	if _, ok := err.(*json.SyntaxError); ok && err.Error() == "unexpected end of JSON input" {
-		r.client.Logger.Debug(
-			"collector.go: working around collector-returning-empty-string bug",
-		)
-		err = nil
-	}
-	return err
+// ReportID returns the report ID.
+func (r reportChan) ReportID() string {
+	return r.ID
 }
 
 // ReportChannel is a channel through which one could submit measurements
 // belonging to the same report. The Report struct belongs to this interface.
 type ReportChannel interface {
 	CanSubmit(m *model.Measurement) bool
+	ReportID() string
 	SubmitMeasurement(ctx context.Context, m *model.Measurement) error
-	Close(ctx context.Context) error
 }
 
-var _ ReportChannel = &Report{}
+var _ ReportChannel = &reportChan{}
 
 // ReportOpener is any struct that is able to open a new ReportChannel. The
 // Client struct belongs to this interface.
 type ReportOpener interface {
-	NewReportChannel(ctx context.Context, rt ReportTemplate) (ReportChannel, error)
-}
-
-// NewReportChannel creates a new ReportChannel
-func (c Client) NewReportChannel(ctx context.Context, rt ReportTemplate) (ReportChannel, error) {
-	report, err := c.OpenReport(ctx, rt)
-	if err != nil {
-		return nil, err
-	}
-	return report, nil
+	OpenReport(ctx context.Context, rt ReportTemplate) (ReportChannel, error)
 }
 
 var _ ReportOpener = Client{}
@@ -229,26 +196,10 @@ func (sub *Submitter) Submit(ctx context.Context, m *model.Measurement) error {
 	sub.mu.Lock()
 	defer sub.mu.Unlock()
 	if sub.channel == nil || !sub.channel.CanSubmit(m) {
-		sub.maybeCloseUnlocked(ctx)
-		sub.channel, err = sub.opener.NewReportChannel(ctx, NewReportTemplate(m))
+		sub.channel, err = sub.opener.OpenReport(ctx, NewReportTemplate(m))
 		if err != nil {
 			return err
 		}
 	}
 	return sub.channel.SubmitMeasurement(ctx, m)
-}
-
-func (sub *Submitter) maybeCloseUnlocked(ctx context.Context) (err error) {
-	if sub.channel != nil {
-		err = sub.channel.Close(ctx)
-		sub.channel = nil
-	}
-	return
-}
-
-// Close will ensure Submitter is not leaking resources.
-func (sub *Submitter) Close(ctx context.Context) error {
-	sub.mu.Lock()
-	defer sub.mu.Unlock()
-	return sub.maybeCloseUnlocked(ctx)
 }

--- a/probeservices/collector_test.go
+++ b/probeservices/collector_test.go
@@ -87,14 +87,11 @@ func TestReportLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	measurement := makeMeasurement(template, report.ID)
+	measurement := makeMeasurement(template, report.ReportID())
 	if report.CanSubmit(&measurement) != true {
 		t.Fatal("report should be able to submit this measurement")
 	}
 	if err = report.SubmitMeasurement(ctx, &measurement); err != nil {
-		t.Fatal(err)
-	}
-	if err = report.Close(ctx); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -117,8 +114,7 @@ func TestReportLifecycleWrongExperiment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer report.Close(ctx)
-	measurement := makeMeasurement(template, report.ID)
+	measurement := makeMeasurement(template, report.ReportID())
 	measurement.TestName = "antani"
 	if report.CanSubmit(&measurement) != false {
 		t.Fatal("report should not be able to submit this measurement")
@@ -273,17 +269,13 @@ func TestEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	measurement := makeMeasurement(template, report.ID)
+	measurement := makeMeasurement(template, report.ReportID())
 	if err = report.SubmitMeasurement(ctx, &measurement); err != nil {
-		t.Fatal(err)
-	}
-	if err = report.Close(ctx); err != nil {
 		t.Fatal(err)
 	}
 }
 
 type RecordingReportChannel struct {
-	cc   int64
 	tmpl probeservices.ReportTemplate
 	m    []*model.Measurement
 	mu   sync.Mutex
@@ -309,8 +301,11 @@ func (rrc *RecordingReportChannel) Close(ctx context.Context) error {
 	}
 	rrc.mu.Lock()
 	defer rrc.mu.Unlock()
-	rrc.cc++
 	return nil
+}
+
+func (rrc *RecordingReportChannel) ReportID() string {
+	return ""
 }
 
 type RecordingReportOpener struct {
@@ -318,7 +313,7 @@ type RecordingReportOpener struct {
 	mu       sync.Mutex
 }
 
-func (rro *RecordingReportOpener) NewReportChannel(
+func (rro *RecordingReportOpener) OpenReport(
 	ctx context.Context, rt probeservices.ReportTemplate,
 ) (probeservices.ReportChannel, error) {
 	if ctx.Err() != nil {
@@ -331,7 +326,7 @@ func (rro *RecordingReportOpener) NewReportChannel(
 	return rrc, nil
 }
 
-func TestNewReportChannelGood(t *testing.T) {
+func TestOpenReportGood(t *testing.T) {
 	ctx := context.Background()
 	template := probeservices.ReportTemplate{
 		DataFormatVersion: probeservices.DefaultDataFormatVersion,
@@ -345,16 +340,13 @@ func TestNewReportChannelGood(t *testing.T) {
 		TestVersion:       "0.1.0",
 	}
 	client := newclient()
-	report, err := client.NewReportChannel(ctx, template)
+	_, err := client.OpenReport(ctx, template)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err = report.Close(ctx); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestNewReportChannelCancelledContext(t *testing.T) {
+func TestOpenReportCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately abort
 	template := probeservices.ReportTemplate{
@@ -369,7 +361,7 @@ func TestNewReportChannelCancelledContext(t *testing.T) {
 		TestVersion:       "0.1.0",
 	}
 	client := newclient()
-	report, err := client.NewReportChannel(ctx, template)
+	report, err := client.OpenReport(ctx, template)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("not the error we expected")
 	}
@@ -416,23 +408,14 @@ func TestSubmitterLifecyle(t *testing.T) {
 	if err := submitter.Submit(ctx, m3); err != nil {
 		t.Fatal(err)
 	}
-	if err := submitter.Close(ctx); err != nil {
-		t.Fatal(err)
-	}
 	if len(rro.channels) != 2 {
 		t.Fatal("unexpected number of channels")
 	}
 	if len(rro.channels[0].m) != 2 {
 		t.Fatal("unexpected number of measurements in first channel")
 	}
-	if rro.channels[0].cc != 1 {
-		t.Fatal("first channel was not closed exactly once")
-	}
 	if len(rro.channels[1].m) != 1 {
 		t.Fatal("unexpected number of measurements in second channel")
-	}
-	if rro.channels[1].cc != 1 {
-		t.Fatal("second channel was not closed exactly once")
 	}
 }
 
@@ -451,9 +434,6 @@ func TestSubmitterCannotOpenNewChannel(t *testing.T) {
 	}
 	m3 := makeMeasurementWithoutTemplate("antani", "example_extended")
 	if err := submitter.Submit(ctx, m3); !errors.Is(err, context.Canceled) {
-		t.Fatal(err)
-	}
-	if err := submitter.Close(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if len(rro.channels) != 0 {

--- a/submitter.go
+++ b/submitter.go
@@ -30,10 +30,6 @@ type SubmitterConfig struct {
 }
 
 // SubmitterExperiment is the Submitter's view of the Experiment.
-//
-// Implementation note: we don't bother to define a function for closing
-// the report here, since closing reports is no longer necessary since
-// changes implemented in ooni/api in Oct-Nov 2020.
 type SubmitterExperiment interface {
 	// ReportID returns the ID of the currently opened report.
 	ReportID() string


### PR DESCRIPTION
The close operation is now a relic of the past that we support
only for the sake of legacy clients.

So, we can remove it and simplify the code a little bit.

While there, make sure we use an interface for the opened report
rather than a struct, so we can improve testing in the future.

Also, the OOID is currently not returned by any collector, hence
it does not make any sense to have code handling it.

Work done as cleanup after https://github.com/ooni/probe-engine/issues/948.