### PR TITLE
fix(run): set dnscheck name and version

### DIFF
--- a/experiment/run/dnscheck.go
+++ b/experiment/run/dnscheck.go
@@ -11,6 +11,8 @@ func dodnscheck(ctx context.Context, input StructuredInput,
 	sess model.ExperimentSession, measurement *model.Measurement,
 	callbacks model.ExperimentCallbacks) error {
 	exp := dnscheck.Measurer{Config: input.DNSCheck}
+	measurement.TestName = exp.ExperimentName()
+	measurement.TestVersion = exp.ExperimentVersion()
 	measurement.Input = model.MeasurementTarget(input.Input)
 	return exp.Run(ctx, sess, measurement, callbacks)
 }


### PR DESCRIPTION
Otherwise measurements are submitted as part of the run
experiment, which is very unhelpful.

See https://github.com/ooni/probe-engine/issues/1115.