### PR TITLE
fix(dnscheck): avoid false positive due to timeout

### DIFF
--- a/experiment/dnscheck/dnscheck.go
+++ b/experiment/dnscheck/dnscheck.go
@@ -82,7 +82,7 @@ func (m Measurer) Run(
 	measurement.TestKeys = tk
 	urlgetter.RegisterExtensions(measurement)
 
-	// 3. select the domain to resolve or use default and, while there, also
+	// 2. select the domain to resolve or use default and, while there, also
 	// ensure that we register all the other options we're using.
 	domain := m.Config.Domain
 	if domain == "" {
@@ -94,7 +94,7 @@ func (m Measurer) Run(
 	tk.HTTPHost = m.Config.HTTPHost
 	tk.TLSServerName = m.Config.TLSServerName
 
-	// 4. parse the input URL describing the resolver to use
+	// 3. parse the input URL describing the resolver to use
 	input := string(measurement.Input)
 	if input == "" {
 		return ErrInputRequired
@@ -110,7 +110,7 @@ func (m Measurer) Run(
 		return ErrUnsupportedURLScheme
 	}
 
-	// 5. possibly expand a domain to a list of IP addresses.
+	// 4. possibly expand a domain to a list of IP addresses.
 	//
 	// Implementation note: because the resolver we constructed also deals
 	// with IP addresses successfully, we just get back the IPs when we are
@@ -131,7 +131,7 @@ func (m Measurer) Run(
 		tk.Bootstrap = &urlgetter.TestKeys{Queries: queries}
 	}
 
-	// 6. merge default addresses for the domain with the ones that
+	// 5. merge default addresses for the domain with the ones that
 	// we did discover here and measure them all.
 	allAddrs := make(map[string]bool)
 	for _, addr := range addrs {
@@ -143,7 +143,7 @@ func (m Measurer) Run(
 		}
 	}
 
-	// 7. determine all the domain lookups we need to perform
+	// 6. determine all the domain lookups we need to perform
 	const maxParallelism = 10
 	parallelism := maxParallelism
 	if parallelism > len(allAddrs) {
@@ -165,7 +165,7 @@ func (m Measurer) Run(
 		})
 	}
 
-	// 8. perform all the required resolutions
+	// 7. perform all the required resolutions
 	for output := range Collect(ctx, multi, inputs, callbacks) {
 		tk.Lookups[output.Input.Config.ResolverURL] = output.TestKeys
 	}

--- a/experiment/dnscheck/dnscheck_test.go
+++ b/experiment/dnscheck/dnscheck_test.go
@@ -48,7 +48,7 @@ func TestExperimentNameAndVersion(t *testing.T) {
 	if measurer.ExperimentName() != "dnscheck" {
 		t.Error("unexpected experiment name")
 	}
-	if measurer.ExperimentVersion() != "0.6.0" {
+	if measurer.ExperimentVersion() != "0.7.0" {
 		t.Error("unexpected experiment version")
 	}
 }
@@ -142,20 +142,19 @@ func TestMakeResolverURL(t *testing.T) {
 }
 
 func TestDNSCheckValid(t *testing.T) {
-	measurer := NewExperimentMeasurer(Config{})
+	measurer := NewExperimentMeasurer(Config{
+		DefaultAddrs: "1.1.1.1 1.0.0.1",
+	})
 	measurement := model.Measurement{Input: "dot://one.one.one.one:853"}
-	// test with valid DNS endpoint
 	err := measurer.Run(
 		context.Background(),
 		newsession(),
 		&measurement,
 		model.NewPrinterCallbacks(log.Log),
 	)
-
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
-
 	tk := measurement.TestKeys.(*TestKeys)
 	if tk.Domain != defaultDomain {
 		t.Fatal("unexpected default value for domain")

--- a/experiment/urlgetter/getter.go
+++ b/experiment/urlgetter/getter.go
@@ -39,6 +39,11 @@ type Getter struct {
 // Get performs the action described by g using the given context
 // and returning the test keys and eventually an error
 func (g Getter) Get(ctx context.Context) (TestKeys, error) {
+	if g.Config.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, g.Config.Timeout)
+		defer cancel()
+	}
 	if g.Begin.IsZero() {
 		g.Begin = time.Now()
 	}

--- a/experiment/urlgetter/getter_test.go
+++ b/experiment/urlgetter/getter_test.go
@@ -13,6 +13,74 @@ import (
 	"github.com/ooni/probe-engine/netx/errorx"
 )
 
+func TestGetterWithVeryShortTimeout(t *testing.T) {
+	g := urlgetter.Getter{
+		Config: urlgetter.Config{
+			Timeout: 1,
+		},
+		Session: &mockable.Session{},
+		Target:  "https://www.google.com",
+	}
+	tk, err := g.Get(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("not the error we expected")
+	}
+	if tk.Agent != "redirect" {
+		t.Fatal("not the Agent we expected")
+	}
+	if tk.BootstrapTime != 0 {
+		t.Fatal("not the BootstrapTime we expected")
+	}
+	if tk.FailedOperation == nil || *tk.FailedOperation != errorx.TopLevelOperation {
+		t.Fatal("not the FailedOperation we expected")
+	}
+	if tk.Failure == nil || *tk.Failure != "generic_timeout_error" {
+		t.Fatal("not the Failure we expected")
+	}
+	if len(tk.NetworkEvents) != 3 {
+		t.Fatal("not the NetworkEvents we expected")
+	}
+	if tk.NetworkEvents[0].Operation != "http_transaction_start" {
+		t.Fatal("not the NetworkEvents[0].Operation we expected")
+	}
+	if tk.NetworkEvents[1].Operation != "http_request_metadata" {
+		t.Fatal("not the NetworkEvents[1].Operation we expected")
+	}
+	if tk.NetworkEvents[2].Operation != "http_transaction_done" {
+		t.Fatal("not the NetworkEvents[2].Operation we expected")
+	}
+	if len(tk.Queries) != 0 {
+		t.Fatal("not the Queries we expected")
+	}
+	if len(tk.TCPConnect) != 0 {
+		t.Fatal("not the TCPConnect we expected")
+	}
+	if len(tk.Requests) != 1 {
+		t.Fatal("not the Requests we expected")
+	}
+	if tk.Requests[0].Request.Method != "GET" {
+		t.Fatal("not the Method we expected")
+	}
+	if tk.Requests[0].Request.URL != "https://www.google.com" {
+		t.Fatal("not the URL we expected")
+	}
+	if tk.SOCKSProxy != "" {
+		t.Fatal("not the SOCKSProxy we expected")
+	}
+	if len(tk.TLSHandshakes) != 0 {
+		t.Fatal("not the TLSHandshakes we expected")
+	}
+	if tk.Tunnel != "" {
+		t.Fatal("not the Tunnel we expected")
+	}
+	if tk.HTTPResponseStatus != 0 {
+		t.Fatal("not the HTTPResponseStatus we expected")
+	}
+	if tk.HTTPResponseBody != "" {
+		t.Fatal("not the HTTPResponseBody we expected")
+	}
+}
+
 func TestGetterWithCancelledContextVanilla(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // faily immediately

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -21,6 +21,7 @@ const (
 type Config struct {
 	// not settable from command line
 	CertPool *x509.CertPool
+	Timeout  time.Duration
 
 	// settable from command line
 	DNSCache          string `ooni:"Add 'DOMAIN IP...' to cache"`
@@ -98,8 +99,9 @@ func (m Measurer) Run(
 	// default timeout that applies. When urlgetter is used as a library, it's
 	// instead the responsibility of the user of urlgetter to set timeouts. Note
 	// that this code is indeed only called when using urlgetter directly.
-	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
-	defer cancel()
+	if m.Config.Timeout <= 0 {
+		m.Config.Timeout = 45 * time.Second
+	}
 	RegisterExtensions(measurement)
 	g := Getter{
 		Config:  m.Config,


### PR DESCRIPTION
1. avoid setting a unique timeout for the whole measurement

2. set a 20 seconds timeout for the bootstrap

3. use up to 10 concurrent goroutines for the lookups

4. set a 45 seconds timeout for each individual lookup

5. urlgetter/getter.go: introduce a timeout (for now do not
expose it to command line since that is more work)

6. urlgetter/urlgetter.go: use the new timeout in getter.go

7. urlgetter/getter.go: add tests for the timeout case

See https://github.com/ooni/probe-engine/issues/1159