### PR TITLE
build-cli.sh: support windows/386 and linux/386

### DIFF
--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -1,5 +1,8 @@
 name: miniooni
 on:
+  push:
+    branches:
+      - 'release/**'
   schedule:
     - cron: "0 0 * * */1"
 jobs:
@@ -13,6 +16,10 @@ jobs:
 
       - run: ./build-cli.sh linux
       - run: ./CLI/linux/amd64/miniooni --yes -nNi https://example.com web_connectivity
+      - uses: actions/upload-artifact@v1
+        with:
+          name: miniooni-linux-386
+          path: ./CLI/linux/386/miniooni
       - uses: actions/upload-artifact@v1
         with:
           name: miniooni-linux-amd64

--- a/CLI/linux/386/.gitignore
+++ b/CLI/linux/386/.gitignore
@@ -1,0 +1,1 @@
+/miniooni

--- a/CLI/windows/386/.gitignore
+++ b/CLI/windows/386/.gitignore
@@ -1,0 +1,1 @@
+/miniooni.exe

--- a/build-cli.sh
+++ b/build-cli.sh
@@ -19,6 +19,9 @@ case $1 in
     go build -o ./CLI/linux/arm64 -tags netgo -ldflags='-s -w -extldflags "-static"' ./cmd/miniooni
     echo "Binary ready at ./CLI/linux/arm64/miniooni";;
   windows)
+    export GOOS=windows GOARCH=386
+    go build -o ./CLI/windows/386 -ldflags="-s -w" ./cmd/miniooni
+    echo "Binary ready at ./CLI/windows/386/miniooni.exe"
     export GOOS=windows GOARCH=amd64
     go build -o ./CLI/windows/amd64 -ldflags="-s -w" ./cmd/miniooni
     echo "Binary ready at ./CLI/windows/amd64/miniooni.exe";;

--- a/build-cli.sh
+++ b/build-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 case $1 in
-  darwin)
+  macos|darwin)
     export GOOS=darwin GOARCH=amd64
     go build -o ./CLI/darwin/amd64 -ldflags="-s -w" ./cmd/miniooni
     echo "Binary ready at ./CLI/darwin/amd64/miniooni";;

--- a/build-cli.sh
+++ b/build-cli.sh
@@ -6,6 +6,9 @@ case $1 in
     go build -o ./CLI/darwin/amd64 -ldflags="-s -w" ./cmd/miniooni
     echo "Binary ready at ./CLI/darwin/amd64/miniooni";;
   linux)
+    export GOOS=linux GOARCH=386
+    go build -o ./CLI/linux/386 -tags netgo -ldflags='-s -w -extldflags "-static"' ./cmd/miniooni
+    echo "Binary ready at ./CLI/linux/386/miniooni"
     export GOOS=linux GOARCH=amd64
     go build -o ./CLI/linux/amd64 -tags netgo -ldflags='-s -w -extldflags "-static"' ./cmd/miniooni
     echo "Binary ready at ./CLI/linux/amd64/miniooni"


### PR DESCRIPTION
Written while working on https://github.com/ooni/probe/issues/1315