### PR TITLE
fix(ndt7): continue after TextMessage

### DIFF
--- a/experiment/ndt7/download.go
+++ b/experiment/ndt7/download.go
@@ -51,9 +51,11 @@ func (mgr downloadManager) run(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+			total += int64(len(data))
 			if err := mgr.onJSON(data); err != nil {
 				return err
 			}
+			continue
 		}
 		n, err := io.Copy(ioutil.Discard, reader)
 		if err != nil {


### PR DESCRIPTION
The reader is already fully read, so falling through does not have
side effects. But doing a continue is cleaner.

While there, make sure we account for TextMessages size.