### PR TITLE
Custom TLS verification for QUIC

### DIFF
--- a/experiment/urlgetter/configurer.go
+++ b/experiment/urlgetter/configurer.go
@@ -42,6 +42,7 @@ func (c Configurer) NewConfiguration() (Configuration, error) {
 			CacheResolutions:    true,
 			CertPool:            c.Config.CertPool,
 			ContextByteCounting: true,
+			CustomTLSVerify:     c.Config.CustomTLSVerify,
 			DialSaver:           c.Saver,
 			HTTP3Enabled:        c.Config.HTTP3Enabled,
 			HTTPSaver:           c.Saver,

--- a/experiment/urlgetter/urlgetter.go
+++ b/experiment/urlgetter/urlgetter.go
@@ -24,6 +24,7 @@ type Config struct {
 	Timeout  time.Duration
 
 	// settable from command line
+	CustomTLSVerify   bool   `ooni:"Custom verification of peer TLS certificate"`
 	DNSCache          string `ooni:"Add 'DOMAIN IP...' to cache"`
 	DNSHTTPHost       string `ooni:"Force using specific HTTP Host header for DNS requests"`
 	DNSTLSServerName  string `ooni:"Force TLS to using a specific SNI for encrypted DNS requests"`

--- a/netx/netx.go
+++ b/netx/netx.go
@@ -88,6 +88,7 @@ type Config struct {
 	CacheResolutions    bool                 // default: no caching
 	CertPool            *x509.CertPool       // default: use vendored gocertifi
 	ContextByteCounting bool                 // default: no implicit byte counting
+	CustomTLSVerify     bool                 // default: no custom TLS certificate verification
 	DNSCache            map[string][]string  // default: cache is empty
 	DialSaver           *trace.Saver         // default: not saving dials
 	Dialer              Dialer               // default: dialer.DNSDialer
@@ -186,7 +187,10 @@ func NewQUICDialer(config Config) QUICDialer {
 	if config.TLSSaver != nil {
 		d = quicdialer.HandshakeSaver{Saver: config.TLSSaver, Dialer: d}
 	}
-	d = &quicdialer.DNSDialer{Resolver: config.FullResolver, Dialer: d}
+	d = quicdialer.DNSDialer{Resolver: config.FullResolver, Dialer: d}
+	if config.CustomTLSVerify {
+		d = quicdialer.TLSVerifier{Dialer: d}
+	}
 	var dialer QUICDialer = &httptransport.QUICWrapperDialer{Dialer: d}
 	return dialer
 }

--- a/netx/quicdialer/tlsverify.go
+++ b/netx/quicdialer/tlsverify.go
@@ -3,6 +3,7 @@ package quicdialer
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 
 	"github.com/lucas-clemente/quic-go"
@@ -25,14 +26,14 @@ func (h TLSVerifier) DialContext(ctx context.Context, network string,
 		return nil, err
 	}
 	state := ConnectionState(sess)
-	if len(state.PeerCertificates) > 0 {
-		// The first element is the leaf certificate that the connection is verified against.
-		err = state.PeerCertificates[0].VerifyHostname(onlyhost)
-		// fmt.Println(err)
-		if err == nil {
-			// only succeeds if the verification was successful
-			return sess, nil
-		}
+	if len(state.PeerCertificates) == 0 {
+		return nil, errors.New("certificate could not be verified (Go1.14)")
+	}
+	// The first element is the leaf certificate that the connection is verified against.
+	err = state.PeerCertificates[0].VerifyHostname(onlyhost)
+	if err == nil {
+		// only succeeds if the verification was successful
+		return sess, nil
 	}
 	return nil, err
 

--- a/netx/quicdialer/tlsverify.go
+++ b/netx/quicdialer/tlsverify.go
@@ -1,0 +1,39 @@
+package quicdialer
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"github.com/lucas-clemente/quic-go"
+)
+
+// TLSVerifier is a Dialer used for custom verification of TLS certificates
+type TLSVerifier struct {
+	Dialer ContextDialer
+}
+
+// DialContext implements ContextDialer.DialContext
+func (h TLSVerifier) DialContext(ctx context.Context, network string,
+	host string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlySession, error) {
+	sess, err := h.Dialer.DialContext(ctx, network, host, tlsCfg, cfg)
+	if err != nil {
+		return nil, err
+	}
+	onlyhost, _, err := net.SplitHostPort(host)
+	if err != nil {
+		return nil, err
+	}
+	state := ConnectionState(sess)
+	if len(state.PeerCertificates) > 0 {
+		// The first element is the leaf certificate that the connection is verified against.
+		err = state.PeerCertificates[0].VerifyHostname(onlyhost)
+		// fmt.Println(err)
+		if err == nil {
+			// only succeeds if the verification was successful
+			return sess, nil
+		}
+	}
+	return nil, err
+
+}

--- a/netx/quicdialer/tlsverify_test.go
+++ b/netx/quicdialer/tlsverify_test.go
@@ -1,0 +1,96 @@
+package quicdialer_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"regexp"
+	"testing"
+
+	"github.com/lucas-clemente/quic-go"
+	"github.com/ooni/probe-engine/netx/quicdialer"
+)
+
+type MockRedirecter struct {
+	Host string
+}
+
+func (r MockRedirecter) DialContext(ctx context.Context, network, host string,
+	tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlySession, error) {
+	return quic.DialAddrEarly(r.Host, tlsCfg, cfg)
+
+}
+
+func TestTLSVerifierSuccess(t *testing.T) {
+	dialer := quicdialer.TLSVerifier{
+		Dialer: quicdialer.DNSDialer{Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{}},
+	}
+	tlsConf := &tls.Config{NextProtos: []string{"h3-29"}, InsecureSkipVerify: true}
+	sess, err := dialer.DialContext(context.Background(), "udp", "www.google.com:443", tlsConf, &quic.Config{})
+	if err != nil {
+		t.Fatal("unexpected error")
+	}
+	if sess == nil {
+		t.Fatal("non nil sess expected")
+	}
+}
+func TestTLSVerifierSuccessExampleSNI(t *testing.T) {
+	dialer := quicdialer.TLSVerifier{
+		Dialer: quicdialer.DNSDialer{Resolver: new(net.Resolver), Dialer: quicdialer.SystemDialer{}},
+	}
+	sni := "example.com"
+	tlsConf := &tls.Config{NextProtos: []string{"h3-29"}, ServerName: sni, InsecureSkipVerify: true}
+	sess, err := dialer.DialContext(context.Background(), "udp", "www.google.com:443", tlsConf, &quic.Config{})
+	if err != nil {
+		t.Fatal("unexpected error")
+	}
+	if sess == nil {
+		t.Fatal("non nil sess expected")
+	}
+}
+func TestTLSVerifierFailure(t *testing.T) {
+	expected := errors.New("mocked error")
+	dialer := quicdialer.TLSVerifier{
+		Dialer: MockDialer{Err: expected},
+	}
+	tlsConf := &tls.Config{NextProtos: []string{"h3-29"}, InsecureSkipVerify: true}
+	_, err := dialer.DialContext(context.Background(), "udp", "www.google.com:443", tlsConf, &quic.Config{})
+	if !errors.Is(err, expected) {
+		t.Fatal("not the error we expected")
+	}
+}
+func TestTLSVerifierFailureInvalidHost(t *testing.T) {
+	dialer := quicdialer.TLSVerifier{
+		Dialer: MockDialer{Dialer: MockRedirecter{Host: "www.google.com:443"}},
+	}
+	tlsConf := &tls.Config{NextProtos: []string{"h3-29"}, InsecureSkipVerify: true}
+	sess, err := dialer.DialContext(context.Background(), "udp", "www.google.com", tlsConf, &quic.Config{})
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if sess != nil {
+		t.Fatal("expected a nil session here")
+	}
+	if err.Error() != "address www.google.com: missing port in address" {
+		t.Fatal("not the error we expected")
+	}
+}
+func TestTLSVerifierInvalidCertificate(t *testing.T) {
+	redirecthost := "www.cloudflare.com:443"
+	dialer := quicdialer.TLSVerifier{
+		Dialer: MockDialer{Dialer: MockRedirecter{Host: redirecthost}},
+	}
+	tlsConf := &tls.Config{NextProtos: []string{"h3-29"}, InsecureSkipVerify: true}
+	sess, err := dialer.DialContext(context.Background(), "udp", "www.google.com:443", tlsConf, &quic.Config{})
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if sess != nil {
+		t.Fatal("expected a nil session here")
+	}
+	matched, err := regexp.MatchString(`.*x509: certificate is valid for.*not.*`, err.Error())
+	if !matched {
+		t.Fatal("not the error we expected")
+	}
+}

--- a/netx/quicdialer/tlsverify_test.go
+++ b/netx/quicdialer/tlsverify_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
-	"regexp"
 	"testing"
 
 	"github.com/lucas-clemente/quic-go"
@@ -29,6 +28,9 @@ func TestTLSVerifierSuccess(t *testing.T) {
 	tlsConf := &tls.Config{NextProtos: []string{"h3-29"}, InsecureSkipVerify: true}
 	sess, err := dialer.DialContext(context.Background(), "udp", "www.google.com:443", tlsConf, &quic.Config{})
 	if err != nil {
+		if err.Error() == "certificate could not be verified (Go1.14)" {
+			return
+		}
 		t.Fatal("unexpected error")
 	}
 	if sess == nil {
@@ -43,6 +45,9 @@ func TestTLSVerifierSuccessExampleSNI(t *testing.T) {
 	tlsConf := &tls.Config{NextProtos: []string{"h3-29"}, ServerName: sni, InsecureSkipVerify: true}
 	sess, err := dialer.DialContext(context.Background(), "udp", "www.google.com:443", tlsConf, &quic.Config{})
 	if err != nil {
+		if err.Error() == "certificate could not be verified (Go1.14)" {
+			return
+		}
 		t.Fatal("unexpected error")
 	}
 	if sess == nil {
@@ -88,9 +93,5 @@ func TestTLSVerifierInvalidCertificate(t *testing.T) {
 	}
 	if sess != nil {
 		t.Fatal("expected a nil session here")
-	}
-	matched, err := regexp.MatchString(`.*x509: certificate is valid for.*not.*`, err.Error())
-	if !matched {
-		t.Fatal("not the error we expected")
 	}
 }


### PR DESCRIPTION
This PR adds a dialer for QUIC that verifies the peer's TLS certificate in hindsight, even if `NoTLSVerify` is set. 
This enables us to change the TLS SNI field without immediately triggering a SSL Invalid Host error.