### PR TITLE
(fix) quic saver: return nil instead of err

### DIFF
--- a/netx/quicdialer/saver.go
+++ b/netx/quicdialer/saver.go
@@ -58,5 +58,5 @@ func (h HandshakeSaver) DialContext(ctx context.Context, network string,
 		TLSVersion:         tlsx.VersionString(state.Version),
 		Time:               stop,
 	})
-	return sess, err
+	return sess, nil
 }


### PR DESCRIPTION
mini fix